### PR TITLE
Fix textarea highlight border and prompt dialog style

### DIFF
--- a/packages/ui/src/components/HistoryDrawer.vue
+++ b/packages/ui/src/components/HistoryDrawer.vue
@@ -1,11 +1,11 @@
 <template>
   <div
     v-if="show"
-    class="fixed inset-0 bg-black bg-opacity-50 z-45 flex items-center justify-center"
+    class="fixed inset-0 bg-black bg-opacity-50 z-[60] flex items-center justify-center"
     @click="emit('update:show', false)"
   >
     <div
-      class="w-full max-w-4xl h-[90vh] theme-drawer transform transition-all duration-300 ease-in-out"
+      class="w-full max-w-4xl h-[85vh] theme-drawer transform transition-all duration-300 ease-in-out"
       :class="show ? 'scale-100 opacity-100' : 'scale-95 opacity-0'"
       @click.stop
     >

--- a/packages/ui/src/components/PromptPanel.vue
+++ b/packages/ui/src/components/PromptPanel.vue
@@ -40,13 +40,13 @@
     </div>
     
     <!-- 内容区域 -->
-    <div class="flex-1 min-h-0 theme-input overflow-hidden">
+    <div class="flex-1 min-h-0 p-[2px] overflow-hidden">
       <div class="h-full relative">
         <textarea
           ref="promptTextarea"
           :value="optimizedPrompt"
           @input="handleInput"
-          class="absolute inset-0 w-full h-full p-4 bg-transparent border-none theme-text placeholder-gray-400 dark:placeholder-gray-500 text-sm sm:text-base overflow-auto focus:ring-2 focus:ring-purple-500/50 dark:focus:ring-purple-600/50 resize-none"
+          class="w-full h-full px-4 py-3 theme-input resize-none"
           placeholder="优化后的提示词将显示在这里..."
         ></textarea>
       </div>

--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -365,10 +365,10 @@ html * {
   
   /* 管理界面容器 */
   .theme-manager-container {
-    @apply bg-white dark:bg-slate-900 
+    @apply bg-white dark:bg-slate-800/90 
          theme-blue:bg-blue-100 theme-green:bg-green-100 theme-purple:bg-gray-900/90
          backdrop-blur-sm rounded-xl shadow-xl 
-         border border-gray-200 dark:border-slate-800 
+         border border-slate-200 dark:border-slate-700 
          theme-blue:border-blue-400 theme-green:border-green-400 theme-purple:border-purple-700/50;
   }
 
@@ -669,11 +669,13 @@ html * {
 
 /* 主题抽屉 */
 .theme-drawer {
-  @apply bg-white dark:bg-slate-800 border-l border-slate-200 dark:border-slate-700;
+  @apply bg-white dark:bg-slate-800/90
+  backdrop-blur-sm rounded-xl shadow-xl
+  border-l border-slate-200 dark:border-slate-700;
 }
 
 .theme-drawer-header {
-  @apply border-b border-slate-200 dark:border-slate-700;
+  @apply rounded-t-xl border-b border-slate-200 dark:border-slate-700;
 }
 
 .theme-drawer-content {
@@ -713,10 +715,6 @@ html * {
 }
 
 /* 管理界面主题 */
-.theme-manager-container {
-  @apply bg-white dark:bg-slate-800 rounded-lg shadow-xl border border-slate-200 dark:border-slate-700;
-}
-
 .theme-manager-header {
   @apply border-b border-slate-200 dark:border-slate-700;
 }


### PR DESCRIPTION
Orignal:
<img width="1379" alt="截屏2025-03-05 08 26 48" src="https://github.com/user-attachments/assets/b8d58bb5-13e3-479a-91fd-169de75ac910" />
Now:
<img width="1389" alt="截屏2025-03-05 08 58 47" src="https://github.com/user-attachments/assets/7e2dcd46-0ac5-4c80-a6a4-3c9b5d80f3da" />

Orignal:
<img width="590" alt="截屏2025-03-05 09 00 09" src="https://github.com/user-attachments/assets/6edc168c-c791-4bd5-ad04-97efa1f61cc5" />
Now:
<img width="585" alt="截屏2025-03-05 09 44 57" src="https://github.com/user-attachments/assets/f04a11dd-bd31-43f4-89d2-1ac29a1b20c8" />
