### PR TITLE
Fix streaming response UI issues in OutputPanel

### DIFF
--- a/packages/ui/src/components/PromptPanel.vue
+++ b/packages/ui/src/components/PromptPanel.vue
@@ -34,7 +34,7 @@
           @click="copyPrompt"
           class="px-3 py-1.5 theme-button-secondary flex items-center space-x-2"
         >
-          <span>{{ t('common.copy') }}</span>
+          <span>{{ t('prompt.copy') }}</span>
         </button>
       </div>
     </div>

--- a/packages/ui/src/components/TestPanel.vue
+++ b/packages/ui/src/components/TestPanel.vue
@@ -42,39 +42,35 @@
       <div class="flex-1 min-h-0 overflow-y-auto mt-5">
         <div class="relative h-full">
           <!-- Original Prompt Test Result -->
-          <div 
-            v-show="isCompareMode" 
+          <div
+            v-show="isCompareMode"
             class="absolute inset-0 flex flex-col md:w-[calc(50%-6px)] md:mr-3"
           >
-            <h3 class="text-lg font-semibold theme-text mb-2">{{ t('test.originalResult') }}</h3>
             <OutputPanelUI
               ref="originalOutputPanelRef"
               :loading="isTestingOriginal"
               :error="originalTestError"
-              :result="originalTestResult"
+              v-model:result="originalTestResult"
               class="flex-1"
-              hide-title
+              :resultTitle="t('test.originalResult')"
             />
           </div>
-          
+
           <!-- Optimized Prompt Test Result -->
-          <div 
-            class="absolute inset-0 flex flex-col"
+          <div
+           class="absolute inset-0 flex flex-col"
             :class="{
-              'md:w-[calc(50%-6px)] md:left-[calc(50%+6px)] transition-[width,left] duration-300': isCompareMode,
-              'w-full': !isCompareMode
+            'md:w-[calc(50%-6px)] md:left-[calc(50%+6px)] transition-[width,left] duration-300': isCompareMode,
+            'w-full': !isCompareMode
             }"
           >
-            <h3 class="text-lg font-semibold theme-text mb-2 truncate">
-              {{ isCompareMode ? t('test.optimizedResult') : t('test.testResult') }}
-            </h3>
             <OutputPanelUI
               ref="optimizedOutputPanelRef"
               :loading="isTestingOptimized"
               :error="optimizedTestError"
-              :result="optimizedTestResult"
+              v-model:result="optimizedTestResult"
               class="flex-1"
-              hide-title
+              :resultTitle="isCompareMode ? t('test.optimizedResult') : t('test.testResult')"
             />
           </div>
         </div>
@@ -162,18 +158,18 @@ const ensureString = (value) => {
 // Test original prompt
 const testOriginalPrompt = async () => {
   if (!props.originalPrompt || !testContent.value) return
-  
+
   isTestingOriginal.value = true
   originalTestError.value = ''
-  
+
   try {
     if (originalOutputPanelRef.value) {
       const streamHandler = originalOutputPanelRef.value.handleStream()
-      
+
       // Ensure prompt is a string
       const promptStr = ensureString(props.originalPrompt)
       console.log('[TestPanel] Original prompt type:', typeof promptStr, promptStr.substring(0, 30))
-      
+
       await props.promptService.testPromptStream(
         promptStr,
         testContent.value,
@@ -197,20 +193,20 @@ const testOriginalPrompt = async () => {
 // Test optimized prompt
 const testOptimizedPrompt = async () => {
   if (!props.optimizedPrompt || !testContent.value) return
-  
+
   isTestingOptimized.value = true
   optimizedTestError.value = ''
-  
+
   try {
     const outputPanel = optimizedOutputPanelRef.value
-    
+
     if (outputPanel) {
       const streamHandler = outputPanel.handleStream()
-      
+
       // Ensure prompt is a string
       const promptStr = ensureString(props.optimizedPrompt)
       console.log('[TestPanel] Optimized prompt type:', typeof promptStr, promptStr.substring(0, 30))
-      
+
       await props.promptService.testPromptStream(
         promptStr,
         testContent.value,
@@ -239,7 +235,7 @@ const handleTest = async () => {
     optimizedTestError.value = errorMsg
     return
   }
-  
+
   if (isCompareMode.value) {
     // Compare test mode: test both original and optimized prompts
     try {
@@ -264,6 +260,7 @@ const handleTest = async () => {
 
 // Component mounted, if there is a default model, select it automatically
 onMounted(() => {
+  console.log("hideTitle value:", originalOutputPanelRef.value?.hideTitle);
   if (props.modelValue) {
     selectedTestModel.value = props.modelValue
   }
@@ -288,4 +285,4 @@ defineExpose({
   border-radius: 0.25rem;
   cursor: pointer;
 }
-</style> 
+</style>

--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -622,7 +622,7 @@ html * {
   /* ===== 状态组件 ===== */
   /* 主题加载中 */
   .theme-loading {
-    @apply text-teal-700;
+    @apply text-teal-300;
   }
   /* 主题错误 */
   .theme-error {
@@ -1100,7 +1100,7 @@ html * {
   /* ===== 状态组件 ===== */
   /* 主题加载中 */
   .theme-loading {
-    @apply text-purple-400 animate-pulse;
+    @apply text-purple-400;
   }
 
   /* 主题错误 */


### PR DESCRIPTION
## 优化 OutputPanel 组件流式响应交互体验
本次 PR 主要解决了 OutputPanel 组件在处理流式响应过程中的几个界面交互问题，提升了用户体验：

### 问题修复：
#### 1. 加载提示显示问题：
- 修改了加载指示器的条件逻辑，确保在开始流式传输但尚未接收到内容时能正确显示加载状态
- 优化后的条件：v-if="(loading || (isStreaming && contentTokens.length === 0))"


#### 2. 复制按钮不显示问题：
- 解决了由于 hide-title 属性导致整个标题栏（含复制按钮）被隐藏的问题
- 引入 resultTitle 属性，允许在显示自定义标题的同时保留复制功能

#### 3. 内容重置问题：
- 修复了流式传输完成后内容被意外重置的问题
- 优化了 watch 监听函数，避免在流式传输后自动触发更新导致的内容丢失

### 效果：
对比测试模式下，用户现在可以看到正确的加载状态、按需复制内容，并且流式响应的完整结果会被正确保留。这些改进使得整体交互体验更加顺畅和符合预期。
<img width="1292" alt="截屏2025-03-13 19 21 41" src="https://github.com/user-attachments/assets/29ee5038-e16e-4e67-a3df-c07c552f84a4" />
截图为左边正在输出，右边输出完毕显示拷贝按钮。