### PR TITLE
Feat: Add provider name on connection test toast

### DIFF
--- a/packages/ui/src/components/ModelManager.vue
+++ b/packages/ui/src/components/ModelManager.vue
@@ -364,10 +364,14 @@ const testConnection = async (key) => {
 
     const llm = createLLMService(modelManager);
     await llm.testConnection(key);
-    toast.success(t('modelManager.testSuccess'));
+    toast.success(t('modelManager.testSuccess', { provider: model.name }));
   } catch (error) {
     console.error('连接测试失败:', error);
-    toast.error(t('modelManager.testFailed', { error: error.message }));
+    const modelName = modelManager.getModel(key)?.name || key;
+    toast.error(t('modelManager.testFailed', { 
+      provider: modelName, 
+      error: error.message || 'Unknown error' 
+    }));
   } finally {
     delete testingConnections.value[key];
   }

--- a/packages/ui/src/i18n/locales/en-US.ts
+++ b/packages/ui/src/i18n/locales/en-US.ts
@@ -91,8 +91,8 @@ export default {
     deleteConfirm: 'Are you sure you want to delete this model? This action cannot be undone.',
 
     // Operation Results
-    testSuccess: 'Connection test successful',
-    testFailed: 'Connection test failed: {error}',
+    testSuccess: 'Connection successful for {provider}!',
+    testFailed: 'Connection failed for {provider}: {error}',
     updateSuccess: 'Update successful',
     updateFailed: 'Update failed: {error}',
     addSuccess: 'Model added successfully',

--- a/packages/ui/src/i18n/locales/zh-CN.ts
+++ b/packages/ui/src/i18n/locales/zh-CN.ts
@@ -93,8 +93,8 @@ export default {
     deleteConfirm: '确定要删除此模型吗？此操作不可恢复。',
 
     // 操作结果
-    testSuccess: '连接测试成功',
-    testFailed: '连接测试失败：{error}',
+    testSuccess: '{provider}连接测试成功',
+    testFailed: '{provider}连接测试失败：{error}',
     updateSuccess: '更新成功',
     updateFailed: '更新失败：{error}',
     addSuccess: '添加成功',


### PR DESCRIPTION
- 增加连接错误通知时用数组传两个参数
注：catch中model.name变量会被释放，所以声明了modelName来重新捕获