### PR TITLE
feat(template): 修复在切换模板语言后，模板选择器不响应式更新

### DIFF
--- a/docs/experience.md
+++ b/docs/experience.md
@@ -182,6 +182,39 @@ for (const [key, value] of Object.entries(importData)) {
 - **用户模板**：可修改，导入时生成新ID
 - **导入规则**：跳过与内置模板ID重复的模板
 
+### 4. 数组内容深度比较修复（2025-01-27）
+**问题**：BugBot 发现模板内容比较使用引用比较而非深度比较
+```typescript
+// ❌ 错误：数组引用比较
+if (updatedTemplate.content !== currentTemplate.content) {
+  // 数组内容相同但引用不同时会触发不必要更新
+}
+
+// ✅ 正确：深度比较函数
+const deepCompareTemplateContent = (content1, content2) => {
+  if (typeof content1 !== typeof content2) return false;
+  
+  if (typeof content1 === 'string') return content1 === content2;
+  
+  if (Array.isArray(content1) && Array.isArray(content2)) {
+    if (content1.length !== content2.length) return false;
+    return content1.every((item1, index) => {
+      const item2 = content2[index];
+      return item1.role === item2.role && item1.content === item2.content;
+    });
+  }
+  
+  return JSON.stringify(content1) === JSON.stringify(content2);
+};
+
+// 使用深度比较
+if (!deepCompareTemplateContent(updatedTemplate.content, currentTemplate.content)) {
+  // 只有内容真正改变时才更新
+}
+```
+
+**关键**：Template 接口的 content 可以是 `string | Array<{role: string; content: string}>`，必须支持两种类型的正确比较。
+
 ---
 
 ## 📝 文档更新规范

--- a/docs/experience.md
+++ b/docs/experience.md
@@ -215,6 +215,27 @@ if (!deepCompareTemplateContent(updatedTemplate.content, currentTemplate.content
 
 **关键**：Template 接口的 content 可以是 `string | Array<{role: string; content: string}>`，必须支持两种类型的正确比较。
 
+### 5. 模板类型过滤器验证修复（2025-01-27）
+**问题**：BugBot 发现 refreshTemplates 函数可能选择不匹配类型过滤器的模板
+```typescript
+// ❌ 问题：更新模板后直接返回，未验证类型匹配
+if (updatedTemplate && contentChanged) {
+  emit('update:modelValue', updatedTemplate)
+  return // 跳过了类型验证
+}
+
+// ✅ 修复：添加类型验证
+if (updatedTemplate && contentChanged) {
+  // 验证更新后的模板是否还匹配当前类型过滤器
+  if (updatedTemplate.metadata.templateType === props.type) {
+    emit('update:modelValue', updatedTemplate)
+    return
+  }
+  // 类型不匹配时继续执行后续逻辑
+}
+```
+**修复效果**：确保模板选择器只选择匹配当前类型的模板，避免类型不一致的问题。
+
 ---
 
 ## 📝 文档更新规范

--- a/packages/extension/src/App.vue
+++ b/packages/extension/src/App.vue
@@ -354,26 +354,9 @@ const handleTemplateManagerClose = () => {
   showTemplates.value = false
 
   // 刷新模板选择器以反映语言变更后的模板
+  // 子组件会通过 v-model 自动更新父组件的状态
   if (templateSelectRef.value?.refresh) {
     templateSelectRef.value.refresh()
-  }
-
-  // 确保当前选中的模板也得到更新（处理语言切换的情况）
-  const currentTemplate = currentSelectedTemplate.value
-  if (currentTemplate && currentTemplate.isBuiltin) {
-    try {
-      // 获取更新后的模板对象
-      const updatedTemplate = templateManager.getTemplate(currentTemplate.id)
-      if (updatedTemplate && (
-        updatedTemplate.name !== currentTemplate.name ||
-        updatedTemplate.content !== currentTemplate.content
-      )) {
-        // 更新当前选中的模板
-        currentSelectedTemplate.value = updatedTemplate
-      }
-    } catch (error) {
-      console.warn('Failed to update current selected template after language change:', error)
-    }
   }
 }
 

--- a/packages/extension/src/App.vue
+++ b/packages/extension/src/App.vue
@@ -77,6 +77,7 @@
           </template>
           <template #template-select>
             <TemplateSelectUI
+              ref="templateSelectRef"
               v-model="currentSelectedTemplate"
               :type="selectedOptimizationMode === 'system' ? 'optimize' : 'userOptimize'"
               :optimization-mode="selectedOptimizationMode"
@@ -346,8 +347,34 @@ const openTemplateManager = (type: string) => {
   showTemplates.value = true
 }
 
+// 模板选择器引用
+const templateSelectRef = ref()
+
 const handleTemplateManagerClose = () => {
   showTemplates.value = false
+
+  // 刷新模板选择器以反映语言变更后的模板
+  if (templateSelectRef.value?.refresh) {
+    templateSelectRef.value.refresh()
+  }
+
+  // 确保当前选中的模板也得到更新（处理语言切换的情况）
+  const currentTemplate = currentSelectedTemplate.value
+  if (currentTemplate && currentTemplate.isBuiltin) {
+    try {
+      // 获取更新后的模板对象
+      const updatedTemplate = templateManager.getTemplate(currentTemplate.id)
+      if (updatedTemplate && (
+        updatedTemplate.name !== currentTemplate.name ||
+        updatedTemplate.content !== currentTemplate.content
+      )) {
+        // 更新当前选中的模板
+        currentSelectedTemplate.value = updatedTemplate
+      }
+    } catch (error) {
+      console.warn('Failed to update current selected template after language change:', error)
+    }
+  }
 }
 
 // 数据管理器

--- a/packages/ui/src/components/TemplateSelect.vue
+++ b/packages/ui/src/components/TemplateSelect.vue
@@ -265,11 +265,15 @@ const refreshTemplates = () => {
         updatedTemplate.name !== currentTemplate.name ||
         !deepCompareTemplateContent(updatedTemplate.content, currentTemplate.content)
       )) {
-        // 通过 v-model 更新父组件状态
-        emit('update:modelValue', updatedTemplate)
-        // 静默更新，不显示用户提示
-        emit('select', updatedTemplate, false)
-        return
+        // 验证更新后的模板是否还匹配当前类型过滤器（修复类型过滤器忽略问题）
+        if (updatedTemplate.metadata.templateType === props.type) {
+          // 通过 v-model 更新父组件状态
+          emit('update:modelValue', updatedTemplate)
+          // 静默更新，不显示用户提示
+          emit('select', updatedTemplate, false)
+          return
+        }
+        // 如果类型不匹配，继续执行后续逻辑选择合适的模板
       }
     } catch (error) {
       console.warn('[TemplateSelect] Failed to get updated template:', error)

--- a/packages/web/src/App.vue
+++ b/packages/web/src/App.vue
@@ -354,26 +354,9 @@ const handleTemplateManagerClose = () => {
   showTemplates.value = false
 
   // 刷新模板选择器以反映语言变更后的模板
+  // 子组件会通过 v-model 自动更新父组件的状态
   if (templateSelectRef.value?.refresh) {
     templateSelectRef.value.refresh()
-  }
-
-  // 确保当前选中的模板也得到更新（处理语言切换的情况）
-  const currentTemplate = currentSelectedTemplate.value
-  if (currentTemplate && currentTemplate.isBuiltin) {
-    try {
-      // 获取更新后的模板对象
-      const updatedTemplate = templateManager.getTemplate(currentTemplate.id)
-      if (updatedTemplate && (
-        updatedTemplate.name !== currentTemplate.name ||
-        updatedTemplate.content !== currentTemplate.content
-      )) {
-        // 更新当前选中的模板
-        currentSelectedTemplate.value = updatedTemplate
-      }
-    } catch (error) {
-      console.warn('Failed to update current selected template after language change:', error)
-    }
   }
 }
 

--- a/packages/web/src/App.vue
+++ b/packages/web/src/App.vue
@@ -77,6 +77,7 @@
           </template>
           <template #template-select>
             <TemplateSelectUI
+              ref="templateSelectRef"
               v-model="currentSelectedTemplate"
               :type="selectedOptimizationMode === 'system' ? 'optimize' : 'userOptimize'"
               :optimization-mode="selectedOptimizationMode"
@@ -346,8 +347,34 @@ const openTemplateManager = (type: string) => {
   showTemplates.value = true
 }
 
+// 模板选择器引用
+const templateSelectRef = ref()
+
 const handleTemplateManagerClose = () => {
   showTemplates.value = false
+
+  // 刷新模板选择器以反映语言变更后的模板
+  if (templateSelectRef.value?.refresh) {
+    templateSelectRef.value.refresh()
+  }
+
+  // 确保当前选中的模板也得到更新（处理语言切换的情况）
+  const currentTemplate = currentSelectedTemplate.value
+  if (currentTemplate && currentTemplate.isBuiltin) {
+    try {
+      // 获取更新后的模板对象
+      const updatedTemplate = templateManager.getTemplate(currentTemplate.id)
+      if (updatedTemplate && (
+        updatedTemplate.name !== currentTemplate.name ||
+        updatedTemplate.content !== currentTemplate.content
+      )) {
+        // 更新当前选中的模板
+        currentSelectedTemplate.value = updatedTemplate
+      }
+    } catch (error) {
+      console.warn('Failed to update current selected template after language change:', error)
+    }
+  }
 }
 
 // 数据管理器


### PR DESCRIPTION
 # 问题描述
1. 在模板管理器，对语言进行切换后，点击关闭按钮，关闭模板管理器的弹窗，发现模板选择器没有响应式更新（如果是点击遮罩层不会出现此bug，因为点击遮罩层把模板选择器也手动关闭了）
2. 同时模板选择器选中的模板名也没有更新。
![CPT2506261035-696x300](https://github.com/user-attachments/assets/d228149d-0f06-457d-9747-80d33de3e4e1)

 # 相关修复
- 在关闭模板管理后，对模板选择器的模板列表进行更新
- 在模板选择器中，对展示的模板进行更新

# 未修复问题

模板选择器中模板的描述词过长，会导致组件宽度超出外部容器，内容被截断。暂时未找到好的方式修复

