### PR TITLE
🐛 Fix: 修复模型管理器中的 baseURL 逻辑

### DIFF
--- a/packages/core/src/services/model/manager.ts
+++ b/packages/core/src/services/model/manager.ts
@@ -81,6 +81,7 @@ export class ModelManager implements IModelManager {
                 ...defaultConfig,
                 // 保留用户配置的关键字段
                 name: existingModel.name !== undefined ? existingModel.name : defaultConfig.name,
+                baseURL: existingModel.baseURL || defaultConfig.baseURL,
                 defaultModel: existingModel.defaultModel !== undefined ? existingModel.defaultModel : defaultConfig.defaultModel,
                 apiKey: existingModel.apiKey || defaultConfig.apiKey,
                 enabled: existingModel.enabled !== undefined ? existingModel.enabled : defaultConfig.enabled,


### PR DESCRIPTION
问题描述
在使用过程中发现，配置 GEMINI 等模型的自定义 baseURL 后，关闭应用重新打开时，baseURL 会重置为默认值，导致用户需要重复配置。

问题原因
模型配置更新时，未正确保留用户自定义的 baseURL 字段，导致配置丢失。

影响范围
✅ 修复 baseURL 配置持久化问题