### PR TITLE
feat(core): add MiniMax provider support

### DIFF
--- a/env.local.example
+++ b/env.local.example
@@ -27,6 +27,9 @@
 # 智谱 AI API 配置
 # VITE_ZHIPU_API_KEY=your-zhipu-api-key-here
 
+# MiniMax API 配置
+# VITE_MINIMAX_API_KEY=your-minimax-api-key-here
+
 # SiliconFlow API 配置
 # VITE_SILICONFLOW_API_KEY=sk-your-siliconflow-api-key-here
 

--- a/packages/core/src/services/llm/adapters/minimax-adapter.ts
+++ b/packages/core/src/services/llm/adapters/minimax-adapter.ts
@@ -1,0 +1,77 @@
+import type { TextModel, TextProvider } from '../types'
+import { OpenAIAdapter } from './openai-adapter'
+
+interface ModelOverride {
+  id: string
+  name: string
+  description: string
+  capabilities?: Partial<TextModel['capabilities']>
+  defaultParameterValues?: Record<string, unknown>
+}
+
+const MINIMAX_STATIC_MODELS: ModelOverride[] = [
+  {
+    id: 'MiniMax-M2.5',
+    name: 'MiniMax M2.5',
+    description: 'MiniMax latest flagship model with advanced capabilities',
+    capabilities: {
+      supportsTools: true,
+      supportsReasoning: false,
+      maxContextLength: 1000000
+    }
+  },
+  {
+    id: 'MiniMax-M2.5-highspeed',
+    name: 'MiniMax M2.5 HighSpeed',
+    description: 'MiniMax high-speed model optimized for fast inference',
+    capabilities: {
+      supportsTools: true,
+      supportsReasoning: false,
+      maxContextLength: 1000000
+    }
+  }
+]
+
+export class MinimaxAdapter extends OpenAIAdapter {
+  public getProvider(): TextProvider {
+    return {
+      id: 'minimax',
+      name: 'MiniMax',
+      description: 'MiniMax AI models via OpenAI-compatible API',
+      requiresApiKey: true,
+      defaultBaseURL: 'https://api.minimax.io/v1',
+      supportsDynamicModels: true,
+      apiKeyUrl: 'https://platform.minimaxi.com/user-center/basic-information/interface-key',
+      connectionSchema: {
+        required: ['apiKey'],
+        optional: ['baseURL'],
+        fieldTypes: {
+          apiKey: 'string',
+          baseURL: 'string'
+        }
+      }
+    }
+  }
+
+  public getModels(): TextModel[] {
+    return MINIMAX_STATIC_MODELS.map((definition) => {
+      const baseModel = this.buildDefaultModel(definition.id)
+
+      return {
+        ...baseModel,
+        name: definition.name,
+        description: definition.description,
+        capabilities: {
+          ...baseModel.capabilities,
+          ...(definition.capabilities ?? {})
+        },
+        defaultParameterValues: definition.defaultParameterValues
+          ? {
+              ...(baseModel.defaultParameterValues ?? {}),
+              ...definition.defaultParameterValues
+            }
+          : baseModel.defaultParameterValues
+      }
+    })
+  }
+}

--- a/packages/core/src/services/llm/adapters/registry.ts
+++ b/packages/core/src/services/llm/adapters/registry.ts
@@ -16,6 +16,7 @@ import { DashScopeAdapter } from './dashscope-adapter';
 import { OpenRouterAdapter } from './openrouter-adapter';
 import { ModelScopeAdapter } from './modelscope-adapter';
 import { OllamaAdapter } from './ollama-adapter';
+import { MinimaxAdapter } from './minimax-adapter';
 import { RequestConfigError } from '../errors';
 
 /**
@@ -58,6 +59,7 @@ export class TextAdapterRegistry
     const openrouterAdapter = new OpenRouterAdapter();
     const modelscopeAdapter = new ModelScopeAdapter();
     const ollamaAdapter = new OllamaAdapter();
+    const minimaxAdapter = new MinimaxAdapter();
 
     this.adapters.set('openai', openaiAdapter);
     this.adapters.set('deepseek', deepseekAdapter);
@@ -69,6 +71,7 @@ export class TextAdapterRegistry
     this.adapters.set('openrouter', openrouterAdapter);
     this.adapters.set('modelscope', modelscopeAdapter);
     this.adapters.set('ollama', ollamaAdapter);
+    this.adapters.set('minimax', minimaxAdapter);
 
     // 预加载静态模型缓存
     this.preloadStaticModels();

--- a/packages/core/src/services/model/defaults.ts
+++ b/packages/core/src/services/model/defaults.ts
@@ -17,7 +17,8 @@ const PROVIDER_ENV_KEYS = {
   zhipu: 'VITE_ZHIPU_API_KEY',
   dashscope: 'VITE_DASHSCOPE_API_KEY',
   openrouter: 'VITE_OPENROUTER_API_KEY',
-  modelscope: 'VITE_MODELSCOPE_API_KEY'
+  modelscope: 'VITE_MODELSCOPE_API_KEY',
+  minimax: 'VITE_MINIMAX_API_KEY'
 } as const;
 
 /**

--- a/packages/core/tests/unit/llm/minimax-adapter.test.ts
+++ b/packages/core/tests/unit/llm/minimax-adapter.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MinimaxAdapter } from '../../../src/services/llm/adapters/minimax-adapter';
+import type { TextModelConfig, Message } from '../../../src/services/llm/types';
+
+let mockOpenAIInstance: any;
+let mockOpenAIConfig: any;
+
+vi.mock('openai', () => {
+  return {
+    default: class MockOpenAI {
+      constructor(config: any) {
+        mockOpenAIConfig = config;
+        return mockOpenAIInstance;
+      }
+    }
+  };
+});
+
+describe('MinimaxAdapter', () => {
+  let adapter: MinimaxAdapter;
+
+  const mockConfig: TextModelConfig = {
+    id: 'minimax',
+    name: 'MiniMax',
+    enabled: true,
+    providerMeta: {
+      id: 'minimax',
+      name: 'MiniMax',
+      description: 'MiniMax AI models via OpenAI-compatible API',
+      requiresApiKey: true,
+      defaultBaseURL: 'https://api.minimax.io/v1',
+      supportsDynamicModels: true,
+      connectionSchema: {
+        required: ['apiKey'],
+        optional: ['baseURL'],
+        fieldTypes: {
+          apiKey: 'string',
+          baseURL: 'string'
+        }
+      }
+    },
+    modelMeta: {
+      id: 'MiniMax-M2.5',
+      name: 'MiniMax M2.5',
+      description: 'MiniMax latest flagship model',
+      providerId: 'minimax',
+      capabilities: {
+        supportsTools: true,
+        supportsReasoning: false,
+        maxContextLength: 1000000
+      },
+      parameterDefinitions: [
+        {
+          name: 'temperature',
+          type: 'number',
+          description: 'Sampling temperature',
+          default: 1,
+          min: 0,
+          max: 2
+        }
+      ],
+      defaultParameterValues: {
+        temperature: 1
+      }
+    },
+    connectionConfig: {
+      apiKey: 'test-minimax-key',
+      baseURL: 'https://api.minimax.io/v1'
+    },
+    paramOverrides: {}
+  };
+
+  const mockMessages: Message[] = [
+    { role: 'user', content: 'Hello, world!' }
+  ];
+
+  beforeEach(() => {
+    adapter = new MinimaxAdapter();
+    mockOpenAIConfig = undefined;
+    vi.clearAllMocks();
+
+    mockOpenAIInstance = {
+      chat: {
+        completions: {
+          create: vi.fn()
+        }
+      },
+      models: {
+        list: vi.fn()
+      }
+    };
+  });
+
+  describe('getProvider', () => {
+    it('should return MiniMax provider metadata', () => {
+      const provider = adapter.getProvider();
+
+      expect(provider.id).toBe('minimax');
+      expect(provider.name).toBe('MiniMax');
+      expect(provider.defaultBaseURL).toBe('https://api.minimax.io/v1');
+      expect(provider.supportsDynamicModels).toBe(true);
+      expect(provider.requiresApiKey).toBe(true);
+    });
+
+    it('should have valid connection schema', () => {
+      const provider = adapter.getProvider();
+
+      expect(provider.connectionSchema.required).toContain('apiKey');
+      expect(provider.connectionSchema.fieldTypes.apiKey).toBe('string');
+      expect(provider.connectionSchema.fieldTypes.baseURL).toBe('string');
+    });
+  });
+
+  describe('getModels', () => {
+    it('should return static MiniMax models list', () => {
+      const models = adapter.getModels();
+
+      expect(Array.isArray(models)).toBe(true);
+      expect(models.length).toBeGreaterThan(0);
+
+      const m25 = models.find(m => m.id === 'MiniMax-M2.5');
+      expect(m25).toBeDefined();
+      expect(m25?.name).toBe('MiniMax M2.5');
+      expect(m25?.providerId).toBe('minimax');
+      expect(m25?.capabilities.supportsTools).toBe(true);
+    });
+
+    it('should include all expected models', () => {
+      const models = adapter.getModels();
+      const modelIds = models.map(m => m.id);
+
+      expect(modelIds).toContain('MiniMax-M2.5');
+      expect(modelIds).toContain('MiniMax-M2.5-highspeed');
+      expect(models.length).toBe(2);
+    });
+
+    it('should have capabilities for each model', () => {
+      const models = adapter.getModels();
+
+      models.forEach(model => {
+        expect(model.capabilities).toBeDefined();
+        expect(typeof model.capabilities.supportsTools).toBe('boolean');
+        expect(typeof model.capabilities.maxContextLength).toBe('number');
+      });
+    });
+  });
+
+  describe('buildDefaultModel', () => {
+    it('should build valid TextModel for unknown model ID', () => {
+      const model = adapter.buildDefaultModel('unknown-minimax-model');
+
+      expect(model.id).toBe('unknown-minimax-model');
+      expect(model.name).toBe('unknown-minimax-model');
+      expect(model.providerId).toBe('minimax');
+      expect(model.capabilities).toBeDefined();
+    });
+  });
+
+  describe('sendMessage', () => {
+    it('should return LLMResponse with correct format', async () => {
+      const mockResponse = {
+        id: 'chatcmpl-minimax-123',
+        object: 'chat.completion',
+        created: Date.now(),
+        model: 'MiniMax-M2.5',
+        choices: [{
+          index: 0,
+          message: {
+            role: 'assistant',
+            content: 'Hello from MiniMax!'
+          },
+          finish_reason: 'stop'
+        }],
+        usage: {
+          prompt_tokens: 10,
+          completion_tokens: 20,
+          total_tokens: 30
+        }
+      };
+
+      mockOpenAIInstance.chat.completions.create.mockResolvedValue(mockResponse);
+
+      const response = await adapter.sendMessage(mockMessages, mockConfig);
+
+      expect(response.content).toBe('Hello from MiniMax!');
+      expect(response.metadata).toEqual({
+        model: 'MiniMax-M2.5',
+        finishReason: 'stop'
+      });
+    });
+  });
+
+  describe('sendMessageStream', () => {
+    it('should trigger callbacks correctly', async () => {
+      const mockStream = {
+        [Symbol.asyncIterator]: async function* () {
+          yield {
+            id: 'chatcmpl-minimax-123',
+            choices: [{
+              index: 0,
+              delta: { content: 'Hello' },
+              finish_reason: null
+            }]
+          };
+          yield {
+            id: 'chatcmpl-minimax-123',
+            choices: [{
+              index: 0,
+              delta: { content: ' MiniMax' },
+              finish_reason: null
+            }]
+          };
+          yield {
+            id: 'chatcmpl-minimax-123',
+            choices: [{
+              index: 0,
+              delta: {},
+              finish_reason: 'stop'
+            }]
+          };
+        }
+      };
+
+      mockOpenAIInstance.chat.completions.create.mockResolvedValue(mockStream);
+
+      const callbacks = {
+        onToken: vi.fn(),
+        onReasoningToken: vi.fn(),
+        onComplete: vi.fn(),
+        onError: vi.fn()
+      };
+
+      await adapter.sendMessageStream(mockMessages, mockConfig, callbacks);
+
+      expect(callbacks.onToken).toHaveBeenCalledWith('Hello');
+      expect(callbacks.onToken).toHaveBeenCalledWith(' MiniMax');
+      expect(callbacks.onComplete).toHaveBeenCalled();
+      expect(callbacks.onError).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/core/tests/unit/llm/registry.test.ts
+++ b/packages/core/tests/unit/llm/registry.test.ts
@@ -85,11 +85,11 @@ describe('TextAdapterRegistry', () => {
       const providers = registry.getAllProviders();
 
       expect(Array.isArray(providers)).toBe(true);
-      expect(providers.length).toBe(10);
+      expect(providers.length).toBe(11);
 
       const providerIds = providers.map(p => p.id);
       expect(providerIds).toEqual(
-        expect.arrayContaining(['openai', 'deepseek', 'siliconflow', 'zhipu', 'gemini', 'anthropic', 'dashscope', 'openrouter', 'modelscope', 'ollama'])
+        expect.arrayContaining(['openai', 'deepseek', 'siliconflow', 'zhipu', 'gemini', 'anthropic', 'dashscope', 'openrouter', 'modelscope', 'ollama', 'minimax'])
       );
     });
 


### PR DESCRIPTION
Add MiniMax as a new LLM provider with OpenAI-compatible API integration. Includes MiniMax-M2.5 and MiniMax-M2.5-highspeed models, adapter registration, environment variable mapping, and unit tests.