### PR TITLE
feat: add OfoxAI as a new model provider

### DIFF
--- a/env.local.example
+++ b/env.local.example
@@ -33,6 +33,9 @@
 # SiliconFlow API 配置
 # VITE_SILICONFLOW_API_KEY=sk-your-siliconflow-api-key-here
 
+# OfoxAI API 配置 - 100+ LLM 模型统一网关
+# VITE_OFOXAI_API_KEY=your-ofoxai-api-key-here
+
 # ModelScope (魔搭) API 配置 - 每天免费 2000 次调用
 # 支持文本模型（LLM）和图像生成模型
 # VITE_MODELSCOPE_API_KEY=your-modelscope-sdk-token-here
@@ -89,7 +92,7 @@
 # 以下配置仅在使用 MCP 服务器时需要
 
 # 首选模型提供商（当配置了多个 API 密钥时）
-# 可选值：openai, gemini, anthropic, deepseek, siliconflow, zhipu, dashscope, openrouter, modelscope, custom, custom_<suffix>
+# 可选值：openai, gemini, anthropic, deepseek, siliconflow, zhipu, dashscope, openrouter, modelscope, ofoxai, custom, custom_<suffix>
 # 注意：必须与上面配置的 API 密钥对应
 # 示例：如果配置了 VITE_CUSTOM_API_KEY_qwen3，可以使用 custom_qwen3
 # MCP_DEFAULT_MODEL_PROVIDER=openai

--- a/packages/core/src/services/llm/adapters/minimax-adapter.ts
+++ b/packages/core/src/services/llm/adapters/minimax-adapter.ts
@@ -11,9 +11,29 @@ interface ModelOverride {
 
 const MINIMAX_STATIC_MODELS: ModelOverride[] = [
   {
+    id: 'MiniMax-M2.7',
+    name: 'MiniMax M2.7',
+    description: 'Latest flagship model with enhanced reasoning and coding',
+    capabilities: {
+      supportsTools: true,
+      supportsReasoning: false,
+      maxContextLength: 1000000
+    }
+  },
+  {
+    id: 'MiniMax-M2.7-highspeed',
+    name: 'MiniMax M2.7 HighSpeed',
+    description: 'High-speed version of M2.7 for low-latency scenarios',
+    capabilities: {
+      supportsTools: true,
+      supportsReasoning: false,
+      maxContextLength: 1000000
+    }
+  },
+  {
     id: 'MiniMax-M2.5',
     name: 'MiniMax M2.5',
-    description: 'MiniMax latest flagship model with advanced capabilities',
+    description: 'MiniMax flagship model with advanced capabilities',
     capabilities: {
       supportsTools: true,
       supportsReasoning: false,

--- a/packages/core/src/services/llm/adapters/ofoxai-adapter.ts
+++ b/packages/core/src/services/llm/adapters/ofoxai-adapter.ts
@@ -1,0 +1,67 @@
+import type { TextModel, TextProvider } from '../types'
+import { OpenAIAdapter } from './openai-adapter'
+
+interface ModelOverride {
+  id: string
+  name: string
+  description: string
+  capabilities?: Partial<TextModel['capabilities']>
+  defaultParameterValues?: Record<string, unknown>
+}
+
+const OFOXAI_STATIC_MODELS: ModelOverride[] = [
+  {
+    id: 'gpt-4o-mini',
+    name: 'GPT-4o Mini',
+    description: 'OpenAI GPT-4o Mini，通过 OfoxAI 访问',
+    capabilities: {
+      supportsTools: true,
+      supportsReasoning: false,
+      maxContextLength: 128000
+    }
+  }
+]
+
+export class OfoxAIAdapter extends OpenAIAdapter {
+  public getProvider(): TextProvider {
+    return {
+      id: 'ofoxai',
+      name: 'OfoxAI',
+      description: 'OfoxAI 统一 API 网关，支持 100+ LLM 模型，OpenAI 兼容格式',
+      requiresApiKey: true,
+      defaultBaseURL: 'https://api.ofox.ai/v1',
+      supportsDynamicModels: true,
+      apiKeyUrl: 'https://ofox.ai',
+      connectionSchema: {
+        required: ['apiKey'],
+        optional: ['baseURL'],
+        fieldTypes: {
+          apiKey: 'string',
+          baseURL: 'string'
+        }
+      }
+    }
+  }
+
+  public getModels(): TextModel[] {
+    return OFOXAI_STATIC_MODELS.map((definition) => {
+      const baseModel = this.buildDefaultModel(definition.id)
+
+      return {
+        ...baseModel,
+        name: definition.name,
+        description: definition.description,
+        capabilities: {
+          ...baseModel.capabilities,
+          ...(definition.capabilities ?? {})
+        },
+        defaultParameterValues: definition.defaultParameterValues
+          ? {
+              ...(baseModel.defaultParameterValues ?? {}),
+              ...definition.defaultParameterValues
+            }
+          : baseModel.defaultParameterValues
+      }
+    })
+  }
+}

--- a/packages/core/src/services/llm/adapters/registry.ts
+++ b/packages/core/src/services/llm/adapters/registry.ts
@@ -17,6 +17,7 @@ import { OpenRouterAdapter } from './openrouter-adapter';
 import { ModelScopeAdapter } from './modelscope-adapter';
 import { OllamaAdapter } from './ollama-adapter';
 import { MinimaxAdapter } from './minimax-adapter';
+import { OfoxAIAdapter } from './ofoxai-adapter';
 import { RequestConfigError } from '../errors';
 
 /**
@@ -60,6 +61,7 @@ export class TextAdapterRegistry
     const modelscopeAdapter = new ModelScopeAdapter();
     const ollamaAdapter = new OllamaAdapter();
     const minimaxAdapter = new MinimaxAdapter();
+    const ofoxaiAdapter = new OfoxAIAdapter();
 
     this.adapters.set('openai', openaiAdapter);
     this.adapters.set('deepseek', deepseekAdapter);
@@ -72,6 +74,7 @@ export class TextAdapterRegistry
     this.adapters.set('modelscope', modelscopeAdapter);
     this.adapters.set('ollama', ollamaAdapter);
     this.adapters.set('minimax', minimaxAdapter);
+    this.adapters.set('ofoxai', ofoxaiAdapter);
 
     // 预加载静态模型缓存
     this.preloadStaticModels();

--- a/packages/core/src/services/model/defaults.ts
+++ b/packages/core/src/services/model/defaults.ts
@@ -18,7 +18,8 @@ const PROVIDER_ENV_KEYS = {
   dashscope: 'VITE_DASHSCOPE_API_KEY',
   openrouter: 'VITE_OPENROUTER_API_KEY',
   modelscope: 'VITE_MODELSCOPE_API_KEY',
-  minimax: 'VITE_MINIMAX_API_KEY'
+  minimax: 'VITE_MINIMAX_API_KEY',
+  ofoxai: 'VITE_OFOXAI_API_KEY'
 } as const;
 
 /**

--- a/packages/core/tests/unit/llm/minimax-adapter.test.ts
+++ b/packages/core/tests/unit/llm/minimax-adapter.test.ts
@@ -40,9 +40,9 @@ describe('MinimaxAdapter', () => {
       }
     },
     modelMeta: {
-      id: 'MiniMax-M2.5',
-      name: 'MiniMax M2.5',
-      description: 'MiniMax latest flagship model',
+      id: 'MiniMax-M2.7',
+      name: 'MiniMax M2.7',
+      description: 'Latest flagship model with enhanced reasoning and coding',
       providerId: 'minimax',
       capabilities: {
         supportsTools: true,
@@ -118,20 +118,29 @@ describe('MinimaxAdapter', () => {
       expect(Array.isArray(models)).toBe(true);
       expect(models.length).toBeGreaterThan(0);
 
-      const m25 = models.find(m => m.id === 'MiniMax-M2.5');
-      expect(m25).toBeDefined();
-      expect(m25?.name).toBe('MiniMax M2.5');
-      expect(m25?.providerId).toBe('minimax');
-      expect(m25?.capabilities.supportsTools).toBe(true);
+      const m27 = models.find(m => m.id === 'MiniMax-M2.7');
+      expect(m27).toBeDefined();
+      expect(m27?.name).toBe('MiniMax M2.7');
+      expect(m27?.providerId).toBe('minimax');
+      expect(m27?.capabilities.supportsTools).toBe(true);
     });
 
     it('should include all expected models', () => {
       const models = adapter.getModels();
       const modelIds = models.map(m => m.id);
 
+      expect(modelIds).toContain('MiniMax-M2.7');
+      expect(modelIds).toContain('MiniMax-M2.7-highspeed');
       expect(modelIds).toContain('MiniMax-M2.5');
       expect(modelIds).toContain('MiniMax-M2.5-highspeed');
-      expect(models.length).toBe(2);
+      expect(models.length).toBe(4);
+    });
+
+    it('should have M2.7 as the first model', () => {
+      const models = adapter.getModels();
+
+      expect(models[0].id).toBe('MiniMax-M2.7');
+      expect(models[1].id).toBe('MiniMax-M2.7-highspeed');
     });
 
     it('should have capabilities for each model', () => {
@@ -162,7 +171,7 @@ describe('MinimaxAdapter', () => {
         id: 'chatcmpl-minimax-123',
         object: 'chat.completion',
         created: Date.now(),
-        model: 'MiniMax-M2.5',
+        model: 'MiniMax-M2.7',
         choices: [{
           index: 0,
           message: {
@@ -184,7 +193,7 @@ describe('MinimaxAdapter', () => {
 
       expect(response.content).toBe('Hello from MiniMax!');
       expect(response.metadata).toEqual({
-        model: 'MiniMax-M2.5',
+        model: 'MiniMax-M2.7',
         finishReason: 'stop'
       });
     });


### PR DESCRIPTION
## Summary

Add [OfoxAI](https://ofox.ai) as a new model provider.

**OfoxAI** is a unified API gateway for 100+ LLM models (Claude, GPT, Gemini, DeepSeek, etc.) with a single API key. OpenAI-compatible format.

- **Website**: https://ofox.ai
- **API Docs**: https://docs.ofox.ai/zh/api
- **Base URL**: `https://api.ofox.ai/v1`
- **Compatibility**: OpenAI API compatible
- **Dynamic Models**: Supported via `/v1/models` endpoint

## Changes

| File | Action | Description |
|------|--------|-------------|
| `packages/core/src/services/llm/adapters/ofoxai-adapter.ts` | **NEW** | OfoxAI adapter extending OpenAIAdapter |
| `packages/core/src/services/llm/adapters/registry.ts` | **MODIFIED** | Register OfoxAI adapter |
| `packages/core/src/services/model/defaults.ts` | **MODIFIED** | Add `VITE_OFOXAI_API_KEY` env mapping |
| `env.local.example` | **MODIFIED** | Add OfoxAI env config example |

Follows the same pattern as OpenRouter adapter (OpenAI-compatible gateway).