### PR TITLE
fix: 修复自定义参数 Python 风格 JSON 解析失败导致 API 400 错误，新增 JSON/字符串格式切换

### DIFF
--- a/docs/superpowers/plans/2026-05-13-custom-param-json-toggle.md
+++ b/docs/superpowers/plans/2026-05-13-custom-param-json-toggle.md
@@ -1,0 +1,564 @@
+# 自定义参数 JSON/字符串格式切换 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 修复自定义参数无法解析 Python 风格 JSON（`False`/`True`/`None`）导致 vLLM API 400 错误，并为自定义参数添加 JSON/字符串格式切换开关。
+
+**Architecture:** 两层修复：核心层在 `parseCustomValue` 中加 Python→JSON 规范化重试；UI 层在 `ModelParameterEditor.vue` 的自定义参数行加格式切换按钮，用本地 `ref` 跟踪用户意图，`isJsonMode` computed 驱动显示。
+
+**Tech Stack:** TypeScript, Vue 3 Composition API, Naive UI (NButton/NSpace/NText), vitest
+
+---
+
+## 文件总览
+
+| 文件 | 操作 | 职责 |
+|---|---|---|
+| `packages/core/src/services/model/parameter-utils.ts` | 修改 | 新增 `normalizePythonLiterals`，修改 `parseCustomValue` |
+| `packages/core/tests/unit/parameter-utils.test.ts` | 修改 | 新增 `parseCustomValue` 测试用例 |
+| `packages/ui/src/i18n/locales/zh-CN/models.ts` | 修改 | 新增 4 个 i18n key |
+| `packages/ui/src/i18n/locales/zh-TW/models.ts` | 修改 | 新增 4 个 i18n key |
+| `packages/ui/src/i18n/locales/en-US/models.ts` | 修改 | 新增 4 个 i18n key |
+| `packages/ui/src/components/ModelParameterEditor.vue` | 修改 | 自定义参数 toggle + 显示 + 处理逻辑 |
+
+---
+
+### Task 1: 修复 `parseCustomValue` - Python 字面量规范化
+
+**Files:**
+- Modify: `packages/core/src/services/model/parameter-utils.ts:40-47`
+- Modify: `packages/core/tests/unit/parameter-utils.test.ts`
+
+- [ ] **Step 1: 在测试文件顶部添加 `parseCustomValue` 的导入和失败测试**
+
+打开 `packages/core/tests/unit/parameter-utils.test.ts`，在文件顶部的 import 行修改：
+
+```typescript
+import {
+  mergeOverrides,
+  parseCustomValue,
+  splitOverridesBySchema,
+  validateOverrides
+} from '../../src/services/model/parameter-utils'
+```
+
+在 `describe('parameter-utils', () => {` 块最末尾（现有测试之后）追加：
+
+```typescript
+  describe('parseCustomValue', () => {
+    it('parses standard JSON object', () => {
+      expect(parseCustomValue('{"key": "value"}')).toEqual({ key: 'value' })
+    })
+
+    it('parses Python-style False/True/None in JSON object', () => {
+      expect(parseCustomValue('{"enable_thinking": False}')).toEqual({ enable_thinking: false })
+      expect(parseCustomValue('{"flag": True}')).toEqual({ flag: true })
+      expect(parseCustomValue('{"val": None}')).toEqual({ val: null })
+    })
+
+    it('parses mixed Python/JSON literals', () => {
+      expect(parseCustomValue('{"a": True, "b": False, "c": None}')).toEqual({
+        a: true, b: false, c: null
+      })
+    })
+
+    it('returns string when content is not valid JSON even after normalization', () => {
+      expect(parseCustomValue('{broken')).toBe('{broken')
+    })
+
+    it('parses JSON array', () => {
+      expect(parseCustomValue('[1, 2, 3]')).toEqual([1, 2, 3])
+    })
+
+    it('parses booleans, null, integers, floats', () => {
+      expect(parseCustomValue('true')).toBe(true)
+      expect(parseCustomValue('false')).toBe(false)
+      expect(parseCustomValue('null')).toBe(null)
+      expect(parseCustomValue('42')).toBe(42)
+      expect(parseCustomValue('3.14')).toBe(3.14)
+    })
+
+    it('returns plain string for non-special input', () => {
+      expect(parseCustomValue('hello world')).toBe('hello world')
+    })
+  })
+```
+
+- [ ] **Step 2: 运行测试，确认新用例失败**
+
+```bash
+cd packages/core && npx vitest run tests/unit/parameter-utils.test.ts
+```
+
+期望输出：`parseCustomValue` 的 "parses Python-style" 测试 FAIL，其余用例 PASS。
+
+- [ ] **Step 3: 在 `parameter-utils.ts` 中新增辅助函数并修改解析逻辑**
+
+在 `packages/core/src/services/model/parameter-utils.ts` 第 15 行（`export function parseCustomValue` 之前）插入：
+
+```typescript
+function normalizePythonLiterals(input: string): string {
+  return input
+    .replace(/\bTrue\b/g, 'true')
+    .replace(/\bFalse\b/g, 'false')
+    .replace(/\bNone\b/g, 'null')
+}
+```
+
+将文件第 40-47 行（JSON 对象/数组解析块）替换为：
+
+```typescript
+  // JSON 对象或数组
+  if ((trimmed.startsWith('{') && trimmed.endsWith('}')) ||
+      (trimmed.startsWith('[') && trimmed.endsWith(']'))) {
+    try {
+      return JSON.parse(trimmed)
+    } catch {
+      // 尝试规范化 Python 风格字面量后重试
+    }
+    try {
+      return JSON.parse(normalizePythonLiterals(trimmed))
+    } catch {
+      // 解析失败，作为字符串处理
+    }
+  }
+```
+
+- [ ] **Step 4: 运行测试，确认全部通过**
+
+```bash
+cd packages/core && npx vitest run tests/unit/parameter-utils.test.ts
+```
+
+期望输出：所有测试 PASS，无 FAIL。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/services/model/parameter-utils.ts packages/core/tests/unit/parameter-utils.test.ts
+git commit -m "fix(core): normalize Python literals in parseCustomValue for JSON objects"
+```
+
+---
+
+### Task 2: 添加 i18n 文案
+
+**Files:**
+- Modify: `packages/ui/src/i18n/locales/zh-CN/models.ts`
+- Modify: `packages/ui/src/i18n/locales/zh-TW/models.ts`
+- Modify: `packages/ui/src/i18n/locales/en-US/models.ts`
+
+- [ ] **Step 1: 在 zh-CN `advancedParameters` 对象末尾追加新 key**
+
+在 `packages/ui/src/i18n/locales/zh-CN/models.ts` 文件中，找到 `advancedParameters` 对象（约第 45 行）。在该对象的最后一个现有 key 之后，闭合括号 `}` 之前，追加：
+
+```typescript
+      "formatJson": "JSON",
+      "formatString": "字符串",
+      "parsedAsObject": "已解析为 Object ✓",
+      "invalidJson": "无效 JSON，将作为字符串发送"
+```
+
+- [ ] **Step 2: 在 zh-TW `advancedParameters` 对象末尾追加新 key**
+
+在 `packages/ui/src/i18n/locales/zh-TW/models.ts` 文件中，找到 `advancedParameters` 对象，在末尾追加：
+
+```typescript
+      "formatJson": "JSON",
+      "formatString": "字串",
+      "parsedAsObject": "已解析為 Object ✓",
+      "invalidJson": "無效 JSON，將作為字串發送"
+```
+
+- [ ] **Step 3: 在 en-US `advancedParameters` 对象末尾追加新 key**
+
+在 `packages/ui/src/i18n/locales/en-US/models.ts` 文件中，找到 `advancedParameters` 对象，在末尾追加：
+
+```typescript
+      "formatJson": "JSON",
+      "formatString": "String",
+      "parsedAsObject": "Parsed as Object ✓",
+      "invalidJson": "Invalid JSON, will be sent as string"
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/ui/src/i18n/locales/zh-CN/models.ts packages/ui/src/i18n/locales/zh-TW/models.ts packages/ui/src/i18n/locales/en-US/models.ts
+git commit -m "feat(i18n): add custom param JSON/string format toggle keys"
+```
+
+---
+
+### Task 3: 更新 `ModelParameterEditor.vue` - Toggle UI 与逻辑
+
+**Files:**
+- Modify: `packages/ui/src/components/ModelParameterEditor.vue`
+
+- [ ] **Step 1: 在 `<script setup>` 中引入 `ref`、`watch` 并添加格式状态**
+
+在 `ModelParameterEditor.vue` 第 258 行（`<script setup lang="ts">`）找到：
+
+```typescript
+import { computed, type PropType } from 'vue'
+```
+
+替换为：
+
+```typescript
+import { computed, ref, watch, type PropType } from 'vue'
+```
+
+在第 261 行找到：
+
+```typescript
+import { useMessage, createDiscreteApi, NAlert, NButton, NCheckbox, NForm, NFormItem, NInput, NInputNumber, NSelect, NSpace, NTag, NText } from 'naive-ui'
+```
+
+替换为：
+
+```typescript
+import { useMessage, createDiscreteApi, NAlert, NButton, NCheckbox, NForm, NFormItem, NInput, NInputNumber, NSelect, NSpace, NTag, NText } from 'naive-ui'
+```
+
+（naive-ui 导入保持不变，NButton 已经在里面了。）
+
+在 `const emit = defineEmits<{...}>()` 之后（约第 285 行），追加以下内容：
+
+```typescript
+// 跟踪每个自定义参数的格式用户意图：'json' | 'string'
+// 初始值从存储值类型推导；用户切换后记录显式选择
+const customParamFormats = ref<Record<string, 'json' | 'string'>>({})
+
+watch(
+  () => props.paramOverrides,
+  (overrides) => {
+    for (const key of Object.keys(overrides)) {
+      if (!schemaMap.value.has(key) && !(key in customParamFormats.value)) {
+        const val = overrides[key]
+        customParamFormats.value[key] = (val !== null && typeof val === 'object') ? 'json' : 'string'
+      }
+    }
+  },
+  { immediate: true }
+)
+```
+
+- [ ] **Step 2: 新增 `getCustomDisplayValue` 和 `handleCustomFormatToggle` 函数**
+
+在 `handleCustomValueChange` 函数（约第 379 行）之后追加：
+
+```typescript
+const getCustomDisplayValue = (key: string): string => {
+  const val = props.paramOverrides[key]
+  if (val !== null && typeof val === 'object') {
+    return JSON.stringify(val, null, 2)
+  }
+  return val === undefined ? '' : String(val)
+}
+
+const handleCustomFormatToggle = (key: string, format: 'json' | 'string') => {
+  if (format === 'json') {
+    const currentText = getCustomDisplayValue(key)
+    const parsed = parseCustomValue(currentText)
+    if (parsed !== null && typeof parsed === 'object') {
+      customParamFormats.value[key] = 'json'
+      const next = { ...props.paramOverrides, [key]: parsed }
+      emit('update:paramOverrides', next)
+    } else {
+      message.error(t('modelManager.advancedParameters.invalidJson'))
+    }
+  } else {
+    customParamFormats.value[key] = 'string'
+    const next = { ...props.paramOverrides }
+    const val = next[key]
+    if (val !== null && typeof val === 'object') {
+      next[key] = JSON.stringify(val)
+    }
+    emit('update:paramOverrides', next)
+  }
+}
+```
+
+- [ ] **Step 3: 修改 `handleCustomValueChange` 以尊重格式设置**
+
+将现有的 `handleCustomValueChange` 函数（约第 379-388 行）：
+
+```typescript
+const handleCustomValueChange = (key: string, value: string) => {
+  const trimmed = value.trim()
+  const next = { ...props.paramOverrides }
+  if (trimmed === '') {
+    delete next[key]
+  } else {
+    next[key] = parseCustomValue(trimmed)
+  }
+  emit('update:paramOverrides', next)
+}
+```
+
+替换为：
+
+```typescript
+const handleCustomValueChange = (key: string, value: string) => {
+  const trimmed = value.trim()
+  const next = { ...props.paramOverrides }
+  if (trimmed === '') {
+    delete next[key]
+  } else {
+    const format = customParamFormats.value[key] ?? 'string'
+    if (format === 'json') {
+      next[key] = parseCustomValue(trimmed)
+    } else {
+      next[key] = trimmed
+    }
+  }
+  emit('update:paramOverrides', next)
+}
+```
+
+- [ ] **Step 4: 更新 `defineExpose` 以包含新函数**
+
+将 `defineExpose` 块（约第 390-394 行）：
+
+```typescript
+defineExpose({
+  handleAddDefinition,
+  handleValueChange,
+  handleCustomValueChange
+})
+```
+
+替换为：
+
+```typescript
+defineExpose({
+  handleAddDefinition,
+  handleValueChange,
+  handleCustomValueChange,
+  handleCustomFormatToggle
+})
+```
+
+- [ ] **Step 5: 替换 text 模式自定义参数的 `<NFormItem>` 模板块**
+
+在 template 中找到 text 模式的自定义参数块（约第 106-131 行）：
+
+```vue
+        <!-- 自定义参数（schema中不存在） -->
+        <NFormItem
+          v-for="entry in customEntries"
+          :key="`custom-${entry.key}`"
+          class="advanced-form-item"
+        >
+          <template #label>
+            <NSpace align="center" :size="8" style="width: 100%;">
+              <span>{{ entry.key }}</span>
+              <NTag type="info" size="small">
+                {{ t('modelManager.advancedParameters.customParam') }}
+              </NTag>
+              <NButton size="tiny" type="error" quaternary circle @click="handleRemove(entry.key)">
+                ×
+              </NButton>
+            </NSpace>
+          </template>
+          <NInput
+            type="textarea"
+            size="small"
+            :autosize="{ minRows: 1, maxRows: 3 }"
+            :value="String(paramOverrides[entry.key] ?? '')"
+            data-test="custom-param-input"
+            class="advanced-control"
+            @update:value="value => handleCustomValueChange(entry.key, value)"
+          />
+        </NFormItem>
+```
+
+替换为：
+
+```vue
+        <!-- 自定义参数（schema中不存在） -->
+        <NFormItem
+          v-for="entry in customEntries"
+          :key="`custom-${entry.key}`"
+          class="advanced-form-item"
+        >
+          <template #label>
+            <NSpace align="center" :size="8" style="width: 100%;">
+              <span>{{ entry.key }}</span>
+              <NTag type="info" size="small">
+                {{ t('modelManager.advancedParameters.customParam') }}
+              </NTag>
+              <NButton size="tiny" type="error" quaternary circle @click="handleRemove(entry.key)">
+                ×
+              </NButton>
+            </NSpace>
+          </template>
+          <NSpace vertical :size="4" style="width: 100%; max-width: 320px;">
+            <NSpace :size="4">
+              <NButton
+                size="tiny"
+                :type="(customParamFormats[entry.key] ?? 'string') === 'json' ? 'primary' : 'default'"
+                @click="handleCustomFormatToggle(entry.key, 'json')"
+              >
+                {{ t('modelManager.advancedParameters.formatJson') }}
+              </NButton>
+              <NButton
+                size="tiny"
+                :type="(customParamFormats[entry.key] ?? 'string') === 'string' ? 'primary' : 'default'"
+                @click="handleCustomFormatToggle(entry.key, 'string')"
+              >
+                {{ t('modelManager.advancedParameters.formatString') }}
+              </NButton>
+            </NSpace>
+            <NInput
+              type="textarea"
+              size="small"
+              :autosize="{ minRows: 1, maxRows: 6 }"
+              :value="getCustomDisplayValue(entry.key)"
+              data-test="custom-param-input"
+              class="advanced-control"
+              @update:value="value => handleCustomValueChange(entry.key, value)"
+            />
+            <NText
+              v-if="(customParamFormats[entry.key] ?? 'string') === 'json'"
+              :depth="paramOverrides[entry.key] !== null && typeof paramOverrides[entry.key] === 'object' ? 3 : undefined"
+              :style="{
+                fontSize: '12px',
+                color: paramOverrides[entry.key] !== null && typeof paramOverrides[entry.key] === 'object'
+                  ? undefined
+                  : 'var(--n-color-error, #d03050)'
+              }"
+            >
+              {{
+                paramOverrides[entry.key] !== null && typeof paramOverrides[entry.key] === 'object'
+                  ? t('modelManager.advancedParameters.parsedAsObject')
+                  : t('modelManager.advancedParameters.invalidJson')
+              }}
+            </NText>
+          </NSpace>
+        </NFormItem>
+```
+
+- [ ] **Step 6: 替换 image 模式自定义参数的 `<NFormItem>` 模板块**
+
+在 template 中找到 image 模式的自定义参数块（约第 228-251 行）：
+
+```vue
+        <!-- 自定义参数（schema中不存在） -->
+        <NFormItem
+          v-for="entry in customEntries"
+          :key="`custom-${entry.key}`"
+          class="advanced-form-item"
+        >
+          <template #label>
+            <NSpace align="center" :size="8" style="width: 100%;">
+              <span>{{ entry.key }}</span>
+              <NTag type="info" size="small">
+                {{ t('modelManager.advancedParameters.customParam') }}
+              </NTag>
+              <NButton size="tiny" type="error" quaternary circle @click="handleRemove(entry.key)">
+                ×
+              </NButton>
+            </NSpace>
+          </template>
+          <NInput
+            size="small"
+            :value="String(paramOverrides[entry.key] ?? '')"
+            data-test="custom-param-input"
+            class="advanced-control"
+            @update:value="value => handleCustomValueChange(entry.key, value)"
+          />
+        </NFormItem>
+```
+
+替换为（与 text 模式完全相同的新模板）：
+
+```vue
+        <!-- 自定义参数（schema中不存在） -->
+        <NFormItem
+          v-for="entry in customEntries"
+          :key="`custom-${entry.key}`"
+          class="advanced-form-item"
+        >
+          <template #label>
+            <NSpace align="center" :size="8" style="width: 100%;">
+              <span>{{ entry.key }}</span>
+              <NTag type="info" size="small">
+                {{ t('modelManager.advancedParameters.customParam') }}
+              </NTag>
+              <NButton size="tiny" type="error" quaternary circle @click="handleRemove(entry.key)">
+                ×
+              </NButton>
+            </NSpace>
+          </template>
+          <NSpace vertical :size="4" style="width: 100%; max-width: 320px;">
+            <NSpace :size="4">
+              <NButton
+                size="tiny"
+                :type="(customParamFormats[entry.key] ?? 'string') === 'json' ? 'primary' : 'default'"
+                @click="handleCustomFormatToggle(entry.key, 'json')"
+              >
+                {{ t('modelManager.advancedParameters.formatJson') }}
+              </NButton>
+              <NButton
+                size="tiny"
+                :type="(customParamFormats[entry.key] ?? 'string') === 'string' ? 'primary' : 'default'"
+                @click="handleCustomFormatToggle(entry.key, 'string')"
+              >
+                {{ t('modelManager.advancedParameters.formatString') }}
+              </NButton>
+            </NSpace>
+            <NInput
+              type="textarea"
+              size="small"
+              :autosize="{ minRows: 1, maxRows: 6 }"
+              :value="getCustomDisplayValue(entry.key)"
+              data-test="custom-param-input"
+              class="advanced-control"
+              @update:value="value => handleCustomValueChange(entry.key, value)"
+            />
+            <NText
+              v-if="(customParamFormats[entry.key] ?? 'string') === 'json'"
+              :depth="paramOverrides[entry.key] !== null && typeof paramOverrides[entry.key] === 'object' ? 3 : undefined"
+              :style="{
+                fontSize: '12px',
+                color: paramOverrides[entry.key] !== null && typeof paramOverrides[entry.key] === 'object'
+                  ? undefined
+                  : 'var(--n-color-error, #d03050)'
+              }"
+            >
+              {{
+                paramOverrides[entry.key] !== null && typeof paramOverrides[entry.key] === 'object'
+                  ? t('modelManager.advancedParameters.parsedAsObject')
+                  : t('modelManager.advancedParameters.invalidJson')
+              }}
+            </NText>
+          </NSpace>
+        </NFormItem>
+```
+
+- [ ] **Step 7: 运行 core 单元测试确认无回归**
+
+```bash
+cd packages/core && npx vitest run
+```
+
+期望输出：所有测试 PASS。
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/ui/src/components/ModelParameterEditor.vue
+git commit -m "feat(ui): add JSON/string format toggle for custom parameters"
+```
+
+---
+
+## 验收标准
+
+1. 在模型编辑界面添加自定义参数 `chat_template_kwargs`，输入 `{"enable_thinking": False}`，点击 JSON 按钮 → 提示"已解析为 Object ✓"，测试连接不再报 400
+2. 点击字符串按钮 → 值转为字符串存储，提示消失
+3. 在字符串模式下输入任意内容 → 作为 string 发送，不自动解析
+4. 现有内置参数（temperature 等）行为不变
+5. `npx vitest run`（core 包）全部通过

--- a/docs/superpowers/specs/2026-05-13-custom-param-format-toggle-design.md
+++ b/docs/superpowers/specs/2026-05-13-custom-param-format-toggle-design.md
@@ -1,0 +1,130 @@
+# 自定义参数 JSON/字符串格式切换设计
+
+**日期：** 2026-05-13  
+**状态：** 已批准
+
+## 背景
+
+用户在模型管理中为自定义参数输入 Python 风格的 JSON（如 `{"enable_thinking": False}`）时，vLLM 等 API 返回 400 错误，原因是该值被作为字符串发送，而 API 期望收到一个字典对象。
+
+根本原因：`parseCustomValue()` 在尝试 `JSON.parse` 时，Python 风格的 `False`/`True`/`None` 不是合法 JSON，解析失败后回退为字符串存储。
+
+## 目标
+
+- 修复 Python 风格 JSON 解析失败导致的 API 400 错误
+- 为自定义参数提供明确的 JSON / 字符串格式切换，让用户清楚知道值以何种类型发送
+- 零新存储字段，向后完全兼容
+
+## 不在范围内
+
+- Schema 中已定义的内置参数（无需 toggle）
+- 图像模型参数
+- 新的数据库迁移或存储格式变更
+
+---
+
+## 方案设计
+
+### 原则
+
+奥卡姆剃刀：最小改动达成目标。Toggle 状态从存储值类型推导，无需额外字段。
+
+### 改动文件（共 2 个）
+
+---
+
+### 1. `packages/core/src/services/model/parameter-utils.ts`
+
+#### 新增辅助函数
+
+```typescript
+function normalizePythonLiterals(input: string): string {
+  return input
+    .replace(/\bTrue\b/g, 'true')
+    .replace(/\bFalse\b/g, 'false')
+    .replace(/\bNone\b/g, 'null')
+}
+```
+
+#### 修改 `parseCustomValue` 中 `{`/`[` 开头的逻辑
+
+**修改前（只有一次 JSON.parse）：**
+```typescript
+if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+  try { return JSON.parse(trimmed) } catch {}
+}
+```
+
+**修改后（失败后 normalize 再重试）：**
+```typescript
+if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+  try { return JSON.parse(trimmed) } catch {}
+  try { return JSON.parse(normalizePythonLiterals(trimmed)) } catch {}
+}
+```
+
+---
+
+### 2. `packages/ui/src/components/ModelParameterEditor.vue`
+
+#### Toggle 状态推导
+
+不新增 prop，toggle 状态从存储值类型计算得出：
+
+```typescript
+function isJsonMode(value: unknown): boolean {
+  return value !== null && typeof value === 'object'
+}
+```
+
+#### UI 结构（每个自定义参数行）
+
+```
+[参数名 tag]               [JSON] [字符串]
+┌────────────────────────────────────────┐
+│ textarea 内容                          │
+└────────────────────────────────────────┘
+  状态提示：已解析为 Object ✓ / 无效 JSON ✗ / 字符串
+```
+
+#### 切换逻辑
+
+- **切换到 JSON**：对当前 textarea 内容调用 `parseCustomValue()`（已含 Python 规范化），若结果为 object/array 则存储该值，否则显示"无效 JSON"错误提示
+- **切换到字符串**：将存储值转为 `JSON.stringify(value)` 或直接存为字符串，不再解析
+- **用户修改 textarea 内容时**：按当前 toggle 状态决定如何处理（JSON 模式调用 `parseCustomValue`；字符串模式直接存为 string）
+
+#### `getDisplayValue` 补充 object 分支
+
+```typescript
+// 已有 string-array、boolean、number 分支，补充：
+if (value !== null && typeof value === 'object') {
+  return JSON.stringify(value, null, 2)
+}
+```
+
+---
+
+## 数据流
+
+```
+用户输入 textarea
+    ↓
+按当前 toggle 状态处理
+  JSON 模式  → parseCustomValue() → 含 Python 规范化 → 存为 object
+  String 模式 → 直接存为 string
+    ↓
+paramOverrides: Record<string, unknown>
+    ↓
+API 请求时 spread 展开 → 正确类型发送
+```
+
+## 向后兼容性
+
+- 现有配置无需迁移：object 类型值自动显示为 JSON 模式，其他类型显示为字符串模式
+- `parseCustomValue` 的现有自动推断行为保持不变，仅对 `{`/`[` 开头的字符串增加了一次重试
+
+## 成功标准
+
+- `{"enable_thinking": False}` 输入后自动解析为 `{"enable_thinking": false}` object，测试连接不再报 400
+- Toggle 切换到字符串模式时，值以原始字符串发送
+- 无现有测试回归

--- a/packages/core/src/services/model/parameter-utils.ts
+++ b/packages/core/src/services/model/parameter-utils.ts
@@ -5,6 +5,13 @@ import {
   isValueEmpty
 } from './parameter-schema'
 
+function normalizePythonLiterals(input: string): string {
+  return input
+    .replace(/\bTrue\b/g, 'true')
+    .replace(/\bFalse\b/g, 'false')
+    .replace(/\bNone\b/g, 'null')
+}
+
 /**
  * 智能解析自定义参数值，自动推断类型
  * - true/false -> boolean
@@ -41,6 +48,11 @@ export function parseCustomValue(value: string): unknown {
       (trimmed.startsWith('[') && trimmed.endsWith(']'))) {
     try {
       return JSON.parse(trimmed)
+    } catch {
+      // 尝试规范化 Python 风格字面量后重试
+    }
+    try {
+      return JSON.parse(normalizePythonLiterals(trimmed))
     } catch {
       // 解析失败，作为字符串处理
     }

--- a/packages/core/tests/unit/parameter-utils.test.ts
+++ b/packages/core/tests/unit/parameter-utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   mergeOverrides,
+  parseCustomValue,
   splitOverridesBySchema,
   validateOverrides
 } from '../../src/services/model/parameter-utils'
@@ -85,5 +86,43 @@ describe('parameter-utils', () => {
     })
     expect(errors.length).toBe(1)
     expect(errors[0].parameterName).toBe('apiKey')
+  })
+
+  describe('parseCustomValue', () => {
+    it('parses standard JSON object', () => {
+      expect(parseCustomValue('{"key": "value"}')).toEqual({ key: 'value' })
+    })
+
+    it('parses Python-style False/True/None in JSON object', () => {
+      expect(parseCustomValue('{"enable_thinking": False}')).toEqual({ enable_thinking: false })
+      expect(parseCustomValue('{"flag": True}')).toEqual({ flag: true })
+      expect(parseCustomValue('{"val": None}')).toEqual({ val: null })
+    })
+
+    it('parses mixed Python/JSON literals', () => {
+      expect(parseCustomValue('{"a": True, "b": False, "c": None}')).toEqual({
+        a: true, b: false, c: null
+      })
+    })
+
+    it('returns string when content is not valid JSON even after normalization', () => {
+      expect(parseCustomValue('{broken')).toBe('{broken')
+    })
+
+    it('parses JSON array', () => {
+      expect(parseCustomValue('[1, 2, 3]')).toEqual([1, 2, 3])
+    })
+
+    it('parses booleans, null, integers, floats', () => {
+      expect(parseCustomValue('true')).toBe(true)
+      expect(parseCustomValue('false')).toBe(false)
+      expect(parseCustomValue('null')).toBe(null)
+      expect(parseCustomValue('42')).toBe(42)
+      expect(parseCustomValue('3.14')).toBe(3.14)
+    })
+
+    it('returns plain string for non-special input', () => {
+      expect(parseCustomValue('hello world')).toBe('hello world')
+    })
   })
 })

--- a/packages/ui/src/components/ModelParameterEditor.vue
+++ b/packages/ui/src/components/ModelParameterEditor.vue
@@ -458,6 +458,7 @@ const handleValueChange = (definition: UnifiedParameterDefinition, rawValue: unk
 const handleRemove = (key: string) => {
   const next = { ...props.paramOverrides }
   delete next[key]
+  delete customParamFormats.value[key]
   emit('update:paramOverrides', next)
 }
 
@@ -489,7 +490,7 @@ const handleCustomFormatToggle = (key: string, format: 'json' | 'string') => {
   if (format === 'json') {
     const currentText = getCustomDisplayValue(key)
     const parsed = parseCustomValue(currentText)
-    if (parsed !== null && typeof parsed === 'object') {
+    if (parsed !== currentText) {
       customParamFormats.value[key] = 'json'
       const next = { ...props.paramOverrides, [key]: parsed }
       emit('update:paramOverrides', next)

--- a/packages/ui/src/components/ModelParameterEditor.vue
+++ b/packages/ui/src/components/ModelParameterEditor.vue
@@ -119,15 +119,49 @@
               </NButton>
             </NSpace>
           </template>
-          <NInput
-            type="textarea"
-            size="small"
-            :autosize="{ minRows: 1, maxRows: 3 }"
-            :value="String(paramOverrides[entry.key] ?? '')"
-            data-test="custom-param-input"
-            class="advanced-control"
-            @update:value="value => handleCustomValueChange(entry.key, value)"
-          />
+          <NSpace vertical :size="4" style="width: 100%; max-width: 320px;">
+            <NSpace :size="4">
+              <NButton
+                size="tiny"
+                :type="(customParamFormats[entry.key] ?? 'string') === 'json' ? 'primary' : 'default'"
+                @click="handleCustomFormatToggle(entry.key, 'json')"
+              >
+                {{ t('modelManager.advancedParameters.formatJson') }}
+              </NButton>
+              <NButton
+                size="tiny"
+                :type="(customParamFormats[entry.key] ?? 'string') === 'string' ? 'primary' : 'default'"
+                @click="handleCustomFormatToggle(entry.key, 'string')"
+              >
+                {{ t('modelManager.advancedParameters.formatString') }}
+              </NButton>
+            </NSpace>
+            <NInput
+              type="textarea"
+              size="small"
+              :autosize="{ minRows: 1, maxRows: 6 }"
+              :value="getCustomDisplayValue(entry.key)"
+              data-test="custom-param-input"
+              class="advanced-control"
+              @update:value="value => handleCustomValueChange(entry.key, value)"
+            />
+            <NText
+              v-if="(customParamFormats[entry.key] ?? 'string') === 'json'"
+              :depth="paramOverrides[entry.key] !== null && typeof paramOverrides[entry.key] === 'object' ? 3 : undefined"
+              :style="{
+                fontSize: '12px',
+                color: paramOverrides[entry.key] !== null && typeof paramOverrides[entry.key] === 'object'
+                  ? undefined
+                  : 'var(--n-color-error, #d03050)'
+              }"
+            >
+              {{
+                paramOverrides[entry.key] !== null && typeof paramOverrides[entry.key] === 'object'
+                  ? t('modelManager.advancedParameters.parsedAsObject')
+                  : t('modelManager.advancedParameters.invalidJson')
+              }}
+            </NText>
+          </NSpace>
         </NFormItem>
       </NForm>
     </template>
@@ -241,13 +275,49 @@
               </NButton>
             </NSpace>
           </template>
-          <NInput
-            size="small"
-            :value="String(paramOverrides[entry.key] ?? '')"
-            data-test="custom-param-input"
-            class="advanced-control"
-            @update:value="value => handleCustomValueChange(entry.key, value)"
-          />
+          <NSpace vertical :size="4" style="width: 100%; max-width: 320px;">
+            <NSpace :size="4">
+              <NButton
+                size="tiny"
+                :type="(customParamFormats[entry.key] ?? 'string') === 'json' ? 'primary' : 'default'"
+                @click="handleCustomFormatToggle(entry.key, 'json')"
+              >
+                {{ t('modelManager.advancedParameters.formatJson') }}
+              </NButton>
+              <NButton
+                size="tiny"
+                :type="(customParamFormats[entry.key] ?? 'string') === 'string' ? 'primary' : 'default'"
+                @click="handleCustomFormatToggle(entry.key, 'string')"
+              >
+                {{ t('modelManager.advancedParameters.formatString') }}
+              </NButton>
+            </NSpace>
+            <NInput
+              type="textarea"
+              size="small"
+              :autosize="{ minRows: 1, maxRows: 6 }"
+              :value="getCustomDisplayValue(entry.key)"
+              data-test="custom-param-input"
+              class="advanced-control"
+              @update:value="value => handleCustomValueChange(entry.key, value)"
+            />
+            <NText
+              v-if="(customParamFormats[entry.key] ?? 'string') === 'json'"
+              :depth="paramOverrides[entry.key] !== null && typeof paramOverrides[entry.key] === 'object' ? 3 : undefined"
+              :style="{
+                fontSize: '12px',
+                color: paramOverrides[entry.key] !== null && typeof paramOverrides[entry.key] === 'object'
+                  ? undefined
+                  : 'var(--n-color-error, #d03050)'
+              }"
+            >
+              {{
+                paramOverrides[entry.key] !== null && typeof paramOverrides[entry.key] === 'object'
+                  ? t('modelManager.advancedParameters.parsedAsObject')
+                  : t('modelManager.advancedParameters.invalidJson')
+              }}
+            </NText>
+          </NSpace>
         </NFormItem>
       </NForm>
     </template>
@@ -255,7 +325,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, type PropType } from 'vue'
+import { computed, ref, watch, type PropType } from 'vue'
 
 import { useI18n } from 'vue-i18n'
 import { useMessage, createDiscreteApi, NAlert, NButton, NCheckbox, NForm, NFormItem, NInput, NInputNumber, NSelect, NSpace, NTag, NText } from 'naive-ui'
@@ -294,6 +364,21 @@ const schemaMap = computed(() => {
   }
   return map
 })
+
+const customParamFormats = ref<Record<string, 'json' | 'string'>>({})
+
+watch(
+  () => props.paramOverrides,
+  (overrides) => {
+    for (const key of Object.keys(overrides)) {
+      if (!schemaMap.value.has(key) && !(key in customParamFormats.value)) {
+        const val = overrides[key]
+        customParamFormats.value[key] = (val !== null && typeof val === 'object') ? 'json' : 'string'
+      }
+    }
+  },
+  { immediate: true }
+)
 
 // 区分已定义参数和自定义参数
 const definedEntries = computed(() => {
@@ -382,15 +467,51 @@ const handleCustomValueChange = (key: string, value: string) => {
   if (trimmed === '') {
     delete next[key]
   } else {
-    next[key] = parseCustomValue(trimmed)
+    const format = customParamFormats.value[key] ?? 'string'
+    if (format === 'json') {
+      next[key] = parseCustomValue(trimmed)
+    } else {
+      next[key] = trimmed
+    }
   }
   emit('update:paramOverrides', next)
+}
+
+const getCustomDisplayValue = (key: string): string => {
+  const val = props.paramOverrides[key]
+  if (val !== null && typeof val === 'object') {
+    return JSON.stringify(val, null, 2)
+  }
+  return val === undefined ? '' : String(val)
+}
+
+const handleCustomFormatToggle = (key: string, format: 'json' | 'string') => {
+  if (format === 'json') {
+    const currentText = getCustomDisplayValue(key)
+    const parsed = parseCustomValue(currentText)
+    if (parsed !== null && typeof parsed === 'object') {
+      customParamFormats.value[key] = 'json'
+      const next = { ...props.paramOverrides, [key]: parsed }
+      emit('update:paramOverrides', next)
+    } else {
+      message.error(t('modelManager.advancedParameters.invalidJson'))
+    }
+  } else {
+    customParamFormats.value[key] = 'string'
+    const next = { ...props.paramOverrides }
+    const val = next[key]
+    if (val !== null && typeof val === 'object') {
+      next[key] = JSON.stringify(val)
+    }
+    emit('update:paramOverrides', next)
+  }
 }
 
 defineExpose({
   handleAddDefinition,
   handleValueChange,
-  handleCustomValueChange
+  handleCustomValueChange,
+  handleCustomFormatToggle
 })
 
 function normalizeValue(definition: UnifiedParameterDefinition, rawValue: unknown): unknown {

--- a/packages/ui/src/i18n/locales/en-US/models.ts
+++ b/packages/ui/src/i18n/locales/en-US/models.ts
@@ -68,7 +68,11 @@ const messages = {
         "belowMin": "Value cannot be less than {min}",
         "aboveMax": "Value cannot be greater than {max}",
         "mustBeInteger": "Must be an integer"
-      }
+      },
+      "formatJson": "JSON",
+      "formatString": "String",
+      "parsedAsObject": "Parsed as Object ✓",
+      "invalidJson": "Invalid JSON, will be sent as string"
     },
     "modelKeyPlaceholder": "Enter model key",
     "displayNamePlaceholder": "Enter display name",

--- a/packages/ui/src/i18n/locales/zh-CN/models.ts
+++ b/packages/ui/src/i18n/locales/zh-CN/models.ts
@@ -69,7 +69,11 @@ const messages = {
         "belowMin": "参数值不能小于 {min}",
         "aboveMax": "参数值不能大于 {max}",
         "mustBeInteger": "参数值必须是整数"
-      }
+      },
+      "formatJson": "JSON",
+      "formatString": "字符串",
+      "parsedAsObject": "已解析为 Object ✓",
+      "invalidJson": "无效 JSON，将作为字符串发送"
     },
     "modelKeyPlaceholder": "请输入模型标识",
     "displayNamePlaceholder": "请输入显示名称",

--- a/packages/ui/src/i18n/locales/zh-TW/models.ts
+++ b/packages/ui/src/i18n/locales/zh-TW/models.ts
@@ -68,7 +68,11 @@ const messages = {
         "belowMin": "參數值不能小於 {min}",
         "aboveMax": "參數值不能大於 {max}",
         "mustBeInteger": "參數值必須是整數"
-      }
+      },
+      "formatJson": "JSON",
+      "formatString": "字串",
+      "parsedAsObject": "已解析為 Object ✓",
+      "invalidJson": "無效 JSON，將作為字串發送"
     },
     "modelKeyPlaceholder": "請輸入模型標識",
     "displayNamePlaceholder": "請輸入顯示名稱",


### PR DESCRIPTION
## 问题背景

使用 vLLM 部署的 Qwen3 等模型时，需要通过自定义参数 `chat_template_kwargs` 传入 `{"enable_thinking": false}` 来关闭模型的思考模式（thinking mode）。

但在模型管理界面中输入该参数值后，测试连接报 400 错误：

\`\`\`
Connection test failed: 400 1 validation error:
{'type': 'dict_type', 'loc': ('body', 'chat_template_kwargs'),
 'msg': 'Input should be a valid dictionary',
 'input': '{"enable_thinking": False}'}
\`\`\`

**根本原因：** 用户从 Python 文档/示例复制的值为 `{"enable_thinking": False}`（Python 布尔值大写），而 `JSON.parse` 只接受小写 `false`。解析失败后值回退为字符串存储，API 收到字符串而非字典对象，故报 `dict_type` 验证错误。

---

## 修复内容

### 1. 核心层修复（`packages/core`）

`parseCustomValue()` 新增 Python→JSON 字面量规范化重试：

- 第一次：标准 `JSON.parse`（快路径）
- 失败后：将 `True`→`true`、`False`→`false`、`None`→`null` 规范化后再次解析

\`\`\`
{"enable_thinking": False}  →  { enable_thinking: false }  ✓（object，不再是字符串）
\`\`\`

### 2. UI 层增强（`packages/ui`）

为自定义参数新增 **JSON / 字符串** 格式切换开关，让用户明确控制参数类型：

- **JSON 模式**：值以 object 类型发送，实时显示「已解析为 Object ✓」或「无效 JSON」提示
- **字符串模式**：值以原始字符串发送
- Toggle 初始状态从存储值类型自动推导，删除参数时同步清理，无状态泄漏

### 3. i18n

新增 `formatJson`、`formatString`、`parsedAsObject`、`invalidJson` 四个 key，覆盖 zh-CN / zh-TW / en-US。

---

## 验证结果

- 输入 `{"enable_thinking": False}` → 切换 JSON 模式 → 解析为 object → 测试连接不再报 400
- `{"enable_thinking": true}` 同理可用，支持开启/关闭思考模式
- 832 个单元测试全部通过，0 回归
- 向后兼容：现有配置无需迁移