### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/packages/core/src/services/llm/adapters/minimax-adapter.ts
+++ b/packages/core/src/services/llm/adapters/minimax-adapter.ts
@@ -11,9 +11,19 @@ interface ModelOverride {
 
 const MINIMAX_STATIC_MODELS: ModelOverride[] = [
   {
+    id: 'MiniMax-M3',
+    name: 'MiniMax M3',
+    description: 'Latest flagship model with enhanced reasoning and coding',
+    capabilities: {
+      supportsTools: true,
+      supportsReasoning: false,
+      maxContextLength: 1000000
+    }
+  },
+  {
     id: 'MiniMax-M2.7',
     name: 'MiniMax M2.7',
-    description: 'Latest flagship model with enhanced reasoning and coding',
+    description: 'Previous flagship model retained for compatibility',
     capabilities: {
       supportsTools: true,
       supportsReasoning: false,
@@ -24,26 +34,6 @@ const MINIMAX_STATIC_MODELS: ModelOverride[] = [
     id: 'MiniMax-M2.7-highspeed',
     name: 'MiniMax M2.7 HighSpeed',
     description: 'High-speed version of M2.7 for low-latency scenarios',
-    capabilities: {
-      supportsTools: true,
-      supportsReasoning: false,
-      maxContextLength: 1000000
-    }
-  },
-  {
-    id: 'MiniMax-M2.5',
-    name: 'MiniMax M2.5',
-    description: 'MiniMax flagship model with advanced capabilities',
-    capabilities: {
-      supportsTools: true,
-      supportsReasoning: false,
-      maxContextLength: 1000000
-    }
-  },
-  {
-    id: 'MiniMax-M2.5-highspeed',
-    name: 'MiniMax M2.5 HighSpeed',
-    description: 'MiniMax high-speed model optimized for fast inference',
     capabilities: {
       supportsTools: true,
       supportsReasoning: false,

--- a/packages/core/tests/unit/llm/minimax-adapter.test.ts
+++ b/packages/core/tests/unit/llm/minimax-adapter.test.ts
@@ -40,8 +40,8 @@ describe('MinimaxAdapter', () => {
       }
     },
     modelMeta: {
-      id: 'MiniMax-M2.7',
-      name: 'MiniMax M2.7',
+      id: 'MiniMax-M3',
+      name: 'MiniMax M3',
       description: 'Latest flagship model with enhanced reasoning and coding',
       providerId: 'minimax',
       capabilities: {
@@ -119,29 +119,30 @@ describe('MinimaxAdapter', () => {
       expect(Array.isArray(models)).toBe(true);
       expect(models.length).toBeGreaterThan(0);
 
-      const m27 = models.find(m => m.id === 'MiniMax-M2.7');
-      expect(m27).toBeDefined();
-      expect(m27?.name).toBe('MiniMax M2.7');
-      expect(m27?.providerId).toBe('minimax');
-      expect(m27?.capabilities.supportsTools).toBe(true);
+      const m3 = models.find(m => m.id === 'MiniMax-M3');
+      expect(m3).toBeDefined();
+      expect(m3?.name).toBe('MiniMax M3');
+      expect(m3?.providerId).toBe('minimax');
+      expect(m3?.capabilities.supportsTools).toBe(true);
     });
 
     it('should include all expected models', () => {
       const models = adapter.getModels();
       const modelIds = models.map(m => m.id);
 
+      expect(modelIds).toContain('MiniMax-M3');
       expect(modelIds).toContain('MiniMax-M2.7');
       expect(modelIds).toContain('MiniMax-M2.7-highspeed');
-      expect(modelIds).toContain('MiniMax-M2.5');
-      expect(modelIds).toContain('MiniMax-M2.5-highspeed');
-      expect(models.length).toBe(4);
+      expect(modelIds).not.toContain('MiniMax-M2.5');
+      expect(modelIds).not.toContain('MiniMax-M2.5-highspeed');
+      expect(models.length).toBe(3);
     });
 
-    it('should have M2.7 as the first model', () => {
+    it('should have M3 as the first model', () => {
       const models = adapter.getModels();
 
-      expect(models[0].id).toBe('MiniMax-M2.7');
-      expect(models[1].id).toBe('MiniMax-M2.7-highspeed');
+      expect(models[0].id).toBe('MiniMax-M3');
+      expect(models[1].id).toBe('MiniMax-M2.7');
     });
 
     it('should have capabilities for each model', () => {
@@ -172,7 +173,7 @@ describe('MinimaxAdapter', () => {
         id: 'chatcmpl-minimax-123',
         object: 'chat.completion',
         created: Date.now(),
-        model: 'MiniMax-M2.7',
+        model: 'MiniMax-M3',
         choices: [{
           index: 0,
           message: {
@@ -194,7 +195,7 @@ describe('MinimaxAdapter', () => {
 
       expect(response.content).toBe('Hello from MiniMax!');
       expect(response.metadata).toEqual({
-        model: 'MiniMax-M2.7',
+        model: 'MiniMax-M3',
         finishReason: 'stop'
       });
     });


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration to include the latest M3 model as the new default.

## Changes
- Add `MiniMax-M3` to the model selection list
- Set `MiniMax-M3` as the new default model
- Retain `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as available alternatives
- Remove deprecated older versions (`MiniMax-M2.5` / `MiniMax-M2.5-highspeed`) from the list
- Update related unit tests

## Why
MiniMax-M3 is the new flagship model with enhanced reasoning and coding capability.

## Testing
- Unit tests updated and passing (`pnpm -F @prompt-optimizer/core test:unit`, minimax-adapter + registry: 32 passed)
- TypeScript typecheck passing (`pnpm typecheck:core`)