### PR TITLE
fix(docker): launch mcp-server via node directly to avoid pnpm verify-deps crash

### DIFF
--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -14,7 +14,7 @@ stdout_logfile=/var/log/supervisor/nginx.out.log
 priority=100
 
 [program:mcp-server]
-command=pnpm start --port=3000
+command=node -r ./preload-env.cjs dist/start.cjs --transport=http --port=3000
 directory=/app/mcp-server
 autostart=true
 autorestart=false


### PR DESCRIPTION
## Problem

The Docker image's `mcp-server` process crashes on boot and never serves `/mcp` (only nginx survives). Reported in #314. Reproduces on `latest`, `2.11.x`, **and a fresh build from `develop`**:

```
[ERR_PNPM_WORKSPACE_PKG_NOT_FOUND] @prompt-optimizer/core@workspace:* is in
the dependencies but no package named @prompt-optimizer/core is present in the workspace
...
mcp-server entered FATAL state, too many start retries too quickly
```

## Root cause

`docker/supervisord.conf` launches the server via `pnpm start`. pnpm 10 runs a dependency-sync check (`runDepsStatusCheck`) **before** executing the script. The production stage copies only `/app/mcp-server` as an isolated package, so pnpm tries to resolve `@prompt-optimizer/core@workspace:*`, can't find the workspace sibling, and aborts before `node` ever runs.

The built artifact is self-contained (deps bundled, `NODE_PATH=/app`) — running `node dist/start.cjs` directly works fine. It's purely pnpm's pre-run guard that kills it.

## Fix

Launch node directly instead of through `pnpm start`, mirroring the existing `start` script:

```diff
-command=pnpm start --port=3000
+command=node -r ./preload-env.cjs dist/start.cjs --transport=http --port=3000
```

## Verification

Fresh build from this branch:

```
mcp:info MCP Server running on HTTP port 3000 with session management
INFO success: mcp-server entered RUNNING state
```

`POST /mcp` `initialize` returns a valid handshake and `tools/list` exposes `optimize-user-prompt`, `optimize-system-prompt`, `iterate-prompt`. Connected successfully from an MCP client (Claude Code).

Fixes #314