### PR TITLE
fix: invalid CSS border value, broken class attribute, passive scroll listener

### DIFF
--- a/packages/ui/src/components/FavoriteButton.vue
+++ b/packages/ui/src/components/FavoriteButton.vue
@@ -119,13 +119,10 @@ interface Props {
   originalContent?: string;
   /** 按钮大小 */
   size?: 'tiny' | 'small' | 'medium' | 'large';
-  /** 是否显示加载状态 */
-  loading?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
   size: 'medium',
-  loading: false
 });
 
 const emit = defineEmits<{

--- a/packages/ui/src/components/MarkdownRenderer.vue
+++ b/packages/ui/src/components/MarkdownRenderer.vue
@@ -536,7 +536,7 @@ onMounted(renderMarkdown);
 /* 水平线样式 */
 .markdown-content hr {
     height: 0.25em;
-    border: 1;
+    border: none;
     margin: 1em 0;
 }
 

--- a/packages/ui/src/components/OutputDisplayCore.vue
+++ b/packages/ui/src/components/OutputDisplayCore.vue
@@ -1,7 +1,7 @@
 <template>
   <NCard
     :bordered="false"
-    class="output-display-core h-full  max-height: 100% "
+    class="output-display-core h-full"
     content-style="padding: 0; height: 100%; max-height: 100%; display: flex; flex-direction: column; overflow: hidden;"
     :data-testid="testId"
   >

--- a/packages/ui/src/composables/performance/useLazyLoad.ts
+++ b/packages/ui/src/composables/performance/useLazyLoad.ts
@@ -1,4 +1,4 @@
-import { ref, onMounted, onUnmounted } from 'vue'
+import { ref, onUnmounted } from 'vue'
 
 interface LazyLoadOptions {
   root?: Element | null

--- a/packages/ui/src/composables/ui/useAutoScroll.ts
+++ b/packages/ui/src/composables/ui/useAutoScroll.ts
@@ -130,7 +130,7 @@ export function useAutoScroll<T extends HTMLElement>(options: {
     // 添加和移除滚动事件监听器
     onMounted(() => {
         if (elementRef.value) {
-            elementRef.value.addEventListener('scroll', handleScroll)
+            elementRef.value.addEventListener('scroll', handleScroll, { passive: true })
         }
     })
 
@@ -140,7 +140,7 @@ export function useAutoScroll<T extends HTMLElement>(options: {
             oldEl.removeEventListener('scroll', handleScroll)
         }
         if (newEl) {
-            newEl.addEventListener('scroll', handleScroll)
+            newEl.addEventListener('scroll', handleScroll, { passive: true })
         }
     })
 


### PR DESCRIPTION
Spotted a few issues in the UI package:

- the \`<hr>\` element in MarkdownRenderer had \`border: 1;\` which is invalid CSS — browsers just ignore it so the default border shows through. changed to \`border: none;\`
- OutputDisplayCore had \`max-height: 100%\` sitting inside the \`class\` attribute instead of a style — it's not a valid class name and does nothing there
- the scroll event listener in useAutoScroll was missing \`{ passive: true }\`, which blocks browser scroll optimizations
- removed an unused \`onMounted\` import from useLazyLoad
- FavoriteButton had a \`loading\` prop that was being shadowed by a local ref of the same name — the prop was dead code