### PR TITLE
fix(web):OpenAI Compatible (Custom) 浏览器使用第三方api跨域问题修复

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -60,6 +60,21 @@ server {
         }
     }
 
+    location /api/openai-compatible-proxy {
+        auth_basic off;
+
+        gzip off;
+
+        proxy_pass http://localhost:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 300s;
+        proxy_connect_timeout 75s;
+    }
+
     location = /healthz {
         auth_basic off;
 

--- a/packages/core/src/services/llm/adapters/openai-adapter.ts
+++ b/packages/core/src/services/llm/adapters/openai-adapter.ts
@@ -2,6 +2,11 @@ import OpenAI from 'openai'
 import { AbstractTextProviderAdapter } from './abstract-adapter'
 import { APIError } from '../errors'
 import { normalizeCustomRequestHeaders } from '../../../utils/custom-request-headers'
+
+const OPENAI_COMPATIBLE_PROXY_PATH = '/api/openai-compatible-proxy'
+const OPENAI_PROXY_BASE_URL_HEADER = 'x-po-target-base-url'
+const OPENAI_PROXY_REQUEST_STYLE_HEADER = 'x-po-request-style'
+const OPENAI_PROXY_CUSTOM_HEADERS_HEADER = 'x-po-custom-headers'
 import type {
   TextProvider,
   TextModel,
@@ -732,16 +737,54 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
     return sanitized
   }
 
-  private getCustomDefaultHeaders(config: TextModelConfig): Record<string, string> | undefined {
-    const isCustomOpenAICompatible =
-      this.getProvider().id === 'openai-compatible' ||
-      config.providerMeta?.id === 'openai-compatible'
+  private isCustomOpenAICompatibleProvider(config: TextModelConfig): boolean {
+    return this.getProvider().id === 'openai-compatible' || config.providerMeta?.id === 'openai-compatible'
+  }
 
-    if (!isCustomOpenAICompatible) {
+  private shouldUseSameOriginProxy(config: TextModelConfig): boolean {
+    if (typeof window === 'undefined') {
+      return false
+    }
+
+    return this.isCustomOpenAICompatibleProvider(config)
+  }
+
+  private getSameOriginProxyBaseURL(): string | undefined {
+    if (typeof window === 'undefined' || !window.location?.origin) {
+      return undefined
+    }
+
+    return `${window.location.origin}${OPENAI_COMPATIBLE_PROXY_PATH}`
+  }
+
+  private getCustomDefaultHeaders(config: TextModelConfig): Record<string, string> | undefined {
+    if (!this.isCustomOpenAICompatibleProvider(config) || this.shouldUseSameOriginProxy(config)) {
       return undefined
     }
 
     return normalizeCustomRequestHeaders(config.connectionConfig?.customHeaders as any)
+  }
+
+  private appendSameOriginProxyHeaders(
+    config: TextModelConfig,
+    headers: Headers
+  ): Headers {
+    const baseURL = typeof config.connectionConfig?.baseURL === 'string'
+      ? config.connectionConfig.baseURL.trim()
+      : ''
+
+    if (baseURL) {
+      headers.set(OPENAI_PROXY_BASE_URL_HEADER, baseURL)
+    }
+
+    headers.set(OPENAI_PROXY_REQUEST_STYLE_HEADER, this.getRequestStyle(config))
+
+    const customHeaders = normalizeCustomRequestHeaders(config.connectionConfig?.customHeaders as any)
+    if (customHeaders) {
+      headers.set(OPENAI_PROXY_CUSTOM_HEADERS_HEADER, JSON.stringify(customHeaders))
+    }
+
+    return headers
   }
 
   // ===== SDK实例创建（从service.ts迁移） =====
@@ -766,6 +809,11 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
       processedBaseURL = processedBaseURL.slice(0, -'/chat/completions'.length)
     }
 
+    const useSameOriginProxy = this.shouldUseSameOriginProxy(config)
+    if (useSameOriginProxy) {
+      processedBaseURL = this.getSameOriginProxyBaseURL() || processedBaseURL
+    }
+
     // 创建OpenAI实例配置
     const defaultTimeout = isStream ? 90000 : 60000
     const timeout =
@@ -788,15 +836,18 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
     const runtimeFetch =
       typeof globalThis.fetch === 'function' ? globalThis.fetch.bind(globalThis) : undefined
 
-    if (runtimeFetch && (!hasApiKey || typeof window !== 'undefined')) {
+    if (runtimeFetch && (useSameOriginProxy || !hasApiKey || typeof window !== 'undefined')) {
       sdkConfig.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
         let headers = init?.headers
 
-        if (!hasApiKey) {
+        if (useSameOriginProxy) {
+          const proxyHeaders = new Headers(headers)
+          headers = this.appendSameOriginProxyHeaders(config, proxyHeaders)
+        } else if (!hasApiKey) {
           headers = this.stripAuthorizationHeader(headers)
         }
 
-        if (typeof window !== 'undefined' && this.shouldForceCrossOriginCredentialOmit(input)) {
+        if (!useSameOriginProxy && typeof window !== 'undefined' && this.shouldForceCrossOriginCredentialOmit(input)) {
           const sanitizedHeaders = this.sanitizeCrossOriginHeaders(headers)
 
           return runtimeFetch(input, {

--- a/packages/core/tests/unit/llm/openai-adapter.test.ts
+++ b/packages/core/tests/unit/llm/openai-adapter.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { OpenAIAdapter } from '../../../src/services/llm/adapters/openai-adapter';
 import { OpenAICompatibleAdapter } from '../../../src/services/llm/adapters/openai-compatible-adapter';
 import type { TextModelConfig, Message } from '../../../src/services/llm/types';
+import { normalizeCustomRequestHeaders } from '../../../src/utils/custom-request-headers';
 
 // 创建 mock OpenAI 实例
 let mockOpenAIInstance: any;
@@ -462,6 +463,94 @@ describe('OpenAIAdapter', () => {
       expect(mockOpenAIConfig?.defaultHeaders).toEqual({
         'x-auth-token': 'gateway-token'
       });
+    });
+
+    it('should route browser openai-compatible requests through same-origin proxy', async () => {
+      const originalWindow = (globalThis as any).window;
+      const originalFetch = (globalThis as any).fetch;
+      const runtimeFetch = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }));
+
+      (globalThis as any).window = {
+        location: {
+          origin: 'http://localhost:8085',
+          href: 'http://localhost:8085/#/basic/system'
+        }
+      };
+      (globalThis as any).fetch = runtimeFetch;
+
+      mockOpenAIInstance.chat.completions.create.mockResolvedValue({
+        id: 'chatcmpl-custom',
+        object: 'chat.completion',
+        created: Date.now(),
+        model: 'custom-model',
+        choices: [{
+          index: 0,
+          message: {
+            role: 'assistant',
+            content: 'ok'
+          },
+          finish_reason: 'stop'
+        }]
+      });
+
+      const compatibleConfig: TextModelConfig = {
+        ...mockConfig,
+        id: 'openai-compatible',
+        name: 'OpenAI Compatible (Custom)',
+        providerMeta: openAICompatibleAdapter.getProvider(),
+        modelMeta: openAICompatibleAdapter.buildDefaultModel('gpt-5.5'),
+        connectionConfig: {
+          baseURL: 'https://gateway.example.com/v1',
+          apiKey: 'gateway-key',
+          requestStyle: 'chat_completions',
+          customHeaders: [
+            { key: 'x-auth-token', value: 'gateway-token' }
+          ]
+        }
+      };
+
+      try {
+        await openAICompatibleAdapter.sendMessage(mockMessages, compatibleConfig);
+
+        expect(mockOpenAIConfig?.baseURL).toBe('http://localhost:8085/api/openai-compatible-proxy');
+        expect(mockOpenAIConfig?.dangerouslyAllowBrowser).toBe(true);
+        expect(typeof mockOpenAIConfig?.fetch).toBe('function');
+        expect(mockOpenAIConfig?.defaultHeaders).toBeUndefined();
+
+        await mockOpenAIConfig.fetch('http://localhost:8085/api/openai-compatible-proxy/chat/completions', {
+          method: 'POST',
+          headers: {
+            Authorization: 'Bearer gateway-key',
+            'Content-Type': 'application/json',
+            'x-auth-token': 'gateway-token'
+          },
+          body: JSON.stringify({ model: 'gpt-5.5', messages: [{ role: 'user', content: 'Hello, world!' }] })
+        });
+
+        const [input, requestInit] = runtimeFetch.mock.calls[0];
+        expect(input).toBe('http://localhost:8085/api/openai-compatible-proxy/chat/completions');
+        expect(requestInit.credentials).toBeUndefined();
+
+        const outgoingHeaders = new Headers(requestInit.headers);
+        expect(outgoingHeaders.get('authorization')).toBe('Bearer gateway-key');
+        expect(outgoingHeaders.get('content-type')).toBe('application/json');
+        expect(outgoingHeaders.get('x-po-target-base-url')).toBe('https://gateway.example.com/v1');
+        expect(outgoingHeaders.get('x-po-custom-headers')).toBe(
+          JSON.stringify(normalizeCustomRequestHeaders(compatibleConfig.connectionConfig.customHeaders as any))
+        );
+      } finally {
+        if (originalWindow === undefined) {
+          delete (globalThis as any).window;
+        } else {
+          (globalThis as any).window = originalWindow;
+        }
+
+        if (originalFetch === undefined) {
+          delete (globalThis as any).fetch;
+        } else {
+          (globalThis as any).fetch = originalFetch;
+        }
+      }
     });
 
     it('should not apply custom request headers to the official OpenAI provider', async () => {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -43,6 +43,174 @@ import { registerHealthzRoute } from './health.js';
 import { randomUUID } from 'node:crypto';
 import express from 'express';
 
+const OPENAI_COMPATIBLE_PROXY_PATH = '/api/openai-compatible-proxy';
+const OPENAI_PROXY_BASE_URL_HEADER = 'x-po-target-base-url';
+const OPENAI_PROXY_CUSTOM_HEADERS_HEADER = 'x-po-custom-headers';
+const HOP_BY_HOP_HEADERS = new Set([
+  'connection',
+  'content-length',
+  'host',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+  'content-encoding'
+]);
+
+function parseProxyJsonHeader(value: string | undefined): Record<string, string> | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(value);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return undefined;
+    }
+
+    const result: Record<string, string> = {};
+    Object.entries(parsed).forEach(([key, rawValue]) => {
+      if (typeof rawValue === 'string') {
+        result[key] = rawValue;
+      }
+    });
+
+    return Object.keys(result).length > 0 ? result : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isAllowedProxyTarget(baseURL: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(baseURL);
+  } catch {
+    return false;
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return false;
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+  if (['localhost', '127.0.0.1', '0.0.0.0', '::1'].includes(hostname)) {
+    return false;
+  }
+
+  return true;
+}
+
+async function proxyOpenAICompatibleRequest(
+  req: express.Request,
+  res: express.Response,
+  upstreamPath: string
+): Promise<void> {
+  const targetBaseURL = String(req.header(OPENAI_PROXY_BASE_URL_HEADER) || '').trim();
+  if (!targetBaseURL || !isAllowedProxyTarget(targetBaseURL)) {
+    res.status(400).json({ error: 'Invalid upstream base URL' });
+    return;
+  }
+
+  const normalizedBase = targetBaseURL.endsWith('/') ? targetBaseURL : `${targetBaseURL}/`;
+  const cleanPath = upstreamPath.startsWith('/') ? upstreamPath.slice(1) : upstreamPath;
+  const targetURL = new URL(cleanPath, normalizedBase);
+
+  const headers = new Headers();
+  const authorization = req.header('authorization');
+  if (authorization) {
+    headers.set('authorization', authorization);
+  }
+
+  const contentType = req.header('content-type');
+  if (contentType) {
+    headers.set('content-type', contentType);
+  }
+
+  const customHeaders = parseProxyJsonHeader(req.header(OPENAI_PROXY_CUSTOM_HEADERS_HEADER));
+  if (customHeaders) {
+    Object.entries(customHeaders).forEach(([key, value]) => {
+      headers.set(key, value);
+    });
+  }
+
+  logger.info(`Proxying openai-compatible request to ${targetURL.origin}${targetURL.pathname}`);
+
+  const upstreamResponse = await fetch(targetURL, {
+    method: req.method,
+    headers,
+    body: req.method === 'GET' ? undefined : JSON.stringify(req.body),
+    signal: AbortSignal.timeout(300000)
+  });
+
+  logger.info(`Upstream response status: ${upstreamResponse.status} ${upstreamResponse.statusText}`);
+
+  res.status(upstreamResponse.status);
+  upstreamResponse.headers.forEach((value, key) => {
+    if (!HOP_BY_HOP_HEADERS.has(key.toLowerCase())) {
+      res.setHeader(key, value);
+    }
+  });
+
+  const body = upstreamResponse.body;
+  if (!body) {
+    res.end();
+    return;
+  }
+
+  const reader = body.getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+
+    if (value) {
+      res.write(Buffer.from(value));
+    }
+  }
+
+  res.end();
+}
+
+function registerOpenAICompatibleProxyRoutes(app: express.Express): void {
+  app.post(`${OPENAI_COMPATIBLE_PROXY_PATH}/chat/completions`, async (req, res) => {
+    try {
+      await proxyOpenAICompatibleRequest(req, res, '/chat/completions');
+    } catch (error) {
+      logger.error('OpenAI-compatible proxy request failed', error as Error);
+      if (!res.headersSent) {
+        res.status(502).json({ error: (error as Error).message || 'Proxy request failed' });
+      }
+    }
+  });
+
+  app.post(`${OPENAI_COMPATIBLE_PROXY_PATH}/responses`, async (req, res) => {
+    try {
+      await proxyOpenAICompatibleRequest(req, res, '/responses');
+    } catch (error) {
+      logger.error('OpenAI-compatible proxy request failed', error as Error);
+      if (!res.headersSent) {
+        res.status(502).json({ error: (error as Error).message || 'Proxy request failed' });
+      }
+    }
+  });
+
+  app.get(`${OPENAI_COMPATIBLE_PROXY_PATH}/models`, async (req, res) => {
+    try {
+      await proxyOpenAICompatibleRequest(req, res, '/models');
+    } catch (error) {
+      logger.error('OpenAI-compatible proxy request failed', error as Error);
+      if (!res.headersSent) {
+        res.status(502).json({ error: (error as Error).message || 'Proxy request failed' });
+      }
+    }
+  });
+}
+
 // 创建服务器实例的工厂函数
 async function createServerInstance(config: MCPServerConfig) {
   // 创建 MCP Server 实例 - 使用正确的 API
@@ -366,6 +534,7 @@ async function main() {
     logger.info('Starting MCP Server for Prompt Optimizer');
     logger.info(`Transport: ${transport}, Port: ${port}`);
 
+    // 启动传输层
     // 初始化 Core 服务（一次性，用于验证配置）
     logger.info('Initializing Core services...');
     const coreServices = CoreServicesManager.getInstance();
@@ -379,6 +548,7 @@ async function main() {
       const app = express();
       app.use(express.json());
       registerHealthzRoute(app, coreServices);
+      registerOpenAICompatibleProxyRoutes(app);
       logger.info('Express app configured');
 
       // 存储每个会话的传输实例


### PR DESCRIPTION
fix: OpenAI Compatible (Custom) 第三方 API 同源代理支持

## 背景

浏览器跨域限制导致无法直接调用第三方自定义 API（不支持 CORS）。
需要添加同源代理机制：浏览器请求发到同源代理地址，服务端转发到
目标 API。

## 修改详情

### 1. packages/core/src/services/llm/adapters/openai-adapter.ts
   客户端 OpenAI 适配器 — 浏览器端代理路由

- 新增 `shouldUseSameOriginProxy()`：检测浏览器环境和自定义
  OpenAI 兼容提供商，返回是否应使用同源代理
- 新增 `getSameOriginProxyBaseURL()`：生成代理地址
  `${window.location.origin}/api/openai-compatible-proxy`
- 新增 `appendSameOriginProxyHeaders()`：在请求头附加代理所需
  的自定义头（x-po-target-base-url、x-po-request-style、
  x-po-custom-headers）
- 修改 `createOpenAIInstance()`：当启用同源代理时，将 baseURL
  替换为代理地址，并通过 fetch 拦截器注入代理头
- 修改 `getCustomDefaultHeaders()`：启用代理时跳过自定义头注入
  （由代理头统一处理）

### 2. packages/mcp-server/src/index.ts — MCP 服务端代理实现

- 新增路由 `/api/openai-compatible-proxy/chat/completions`
  `/api/openai-compatible-proxy/responses`
  `/api/openai-compatible-proxy/models`
- 新增 `proxyOpenAICompatibleRequest()` 代理函数：
  - 从 `x-po-target-base-url` 头读取目标地址
  - 通过 `isAllowedProxyTarget()` 安全校验（禁止代理到内网地址）
  - 转发 `Authorization`、`Content-Type` 及自定义头
  - 使用 `fetch()` 转发请求到上游 API
  - 剥离 `content-encoding` 等逐跳头，防止浏览器二次解码
  - 流式读写响应体
  - 超时时间 5 分钟
- 注册到 HTTP 传输模式下的 Express 实例

### 3. docker/nginx.conf — Nginx 代理配置

- 新增 `/api/openai-compatible-proxy` location 块：
  - `auth_basic off`：跳过 Basic 认证
  - `gzip off`：禁用 nginx 层 gzip 压缩，避免与上游冲突
  - `proxy_read_timeout 300s`：匹配后端 5 分钟超时

### 4. packages/core/tests/unit/llm/openai-adapter.test.ts
   新增浏览器同源代理单元测试

- `should route browser openai-compatible requests through same-origin proxy`
  - 模拟浏览器环境（window.location.origin）
  - 验证 baseURL 被重写为代理地址
  - 验证代理头（x-po-target-base-url 等）被正确注入
  - 验证凭证和跨域头处理正确

## 影响范围

- 仅影响 OpenAI Compatible (Custom) 提供商在浏览器中的请求
- 官方 API（DeepSeek、OpenAI 等）走直连，不受影响
- 服务端（Node.js/Desktop）不受影响
- MCP 服务器启动仍需至少一个 API Key