### PR TITLE
fix(web):OpenAI Compatible (Custom) 浏览器使用第三方api跨域问题修复

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -60,6 +60,21 @@ server {
         }
     }
 
+    location /api/openai-compatible-proxy {
+        auth_basic off;
+
+        gzip off;
+
+        proxy_pass http://localhost:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 300s;
+        proxy_connect_timeout 75s;
+    }
+
     location = /healthz {
         auth_basic off;
 

--- a/packages/core/src/services/llm/adapters/openai-adapter.ts
+++ b/packages/core/src/services/llm/adapters/openai-adapter.ts
@@ -2,6 +2,11 @@ import OpenAI from 'openai'
 import { AbstractTextProviderAdapter } from './abstract-adapter'
 import { APIError } from '../errors'
 import { normalizeCustomRequestHeaders } from '../../../utils/custom-request-headers'
+
+const OPENAI_COMPATIBLE_PROXY_PATH = '/api/openai-compatible-proxy'
+const OPENAI_PROXY_BASE_URL_HEADER = 'x-po-target-base-url'
+const OPENAI_PROXY_REQUEST_STYLE_HEADER = 'x-po-request-style'
+const OPENAI_PROXY_CUSTOM_HEADERS_HEADER = 'x-po-custom-headers'
 import type {
   TextProvider,
   TextModel,
@@ -732,16 +737,54 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
     return sanitized
   }
 
-  private getCustomDefaultHeaders(config: TextModelConfig): Record<string, string> | undefined {
-    const isCustomOpenAICompatible =
-      this.getProvider().id === 'openai-compatible' ||
-      config.providerMeta?.id === 'openai-compatible'
+  private isCustomOpenAICompatibleProvider(config: TextModelConfig): boolean {
+    return this.getProvider().id === 'openai-compatible' || config.providerMeta?.id === 'openai-compatible'
+  }
 
-    if (!isCustomOpenAICompatible) {
+  private shouldUseSameOriginProxy(config: TextModelConfig): boolean {
+    if (typeof window === 'undefined') {
+      return false
+    }
+
+    return this.isCustomOpenAICompatibleProvider(config)
+  }
+
+  private getSameOriginProxyBaseURL(): string | undefined {
+    if (typeof window === 'undefined' || !window.location?.origin) {
+      return undefined
+    }
+
+    return `${window.location.origin}${OPENAI_COMPATIBLE_PROXY_PATH}`
+  }
+
+  private getCustomDefaultHeaders(config: TextModelConfig): Record<string, string> | undefined {
+    if (!this.isCustomOpenAICompatibleProvider(config) || this.shouldUseSameOriginProxy(config)) {
       return undefined
     }
 
     return normalizeCustomRequestHeaders(config.connectionConfig?.customHeaders as any)
+  }
+
+  private appendSameOriginProxyHeaders(
+    config: TextModelConfig,
+    headers: Headers
+  ): Headers {
+    const baseURL = typeof config.connectionConfig?.baseURL === 'string'
+      ? config.connectionConfig.baseURL.trim()
+      : ''
+
+    if (baseURL) {
+      headers.set(OPENAI_PROXY_BASE_URL_HEADER, baseURL)
+    }
+
+    headers.set(OPENAI_PROXY_REQUEST_STYLE_HEADER, this.getRequestStyle(config))
+
+    const customHeaders = normalizeCustomRequestHeaders(config.connectionConfig?.customHeaders as any)
+    if (customHeaders) {
+      headers.set(OPENAI_PROXY_CUSTOM_HEADERS_HEADER, JSON.stringify(customHeaders))
+    }
+
+    return headers
   }
 
   // ===== SDK实例创建（从service.ts迁移） =====
@@ -766,6 +809,11 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
       processedBaseURL = processedBaseURL.slice(0, -'/chat/completions'.length)
     }
 
+    const useSameOriginProxy = this.shouldUseSameOriginProxy(config)
+    if (useSameOriginProxy) {
+      processedBaseURL = this.getSameOriginProxyBaseURL() || processedBaseURL
+    }
+
     // 创建OpenAI实例配置
     const defaultTimeout = isStream ? 90000 : 60000
     const timeout =
@@ -788,15 +836,18 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
     const runtimeFetch =
       typeof globalThis.fetch === 'function' ? globalThis.fetch.bind(globalThis) : undefined
 
-    if (runtimeFetch && (!hasApiKey || typeof window !== 'undefined')) {
+    if (runtimeFetch && (useSameOriginProxy || !hasApiKey || typeof window !== 'undefined')) {
       sdkConfig.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
         let headers = init?.headers
 
-        if (!hasApiKey) {
+        if (useSameOriginProxy) {
+          const proxyHeaders = new Headers(headers)
+          headers = this.appendSameOriginProxyHeaders(config, proxyHeaders)
+        } else if (!hasApiKey) {
           headers = this.stripAuthorizationHeader(headers)
         }
 
-        if (typeof window !== 'undefined' && this.shouldForceCrossOriginCredentialOmit(input)) {
+        if (!useSameOriginProxy && typeof window !== 'undefined' && this.shouldForceCrossOriginCredentialOmit(input)) {
           const sanitizedHeaders = this.sanitizeCrossOriginHeaders(headers)
 
           return runtimeFetch(input, {

--- a/packages/core/tests/unit/llm/openai-adapter.test.ts
+++ b/packages/core/tests/unit/llm/openai-adapter.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { OpenAIAdapter } from '../../../src/services/llm/adapters/openai-adapter';
 import { OpenAICompatibleAdapter } from '../../../src/services/llm/adapters/openai-compatible-adapter';
 import type { TextModelConfig, Message } from '../../../src/services/llm/types';
+import { normalizeCustomRequestHeaders } from '../../../src/utils/custom-request-headers';
 
 // 创建 mock OpenAI 实例
 let mockOpenAIInstance: any;
@@ -462,6 +463,94 @@ describe('OpenAIAdapter', () => {
       expect(mockOpenAIConfig?.defaultHeaders).toEqual({
         'x-auth-token': 'gateway-token'
       });
+    });
+
+    it('should route browser openai-compatible requests through same-origin proxy', async () => {
+      const originalWindow = (globalThis as any).window;
+      const originalFetch = (globalThis as any).fetch;
+      const runtimeFetch = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }));
+
+      (globalThis as any).window = {
+        location: {
+          origin: 'http://localhost:8085',
+          href: 'http://localhost:8085/#/basic/system'
+        }
+      };
+      (globalThis as any).fetch = runtimeFetch;
+
+      mockOpenAIInstance.chat.completions.create.mockResolvedValue({
+        id: 'chatcmpl-custom',
+        object: 'chat.completion',
+        created: Date.now(),
+        model: 'custom-model',
+        choices: [{
+          index: 0,
+          message: {
+            role: 'assistant',
+            content: 'ok'
+          },
+          finish_reason: 'stop'
+        }]
+      });
+
+      const compatibleConfig: TextModelConfig = {
+        ...mockConfig,
+        id: 'openai-compatible',
+        name: 'OpenAI Compatible (Custom)',
+        providerMeta: openAICompatibleAdapter.getProvider(),
+        modelMeta: openAICompatibleAdapter.buildDefaultModel('gpt-5.5'),
+        connectionConfig: {
+          baseURL: 'https://gateway.example.com/v1',
+          apiKey: 'gateway-key',
+          requestStyle: 'chat_completions',
+          customHeaders: [
+            { key: 'x-auth-token', value: 'gateway-token' }
+          ]
+        }
+      };
+
+      try {
+        await openAICompatibleAdapter.sendMessage(mockMessages, compatibleConfig);
+
+        expect(mockOpenAIConfig?.baseURL).toBe('http://localhost:8085/api/openai-compatible-proxy');
+        expect(mockOpenAIConfig?.dangerouslyAllowBrowser).toBe(true);
+        expect(typeof mockOpenAIConfig?.fetch).toBe('function');
+        expect(mockOpenAIConfig?.defaultHeaders).toBeUndefined();
+
+        await mockOpenAIConfig.fetch('http://localhost:8085/api/openai-compatible-proxy/chat/completions', {
+          method: 'POST',
+          headers: {
+            Authorization: 'Bearer gateway-key',
+            'Content-Type': 'application/json',
+            'x-auth-token': 'gateway-token'
+          },
+          body: JSON.stringify({ model: 'gpt-5.5', messages: [{ role: 'user', content: 'Hello, world!' }] })
+        });
+
+        const [input, requestInit] = runtimeFetch.mock.calls[0];
+        expect(input).toBe('http://localhost:8085/api/openai-compatible-proxy/chat/completions');
+        expect(requestInit.credentials).toBeUndefined();
+
+        const outgoingHeaders = new Headers(requestInit.headers);
+        expect(outgoingHeaders.get('authorization')).toBe('Bearer gateway-key');
+        expect(outgoingHeaders.get('content-type')).toBe('application/json');
+        expect(outgoingHeaders.get('x-po-target-base-url')).toBe('https://gateway.example.com/v1');
+        expect(outgoingHeaders.get('x-po-custom-headers')).toBe(
+          JSON.stringify(normalizeCustomRequestHeaders(compatibleConfig.connectionConfig.customHeaders as any))
+        );
+      } finally {
+        if (originalWindow === undefined) {
+          delete (globalThis as any).window;
+        } else {
+          (globalThis as any).window = originalWindow;
+        }
+
+        if (originalFetch === undefined) {
+          delete (globalThis as any).fetch;
+        } else {
+          (globalThis as any).fetch = originalFetch;
+        }
+      }
     });
 
     it('should not apply custom request headers to the official OpenAI provider', async () => {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -43,6 +43,187 @@ import { registerHealthzRoute } from './health.js';
 import { randomUUID } from 'node:crypto';
 import express from 'express';
 
+const OPENAI_COMPATIBLE_PROXY_PATH = '/api/openai-compatible-proxy';
+const OPENAI_PROXY_BASE_URL_HEADER = 'x-po-target-base-url';
+const OPENAI_PROXY_CUSTOM_HEADERS_HEADER = 'x-po-custom-headers';
+const HOP_BY_HOP_HEADERS = new Set([
+  'connection',
+  'content-length',
+  'host',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+  'content-encoding'
+]);
+
+function parseProxyJsonHeader(value: string | undefined): Record<string, string> | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(value);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return undefined;
+    }
+
+    const result: Record<string, string> = {};
+    Object.entries(parsed).forEach(([key, rawValue]) => {
+      if (typeof rawValue === 'string') {
+        result[key] = rawValue;
+      }
+    });
+
+    return Object.keys(result).length > 0 ? result : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isAllowedProxyTarget(baseURL: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(baseURL);
+  } catch {
+    return false;
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return false;
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+  if (['localhost', '127.0.0.1', '0.0.0.0', '::1'].includes(hostname)) {
+    return false;
+  }
+
+  return true;
+}
+
+function extractJsonRpcId(body: unknown): string | number | null {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return null;
+  }
+
+  const candidate = (body as { id?: unknown }).id;
+  if (typeof candidate === 'string' || typeof candidate === 'number' || candidate === null) {
+    return candidate;
+  }
+
+  return null;
+}
+
+async function proxyOpenAICompatibleRequest(
+  req: express.Request,
+  res: express.Response,
+  upstreamPath: string
+): Promise<void> {
+  const targetBaseURL = String(req.header(OPENAI_PROXY_BASE_URL_HEADER) || '').trim();
+  if (!targetBaseURL || !isAllowedProxyTarget(targetBaseURL)) {
+    res.status(400).json({ error: 'Invalid upstream base URL' });
+    return;
+  }
+
+  const normalizedBase = targetBaseURL.endsWith('/') ? targetBaseURL : `${targetBaseURL}/`;
+  const cleanPath = upstreamPath.startsWith('/') ? upstreamPath.slice(1) : upstreamPath;
+  const targetURL = new URL(cleanPath, normalizedBase);
+
+  const headers = new Headers();
+  const authorization = req.header('authorization');
+  if (authorization) {
+    headers.set('authorization', authorization);
+  }
+
+  const contentType = req.header('content-type');
+  if (contentType) {
+    headers.set('content-type', contentType);
+  }
+
+  const customHeaders = parseProxyJsonHeader(req.header(OPENAI_PROXY_CUSTOM_HEADERS_HEADER));
+  if (customHeaders) {
+    Object.entries(customHeaders).forEach(([key, value]) => {
+      headers.set(key, value);
+    });
+  }
+
+  logger.info(`Proxying openai-compatible request to ${targetURL.origin}${targetURL.pathname}`);
+
+  const upstreamResponse = await fetch(targetURL, {
+    method: req.method,
+    headers,
+    body: req.method === 'GET' ? undefined : JSON.stringify(req.body),
+    signal: AbortSignal.timeout(300000)
+  });
+
+  logger.info(`Upstream response status: ${upstreamResponse.status} ${upstreamResponse.statusText}`);
+
+  res.status(upstreamResponse.status);
+  upstreamResponse.headers.forEach((value, key) => {
+    if (!HOP_BY_HOP_HEADERS.has(key.toLowerCase())) {
+      res.setHeader(key, value);
+    }
+  });
+
+  const body = upstreamResponse.body;
+  if (!body) {
+    res.end();
+    return;
+  }
+
+  const reader = body.getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+
+    if (value) {
+      res.write(Buffer.from(value));
+    }
+  }
+
+  res.end();
+}
+
+function registerOpenAICompatibleProxyRoutes(app: express.Express): void {
+  app.post(`${OPENAI_COMPATIBLE_PROXY_PATH}/chat/completions`, async (req, res) => {
+    try {
+      await proxyOpenAICompatibleRequest(req, res, '/chat/completions');
+    } catch (error) {
+      logger.error('OpenAI-compatible proxy request failed', error as Error);
+      if (!res.headersSent) {
+        res.status(502).json({ error: (error as Error).message || 'Proxy request failed' });
+      }
+    }
+  });
+
+  app.post(`${OPENAI_COMPATIBLE_PROXY_PATH}/responses`, async (req, res) => {
+    try {
+      await proxyOpenAICompatibleRequest(req, res, '/responses');
+    } catch (error) {
+      logger.error('OpenAI-compatible proxy request failed', error as Error);
+      if (!res.headersSent) {
+        res.status(502).json({ error: (error as Error).message || 'Proxy request failed' });
+      }
+    }
+  });
+
+  app.get(`${OPENAI_COMPATIBLE_PROXY_PATH}/models`, async (req, res) => {
+    try {
+      await proxyOpenAICompatibleRequest(req, res, '/models');
+    } catch (error) {
+      logger.error('OpenAI-compatible proxy request failed', error as Error);
+      if (!res.headersSent) {
+        res.status(502).json({ error: (error as Error).message || 'Proxy request failed' });
+      }
+    }
+  });
+}
+
 // 创建服务器实例的工厂函数
 async function createServerInstance(config: MCPServerConfig) {
   // 创建 MCP Server 实例 - 使用正确的 API
@@ -366,19 +547,29 @@ async function main() {
     logger.info('Starting MCP Server for Prompt Optimizer');
     logger.info(`Transport: ${transport}, Port: ${port}`);
 
-    // 初始化 Core 服务（一次性，用于验证配置）
-    logger.info('Initializing Core services...');
-    const coreServices = CoreServicesManager.getInstance();
-    await coreServices.initialize(config);
-    logger.info('Core services initialized successfully');
-
     // 启动传输层
     if (transport === 'http') {
       logger.info('Starting HTTP server with session management...');
-      // 使用 Express 和会话管理支持多客户端连接
       const app = express();
       app.use(express.json());
-      registerHealthzRoute(app, coreServices);
+
+      // 代理路由不依赖 Core 服务，优先注册
+      registerOpenAICompatibleProxyRoutes(app);
+
+      // 初始化 Core 服务（需要 API Key，失败不影响代理功能）
+      let coreServices: CoreServicesManager | null = null;
+      try {
+        logger.info('Initializing Core services...');
+        coreServices = CoreServicesManager.getInstance();
+        await coreServices.initialize(config);
+        logger.info('Core services initialized successfully');
+      } catch (initError) {
+        logger.warn('Core services initialization failed, MCP tools unavailable', initError as Error);
+      }
+
+      if (coreServices) {
+        registerHealthzRoute(app, coreServices);
+      }
       logger.info('Express app configured');
 
       // 存储每个会话的传输实例
@@ -394,6 +585,18 @@ async function main() {
           // 重用现有传输
           httpTransport = transports[sessionId];
         } else if (!sessionId && isInitializeRequest(req.body)) {
+          if (!coreServices) {
+            res.status(503).json({
+              jsonrpc: '2.0',
+              error: {
+                code: -32000,
+                message: 'MCP tools are unavailable because Core services failed to initialize',
+              },
+              id: extractJsonRpcId(req.body),
+            });
+            return;
+          }
+
           // 新的初始化请求 - 为每个会话创建独立的服务器实例
           httpTransport = new StreamableHTTPServerTransport({
             sessionIdGenerator: () => randomUUID(),
@@ -467,7 +670,7 @@ async function main() {
       logger.info('HTTP server setup completed');
     } else {
       // stdio 模式 - 创建单个服务器实例
-      const { server } = await createServerInstance(config);
+      const { server, coreServices } = await createServerInstance(config);
       await setupServerHandlers(server, coreServices);
 
       const stdioTransport = new StdioServerTransport();


### PR DESCRIPTION
 PR Title

  fix(web): route browser OpenAI-compatible custom requests through same-origin proxy

  PR Description

  ## Summary / 概述

  This PR fixes browser-side CORS issues when using the `OpenAI Compatible (Custom)` provider with third-party APIs.

  本次改动修复了浏览器环境下使用 `OpenAI Compatible (Custom)` 接入第三方 API 时的跨域问题。

  ## What changed / 变更内容

  - Added a same-origin proxy endpoint at `/api/openai-compatible-proxy` in the MCP HTTP server.
  - 在 MCP HTTP 服务中新增了 `/api/openai-compatible-proxy` 同源代理入口。

  - Added matching Nginx proxy rules in Docker so browser requests can be forwarded through the web origin.
  - 在 Docker 的 Nginx 中增加了对应代理规则，使浏览器请求能够通过当前 Web 同源地址转发。

  - Updated `OpenAIAdapter` so browser-side `openai-compatible` requests automatically use the same-origin proxy instead of calling third-party endpoints directly.
  - 更新 `OpenAIAdapter`，让浏览器环境下的 `openai-compatible` 请求自动走同源代理，而不是直接访问第三方接口。

  - Forwarded upstream base URL and custom headers through proxy-specific headers.
  - 通过专用请求头透传上游 `baseURL` 和自定义请求头。

  - Kept the proxy path available in HTTP mode even when MCP Core services fail to initialize.
  - 保证在 HTTP 模式下，即使 MCP Core 服务初始化失败，代理路径仍然可用。

  - Added unit tests covering browser proxy routing behavior.
  - 补充了浏览器代理路由行为的单元测试。

  ## Why / 背景说明

  Browser requests to third-party OpenAI-compatible services may fail due to cross-origin restrictions.
  Routing those requests through a same-origin proxy avoids browser CORS failures while preserving support for custom upstream endpoints and headers.

  浏览器直接访问第三方 OpenAI-compatible 服务时，可能因为跨域限制导致请求失败。
  通过同源代理转发，可以规避浏览器 CORS 限制，同时保留对自定义上游地址和自定义请求头的支持。

  ## Implementation details / 实现细节

  ### Frontend / 前端
  - For browser-based `openai-compatible` requests, replace the SDK `baseURL` with:
    - `${window.location.origin}/api/openai-compatible-proxy`
  - 在浏览器环境下，将 `openai-compatible` 请求的 SDK `baseURL` 替换为：
    - `${window.location.origin}/api/openai-compatible-proxy`

  - Inject proxy metadata headers:
    - `x-po-target-base-url`
    - `x-po-request-style`
    - `x-po-custom-headers`
  - 注入代理元信息请求头：
    - `x-po-target-base-url`
    - `x-po-request-style`
    - `x-po-custom-headers`

  ### MCP server / MCP 服务端
  - Added proxy handlers for:
    - `POST /api/openai-compatible-proxy/chat/completions`
    - `POST /api/openai-compatible-proxy/responses`
    - `GET /api/openai-compatible-proxy/models`
  - 新增以下代理处理路由：
    - `POST /api/openai-compatible-proxy/chat/completions`
    - `POST /api/openai-compatible-proxy/responses`
    - `GET /api/openai-compatible-proxy/models`

  - Forward request body and relevant headers to the upstream target.
  - 将请求体和相关请求头转发到上游目标服务。

  - Filter hop-by-hop headers before returning upstream responses.
  - 返回上游响应前过滤 hop-by-hop 头。

  ### Docker / Nginx
  - Added an Nginx location for `/api/openai-compatible-proxy`.
  - 为 `/api/openai-compatible-proxy` 增加了 Nginx 路由配置。

  - Disabled Basic auth on the proxy path.
  - 对代理路径关闭了 Basic Auth。

  - Forwarded proxy traffic to the local MCP server on port `3000`.
  - 将代理流量转发到容器内 `3000` 端口的 MCP 服务。

  ## Testing / 测试

  - Added unit coverage in `packages/core/tests/unit/llm/openai-adapter.test.ts`
  - 已在 `packages/core/tests/unit/llm/openai-adapter.test.ts` 中补充单元测试

  - Verified that browser-side OpenAI-compatible requests are routed through the same-origin proxy
  - 已验证浏览器端 OpenAI-compatible 请求会通过同源代理转发

  - Verified Docker build succeeds with the updated MCP server flow
  - 已验证更新后的 MCP 服务流程可以正常完成 Docker 构建

  ## Impact / 影响范围

  - Fixes browser CORS failures for custom OpenAI-compatible providers
  - 修复了自定义 OpenAI-compatible 提供商在浏览器中的跨域失败问题

  - Does not change the behavior of the official OpenAI provider
  - 不影响官方 OpenAI Provider 的现有行为