### PR TITLE
feat(core): add Requesty LLM provider adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ MCP Server requires API key configuration to function properly. Main MCP-specifi
 
 ```bash
 # MCP Server Configuration
-MCP_DEFAULT_MODEL_PROVIDER=openai  # Options: openai, gemini, anthropic, deepseek, grok, siliconflow, zhipu, dashscope, openrouter, modelscope, custom
+MCP_DEFAULT_MODEL_PROVIDER=openai  # Options: openai, gemini, anthropic, deepseek, grok, siliconflow, zhipu, dashscope, openrouter, requesty, modelscope, custom
 MCP_LOG_LEVEL=info                 # Log level
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -219,7 +219,7 @@ MCP Server 需要配置 API 密钥才能正常工作。主要的 MCP 专属配�
 
 ```bash
 # MCP 服务器配置
-MCP_DEFAULT_MODEL_PROVIDER=openai  # 可选值：openai, gemini, anthropic, deepseek, grok, siliconflow, zhipu, dashscope, openrouter, modelscope, custom
+MCP_DEFAULT_MODEL_PROVIDER=openai  # 可选值：openai, gemini, anthropic, deepseek, grok, siliconflow, zhipu, dashscope, openrouter, requesty, modelscope, custom
 MCP_LOG_LEVEL=info                 # 日志级别
 ```
 

--- a/docs/user/mcp-server.md
+++ b/docs/user/mcp-server.md
@@ -73,7 +73,7 @@ VITE_CUSTOM_API_MODEL=qwen2.5:0.5b
 
 ```bash
 # 首选模型提供商（当配置了多个 API 密钥时）
-# 可选值：openai, gemini, anthropic, deepseek, grok, siliconflow, zhipu, dashscope, openrouter, modelscope, custom
+# 可选值：openai, gemini, anthropic, deepseek, grok, siliconflow, zhipu, dashscope, openrouter, requesty, modelscope, custom
 MCP_DEFAULT_MODEL_PROVIDER=openai
 
 # 日志级别（可选，默认 debug）

--- a/docs/user/mcp-server_en.md
+++ b/docs/user/mcp-server_en.md
@@ -73,7 +73,7 @@ VITE_CUSTOM_API_MODEL=qwen2.5:0.5b
 
 ```bash
 # Preferred model provider (when multiple API keys are configured)
-# Options: openai, gemini, anthropic, deepseek, grok, siliconflow, zhipu, dashscope, openrouter, modelscope, custom
+# Options: openai, gemini, anthropic, deepseek, grok, siliconflow, zhipu, dashscope, openrouter, requesty, modelscope, custom
 MCP_DEFAULT_MODEL_PROVIDER=openai
 
 # Log level (optional, default: debug)

--- a/env.local.example
+++ b/env.local.example
@@ -123,7 +123,7 @@
 # 以下配置仅在使用 MCP 服务器时需要
 
 # 首选模型提供商（当配置了多个 API 密钥时）
-# 可选值：openai, gemini, anthropic, deepseek, grok, siliconflow, zhipu, dashscope, openrouter, modelscope, custom, custom_<suffix>
+# 可选值：openai, gemini, anthropic, deepseek, grok, siliconflow, zhipu, dashscope, openrouter, requesty, modelscope, custom, custom_<suffix>
 # 注意：必须与上面配置的 API 密钥对应
 # 示例：如果配置了 VITE_CUSTOM_API_KEY_qwen3，可以使用 custom_qwen3
 # MCP_DEFAULT_MODEL_PROVIDER=openai

--- a/packages/core/src/services/llm/adapters/registry.ts
+++ b/packages/core/src/services/llm/adapters/registry.ts
@@ -15,6 +15,7 @@ import { SiliconflowAdapter } from './siliconflow-adapter';
 import { ZhipuAdapter } from './zhipu-adapter';
 import { DashScopeAdapter } from './dashscope-adapter';
 import { OpenRouterAdapter } from './openrouter-adapter';
+import { RequestyAdapter } from './requesty-adapter';
 import { ModelScopeAdapter } from './modelscope-adapter';
 import { OllamaAdapter } from './ollama-adapter';
 import { MinimaxAdapter } from './minimax-adapter';
@@ -63,6 +64,7 @@ export class TextAdapterRegistry
     const geminiAdapter = new GeminiAdapter();
     const dashscopeAdapter = new DashScopeAdapter();
     const openrouterAdapter = new OpenRouterAdapter();
+    const requestyAdapter = new RequestyAdapter();
     const modelscopeAdapter = new ModelScopeAdapter();
     const ollamaAdapter = new OllamaAdapter();
     const minimaxAdapter = new MinimaxAdapter();
@@ -80,6 +82,7 @@ export class TextAdapterRegistry
     this.adapters.set('gemini', geminiAdapter);
     this.adapters.set('dashscope', dashscopeAdapter);
     this.adapters.set('openrouter', openrouterAdapter);
+    this.adapters.set('requesty', requestyAdapter);
     this.adapters.set('modelscope', modelscopeAdapter);
     this.adapters.set('ollama', ollamaAdapter);
     this.adapters.set('minimax', minimaxAdapter);

--- a/packages/core/src/services/llm/adapters/requesty-adapter.ts
+++ b/packages/core/src/services/llm/adapters/requesty-adapter.ts
@@ -1,0 +1,77 @@
+import type { TextModel, TextProvider } from '../types'
+import { OpenAIAdapter } from './openai-adapter'
+
+interface ModelOverride {
+  id: string
+  name: string
+  description: string
+  capabilities?: Partial<TextModel['capabilities']>
+  defaultParameterValues?: Record<string, unknown>
+}
+
+const REQUESTY_STATIC_MODELS: ModelOverride[] = [
+  {
+    id: 'openai/gpt-4o-mini',
+    name: 'GPT-4o mini',
+    description: 'OpenAI GPT-4o mini served through Requesty',
+    capabilities: {
+      supportsTools: true,
+      supportsReasoning: false,
+      maxContextLength: 128000
+    }
+  },
+  {
+    id: 'anthropic/claude-sonnet-4-5',
+    name: 'Claude Sonnet 4.5',
+    description: 'Anthropic Claude Sonnet 4.5 served through Requesty',
+    capabilities: {
+      supportsTools: true,
+      supportsReasoning: true,
+      maxContextLength: 200000
+    }
+  }
+]
+
+export class RequestyAdapter extends OpenAIAdapter {
+  public getProvider(): TextProvider {
+    return {
+      id: 'requesty',
+      name: 'Requesty',
+      description: 'OpenAI-compatible gateway for accessing models from many providers',
+      requiresApiKey: true,
+      defaultBaseURL: 'https://router.requesty.ai/v1',
+      supportsDynamicModels: true,
+      apiKeyUrl: 'https://app.requesty.ai/api-keys',
+      connectionSchema: {
+        required: ['apiKey'],
+        optional: ['baseURL'],
+        fieldTypes: {
+          apiKey: 'string',
+          baseURL: 'string'
+        }
+      }
+    }
+  }
+
+  public getModels(): TextModel[] {
+    return REQUESTY_STATIC_MODELS.map((definition) => {
+      const baseModel = this.buildDefaultModel(definition.id)
+
+      return {
+        ...baseModel,
+        name: definition.name,
+        description: definition.description,
+        capabilities: {
+          ...baseModel.capabilities,
+          ...(definition.capabilities ?? {})
+        },
+        defaultParameterValues: definition.defaultParameterValues
+          ? {
+              ...(baseModel.defaultParameterValues ?? {}),
+              ...definition.defaultParameterValues
+            }
+          : baseModel.defaultParameterValues
+      }
+    })
+  }
+}

--- a/packages/core/tests/unit/llm/registry.test.ts
+++ b/packages/core/tests/unit/llm/registry.test.ts
@@ -84,6 +84,13 @@ describe('TextAdapterRegistry', () => {
       expect(adapter.getProvider().id).toBe('grok');
     });
 
+    it('should return Requesty adapter for "requesty" provider', () => {
+      const adapter = registry.getAdapter('requesty');
+
+      expect(adapter).toBeDefined();
+      expect(adapter.getProvider().id).toBe('requesty');
+    });
+
     it('should return Xiaomi MiMo Token Plan adapter for "xiaomi-mimo-token-plan" provider', () => {
       const adapter = registry.getAdapter('xiaomi-mimo-token-plan');
 
@@ -118,11 +125,11 @@ describe('TextAdapterRegistry', () => {
       const providers = registry.getAllProviders();
 
       expect(Array.isArray(providers)).toBe(true);
-      expect(providers.length).toBe(16);
+      expect(providers.length).toBe(17);
 
       const providerIds = providers.map(p => p.id);
       expect(providerIds).toEqual(
-        expect.arrayContaining(['openai', 'openai-compatible', 'deepseek', 'siliconflow', 'zhipu', 'gemini', 'anthropic', 'dashscope', 'openrouter', 'modelscope', 'ollama', 'minimax', 'cloudflare', 'grok', 'chrome-built-in', 'xiaomi-mimo-token-plan'])
+        expect.arrayContaining(['openai', 'openai-compatible', 'deepseek', 'siliconflow', 'zhipu', 'gemini', 'anthropic', 'dashscope', 'openrouter', 'requesty', 'modelscope', 'ollama', 'minimax', 'cloudflare', 'grok', 'chrome-built-in', 'xiaomi-mimo-token-plan'])
       );
     });
 

--- a/packages/ui/src/components/ProviderPillSelect.vue
+++ b/packages/ui/src/components/ProviderPillSelect.vue
@@ -111,6 +111,7 @@ const providerOrder = [
   'anthropic',
   'dashscope',
   'openrouter',
+  'requesty',
   'zhipu',
   'zhipuai',
   'chrome-built-in',


### PR DESCRIPTION
Adds a dedicated Requesty LLM provider adapter that mirrors the existing OpenRouter adapter. Requesty is an OpenAI-compatible LLM gateway that uses the same `provider/model` naming convention (e.g. `openai/gpt-4o-mini`, `anthropic/claude-sonnet-4-5`).

Changes:
- New `RequestyAdapter` (`packages/core/src/services/llm/adapters/requesty-adapter.ts`) extending `OpenAIAdapter`, fixed base URL `https://router.requesty.ai/v1`, `REQUESTY_API_KEY` auth, `supportsDynamicModels: true`.
- Registered in the text adapter registry right after OpenRouter.
- Added to the provider pill ordering in the UI.
- Listed `requesty` as an `MCP_DEFAULT_MODEL_PROVIDER` option in README (en/zh), MCP docs (en/zh) and `env.local.example`.
- Extended the registry unit test (provider count 17, `getAdapter('requesty')`).

Testing: `packages/core` typecheck passes; LLM unit tests pass (135 passed / 12 skipped). Verified a live chat/completions round-trip through the new adapter against `https://router.requesty.ai/v1` using `provider/model` naming.

Docs: https://requesty.ai · https://docs.requesty.ai · https://app.requesty.ai/api-keys · https://app.requesty.ai/router/list

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.
