### PR TITLE
Add Atlas Cloud LLM provider

### DIFF
--- a/packages/core/src/services/llm/adapters/atlascloud-adapter.ts
+++ b/packages/core/src/services/llm/adapters/atlascloud-adapter.ts
@@ -1,0 +1,93 @@
+import type { TextModel, TextProvider } from '../types'
+import { OpenAIAdapter } from './openai-adapter'
+
+interface ModelOverride {
+  id: string
+  name: string
+  description: string
+  capabilities?: Partial<TextModel['capabilities']>
+  defaultParameterValues?: Record<string, unknown>
+}
+
+const ATLASCLOUD_STATIC_MODELS: ModelOverride[] = [
+  {
+    id: 'qwen/qwen3.5-flash',
+    name: 'Qwen3.5 Flash',
+    description: 'Qwen3.5 Flash via Atlas Cloud OpenAI-compatible LLM API',
+    capabilities: {
+      supportsTools: true,
+      supportsReasoning: false,
+      maxContextLength: 131072
+    }
+  },
+  {
+    id: 'deepseek-ai/deepseek-v4-pro',
+    name: 'DeepSeek V4 Pro',
+    description: 'DeepSeek V4 Pro via Atlas Cloud OpenAI-compatible LLM API',
+    capabilities: {
+      supportsTools: true,
+      supportsReasoning: true,
+      maxContextLength: 1000000
+    },
+    defaultParameterValues: {
+      max_tokens: 1024
+    }
+  },
+  {
+    id: 'deepseek-ai/deepseek-v4-flash',
+    name: 'DeepSeek V4 Flash',
+    description: 'DeepSeek V4 Flash via Atlas Cloud OpenAI-compatible LLM API',
+    capabilities: {
+      supportsTools: true,
+      supportsReasoning: true,
+      maxContextLength: 1000000
+    },
+    defaultParameterValues: {
+      max_tokens: 1024
+    }
+  }
+]
+
+export class AtlasCloudAdapter extends OpenAIAdapter {
+  public getProvider(): TextProvider {
+    return {
+      id: 'atlascloud',
+      name: 'Atlas Cloud',
+      description: 'Atlas Cloud OpenAI-compatible LLM models',
+      requiresApiKey: true,
+      defaultBaseURL: 'https://api.atlascloud.ai/v1',
+      supportsDynamicModels: true,
+      apiKeyUrl: 'https://www.atlascloud.ai/console/api-keys',
+      connectionSchema: {
+        required: ['apiKey'],
+        optional: ['baseURL'],
+        fieldTypes: {
+          apiKey: 'string',
+          baseURL: 'string'
+        }
+      }
+    }
+  }
+
+  public getModels(): TextModel[] {
+    return ATLASCLOUD_STATIC_MODELS.map((definition) => {
+      const baseModel = this.buildDefaultModel(definition.id)
+
+      return {
+        ...baseModel,
+        name: definition.name,
+        description: definition.description,
+        capabilities: {
+          ...baseModel.capabilities,
+          ...(definition.capabilities ?? {})
+        },
+        defaultParameterValues: definition.defaultParameterValues
+          ? {
+              ...(baseModel.defaultParameterValues ?? {}),
+              ...definition.defaultParameterValues
+            }
+          : baseModel.defaultParameterValues
+      }
+    })
+  }
+}

--- a/packages/core/src/services/llm/adapters/registry.ts
+++ b/packages/core/src/services/llm/adapters/registry.ts
@@ -11,6 +11,7 @@ import { OpenAICompatibleAdapter } from './openai-compatible-adapter';
 import { AnthropicAdapter } from './anthropic-adapter';
 import { GeminiAdapter } from './gemini-adapter';
 import { DeepseekAdapter } from './deepseek-adapter';
+import { AtlasCloudAdapter } from './atlascloud-adapter';
 import { SiliconflowAdapter } from './siliconflow-adapter';
 import { ZhipuAdapter } from './zhipu-adapter';
 import { DashScopeAdapter } from './dashscope-adapter';
@@ -57,6 +58,7 @@ export class TextAdapterRegistry
     const openaiAdapter = new OpenAIAdapter();
     const openaiCompatibleAdapter = new OpenAICompatibleAdapter();
     const deepseekAdapter = new DeepseekAdapter();
+    const atlasCloudAdapter = new AtlasCloudAdapter();
     const siliconflowAdapter = new SiliconflowAdapter();
     const zhipuAdapter = new ZhipuAdapter();
     const anthropicAdapter = new AnthropicAdapter();
@@ -74,6 +76,7 @@ export class TextAdapterRegistry
     this.adapters.set('openai', openaiAdapter);
     this.adapters.set('openai-compatible', openaiCompatibleAdapter);
     this.adapters.set('deepseek', deepseekAdapter);
+    this.adapters.set('atlascloud', atlasCloudAdapter);
     this.adapters.set('siliconflow', siliconflowAdapter);
     this.adapters.set('zhipu', zhipuAdapter);
     this.adapters.set('anthropic', anthropicAdapter);

--- a/packages/core/tests/unit/llm/atlascloud-adapter.test.ts
+++ b/packages/core/tests/unit/llm/atlascloud-adapter.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { AtlasCloudAdapter } from '../../../src/services/llm/adapters/atlascloud-adapter'
+
+describe('AtlasCloudAdapter', () => {
+  it('exposes Atlas Cloud provider metadata', () => {
+    const adapter = new AtlasCloudAdapter()
+    const provider = adapter.getProvider()
+
+    expect(provider.id).toBe('atlascloud')
+    expect(provider.name).toBe('Atlas Cloud')
+    expect(provider.defaultBaseURL).toBe('https://api.atlascloud.ai/v1')
+    expect(provider.supportsDynamicModels).toBe(true)
+    expect(provider.requiresApiKey).toBe(true)
+    expect(provider.apiKeyUrl).toBe('https://www.atlascloud.ai/console/api-keys')
+    expect(provider.connectionSchema?.required).toContain('apiKey')
+    expect(provider.connectionSchema?.optional).toContain('baseURL')
+  })
+
+  it('returns Atlas Cloud static models with provider metadata', () => {
+    const adapter = new AtlasCloudAdapter()
+    const models = adapter.getModels()
+
+    expect(models.map((model) => model.id)).toEqual([
+      'qwen/qwen3.5-flash',
+      'deepseek-ai/deepseek-v4-pro',
+      'deepseek-ai/deepseek-v4-flash'
+    ])
+    expect(models.every((model) => model.providerId === 'atlascloud')).toBe(true)
+    expect(
+      models.find((model) => model.id === 'deepseek-ai/deepseek-v4-pro')?.capabilities.supportsReasoning
+    ).toBe(true)
+    expect(
+      models.find((model) => model.id === 'deepseek-ai/deepseek-v4-pro')?.defaultParameterValues
+    ).toEqual(
+      expect.objectContaining({
+        max_tokens: 1024
+      })
+    )
+  })
+})

--- a/packages/core/tests/unit/llm/registry.test.ts
+++ b/packages/core/tests/unit/llm/registry.test.ts
@@ -35,6 +35,13 @@ describe('TextAdapterRegistry', () => {
       expect(adapter.getProvider().id).toBe('deepseek');
     });
 
+    it('should return Atlas Cloud adapter for "atlascloud" provider', () => {
+      const adapter = registry.getAdapter('atlascloud');
+
+      expect(adapter).toBeDefined();
+      expect(adapter.getProvider().id).toBe('atlascloud');
+    });
+
     it('should return Ollama adapter for "ollama" provider', () => {
       const adapter = registry.getAdapter('ollama');
 
@@ -118,11 +125,11 @@ describe('TextAdapterRegistry', () => {
       const providers = registry.getAllProviders();
 
       expect(Array.isArray(providers)).toBe(true);
-      expect(providers.length).toBe(16);
+      expect(providers.length).toBe(17);
 
       const providerIds = providers.map(p => p.id);
       expect(providerIds).toEqual(
-        expect.arrayContaining(['openai', 'openai-compatible', 'deepseek', 'siliconflow', 'zhipu', 'gemini', 'anthropic', 'dashscope', 'openrouter', 'modelscope', 'ollama', 'minimax', 'cloudflare', 'grok', 'chrome-built-in', 'xiaomi-mimo-token-plan'])
+        expect.arrayContaining(['openai', 'openai-compatible', 'deepseek', 'atlascloud', 'siliconflow', 'zhipu', 'gemini', 'anthropic', 'dashscope', 'openrouter', 'modelscope', 'ollama', 'minimax', 'cloudflare', 'grok', 'chrome-built-in', 'xiaomi-mimo-token-plan'])
       );
     });
 


### PR DESCRIPTION
## Summary
- add Atlas Cloud as an OpenAI-compatible LLM provider
- register the provider in the text adapter registry
- add focused adapter and registry coverage

## Validation
- corepack pnpm --config.engine-strict=false -F @prompt-optimizer/core test -- tests/unit/llm/atlascloud-adapter.test.ts tests/unit/llm/registry.test.ts
- corepack pnpm --config.engine-strict=false -F @prompt-optimizer/core typecheck

Note: local validation used Node v24.14.0 with engine-strict disabled because this workspace does not have Node 22 installed.

No README changes. No sponsor, logo, credits, or partner placement.