### PR TITLE
fix(ui): prevent CategoryManager delete dialog XSS

### DIFF
--- a/packages/ui/src/components/CategoryManager.vue
+++ b/packages/ui/src/components/CategoryManager.vue
@@ -113,7 +113,11 @@
       :mask-closable="false"
       @positive-click="handleConfirmDelete"
     >
-      <p v-html="t('favorites.categoryManager.deleteWarning', { name: deletingCategory?.name })"></p>
+      <i18n-t tag="p" keypath="favorites.categoryManager.deleteWarning" scope="global">
+        <template #name>
+          <strong>{{ deletingCategory?.name }}</strong>
+        </template>
+      </i18n-t>
       <p v-if="deletingCategoryHasChildren" style="color: var(--n-color-error)">
         {{ t('favorites.categoryManager.deleteChildrenWarning', { count: deletingCategoryChildCount }) }}
       </p>

--- a/packages/ui/src/i18n/locales/en-US/favorites.ts
+++ b/packages/ui/src/i18n/locales/en-US/favorites.ts
@@ -535,7 +535,7 @@ const messages = {
       "parentCategoryPlaceholder": "Select parent category (leave empty for root)",
       "categoryColor": "Category Color",
       "confirmDelete": "Confirm Delete",
-      "deleteWarning": "Are you sure you want to delete category <strong>{name}</strong>?",
+      "deleteWarning": "Are you sure you want to delete category {name}?",
       "deleteChildrenWarning": "Warning: This category has {count} subcategories that will also be deleted!",
       "deleteUsageWarning": "Note: This category is used by {count} favorites, which will become uncategorized after deletion.",
       "deleteSuccess": "Deleted successfully",

--- a/packages/ui/src/i18n/locales/zh-CN/favorites.ts
+++ b/packages/ui/src/i18n/locales/zh-CN/favorites.ts
@@ -535,7 +535,7 @@ const messages = {
       "parentCategoryPlaceholder": "选择父分类（不选则为根分类）",
       "categoryColor": "分类颜色",
       "confirmDelete": "确认删除",
-      "deleteWarning": "确定要删除分类 <strong>{name}</strong> 吗？",
+      "deleteWarning": "确定要删除分类 {name} 吗？",
       "deleteChildrenWarning": "警告：该分类下还有 {count} 个子分类，将一并删除！",
       "deleteUsageWarning": "提示：该分类已被 {count} 个收藏使用，删除后这些收藏将变为未分类。",
       "deleteSuccess": "删除成功",

--- a/packages/ui/src/i18n/locales/zh-TW/favorites.ts
+++ b/packages/ui/src/i18n/locales/zh-TW/favorites.ts
@@ -535,7 +535,7 @@ const messages = {
       "parentCategoryPlaceholder": "選擇父分類（不選則為根分類）",
       "categoryColor": "分類顏色",
       "confirmDelete": "確認刪除",
-      "deleteWarning": "確定要刪除分類 <strong>{name}</strong> 嗎？",
+      "deleteWarning": "確定要刪除分類 {name} 嗎？",
       "deleteChildrenWarning": "警告：該分類下還有 {count} 個子分類，將一併刪除！",
       "deleteUsageWarning": "提示：該分類已被 {count} 個收藏使用，刪除後這些收藏將變為未分類。",
       "deleteSuccess": "刪除成功",

--- a/packages/ui/tests/unit/components/CategoryManager.spec.ts
+++ b/packages/ui/tests/unit/components/CategoryManager.spec.ts
@@ -1,0 +1,66 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { ref } from 'vue'
+import { describe, expect, it, vi } from 'vitest'
+
+import CategoryManager from '../../../src/components/CategoryManager.vue'
+
+const mountManager = (categoryName: string) => {
+  const category = {
+    id: 'category-1',
+    name: categoryName,
+    createdAt: 1,
+    sortOrder: 1,
+  }
+  const favoriteManager = {
+    getCategories: vi.fn().mockResolvedValue([category]),
+    getCategoryUsage: vi.fn().mockResolvedValue(0),
+  }
+
+  return {
+    category,
+    wrapper: mount(CategoryManager, {
+      global: {
+        provide: {
+          services: ref({ favoriteManager }),
+        },
+        stubs: {
+          NButton: true,
+          NIcon: true,
+          NSpace: true,
+          NTree: true,
+          NForm: true,
+          NFormItem: true,
+          NInput: true,
+          NTreeSelect: true,
+          NColorPicker: true,
+          NDropdown: true,
+          // Keep modal content in-tree for XSS assertions without full Naive UI dialog plumbing.
+          NModal: {
+            template: '<div class="n-dialog__content"><slot /></div>',
+          },
+        },
+      },
+    }),
+  }
+}
+
+describe('CategoryManager', () => {
+  it('renders an untrusted category name as text in the delete confirmation', async () => {
+    const categoryName = '<img src=x onerror="window.__categoryXss = true">'
+    const { category, wrapper } = mountManager(categoryName)
+    await flushPromises()
+
+    await (wrapper.vm as unknown as {
+      handleDeleteCategory: (category: typeof category) => Promise<void>
+    }).handleDeleteCategory(category)
+    await flushPromises()
+
+    const modal = wrapper.get('.n-dialog__content')
+    // Must not parse the untrusted name into a real DOM node.
+    expect(modal.find('img').exists()).toBe(false)
+    expect(modal.element.querySelector('img')).toBeNull()
+    // Vue text interpolation keeps the payload visible as text, not executable HTML.
+    expect(modal.text()).toContain(categoryName)
+    expect(modal.html()).toContain('&lt;img')
+  })
+})


### PR DESCRIPTION
## Summary
- Replace `v-html` category name rendering in the delete confirmation with `i18n-t` text interpolation.
- Strip HTML tags from the related i18n strings so emphasis is owned by the component template.
- Add a unit test that asserts untrusted category names cannot create DOM nodes.

## Why
Part of the split follow-up requested when #324 was closed. This is the smallest independent security fix.

## Test plan
- [x] `pnpm -F @prompt-optimizer/ui test --run tests/unit/components/CategoryManager.spec.ts`

## Non-goals
- No desktop/core/MCP changes
- No style-system rewrite