### PR TITLE
feat(core): electron subpath entry + SDK loader helper

### DIFF
--- a/docs/architecture/electron-adapter-entrypoint.md
+++ b/docs/architecture/electron-adapter-entrypoint.md
@@ -1,0 +1,42 @@
+# Electron Adapter Entrypoint
+
+Status: Accepted  
+Date: 2026-07-17
+
+## Context
+
+`@prompt-optimizer/core` previously exported browser domain modules and Electron
+renderer proxies from the same package entry. Web and Extension builds therefore
+had no explicit platform seam and could retain Electron-only implementations in
+their initial dependency graph.
+
+## Decision
+
+- Browser-neutral domain modules remain available from `@prompt-optimizer/core`.
+- Electron renderer adapters are exported from `@prompt-optimizer/core/electron`.
+- `useAppInitializer` dynamically imports the Electron entry only after runtime
+  detection confirms that the Electron bridge is available.
+- The Core package emits ESM, CJS, and declarations for both entries.
+
+## Considered Alternatives
+
+- Keep one Core entry: lowest implementation cost, but preserves the platform
+  leakage and gives browser builds less control over Electron-only code.
+- Introduce runtime plugins: greater extensibility, but unjustified protocol,
+  versioning, and security cost for the two platform adapters currently needed.
+- Rewrite platform services: rejected because the existing proxy interfaces and
+  persistence behavior are already tested and compatible.
+
+## Consequences
+
+- Positive: platform ownership is explicit and Electron adapters load on demand.
+- Positive: Web initial assets are smaller without changing data or service interfaces.
+- Negative: package builds and Vite aliases must preserve the additional subpath.
+- Risk control: repository tests verify the export, build entry, dynamic import,
+  and consumer aliases; Core/UI/Web/Extension builds remain required release gates.
+
+## Revisit Triggers
+
+Revisit this decision when third-party runtime adapters are supported, when Core
+publishes a public compatibility contract, or when browser-specific Core entries
+can provide a materially smaller interface than the current source entry.

--- a/docs/architecture/llm-sdk-lazy-loading.md
+++ b/docs/architecture/llm-sdk-lazy-loading.md
@@ -1,0 +1,64 @@
+# LLM SDK Lazy Loading
+
+Status: Accepted  
+Date: 2026-07-17
+
+## Context
+
+The browser application needs Provider metadata during startup, but it does not
+need the OpenAI, Anthropic, or Google Gen AI network clients until a user sends a
+request or explicitly refreshes a remote model list. Static SDK imports made the
+three clients part of the initial dependency graph even though the Registry only
+used synchronous metadata at startup.
+
+The measured Web initial bundle was 812.1 KiB gzip. The Provider/SDK chunk alone
+was 110.7 KiB gzip and was module-preloaded before the application became usable.
+
+## Decision
+
+- Keep `TextAdapterRegistry` synchronous so Provider and model metadata remain
+  immediately available to managers and settings views.
+- Load the OpenAI, Anthropic, and Google Gen AI constructors inside their Adapter
+  request paths through a shared retryable loader.
+- Coalesce concurrent imports, retain a successful module, and clear a rejected
+  promise so a transient chunk failure can be retried.
+- Reuse the Google loader for both text and image Adapters.
+- Preserve all existing Adapter interfaces and error behavior. The first request
+  for a given SDK pays one additional local chunk load; subsequent requests reuse
+  the same module.
+
+## Considered Alternatives
+
+Scores are equally weighted from 1 (least favorable) to 5 (most favorable).
+For cost, risk, difficulty, and time efficiency, a higher score means cheaper,
+safer, easier, or faster.
+
+| Alternative | Effect | Cost | Risk | Difficulty | Time efficiency | Total |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Lazy-load SDKs inside Adapters | 5 | 4 | 4 | 4 | 5 | 22 |
+| Make the Provider Registry asynchronous | 5 | 2 | 2 | 2 | 2 | 13 |
+| Add a separate browser Core entry | 4 | 3 | 3 | 3 | 3 | 16 |
+
+An asynchronous Registry could split every Provider Adapter, but it would widen
+the interface change across model migration, defaults, UI settings, and tests.
+A browser Core entry remains useful for future platform isolation, but it does
+not by itself prevent SDK imports once the Registry is used.
+
+## Consequences
+
+- Positive: measured Web initial total falls from 812.1 to 721.4 KiB gzip
+  (90.7 KiB, 11.2%). Initial JavaScript falls from 787.8 to 697.1 KiB gzip.
+- Positive: startup still constructs the Registry and exposes all static Provider
+  metadata without waiting on an SDK network chunk.
+- Positive: the loader module centralizes concurrency and retry behavior.
+- Negative: the first real request for each SDK performs one extra same-origin
+  chunk fetch before the remote API request.
+- Risk control: Core tests cover loader coalescing/retry and Adapter behavior;
+  repository tests guard against static SDK imports; the Web bundle budget and
+  browser route smoke tests remain release gates.
+
+## Revisit Triggers
+
+Revisit the Registry interface only if Adapter metadata itself becomes a material
+startup cost, if third-party runtime Adapters are introduced, or if field data
+shows that first-request chunk latency outweighs the startup reduction.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,11 +11,16 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./electron": {
+      "types": "./dist/electron.d.ts",
+      "import": "./dist/electron.js",
+      "require": "./dist/electron.cjs"
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format cjs,esm --dts",
-    "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
+    "build": "tsup src/index.ts src/electron.ts --format cjs,esm --dts",
+    "dev": "tsup src/index.ts src/electron.ts --format cjs,esm --dts --watch",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/packages/core/src/electron.ts
+++ b/packages/core/src/electron.ts
@@ -1,0 +1,22 @@
+/**
+ * Electron-only adapters.
+ *
+ * Keep this entry separate from the browser-facing core graph so Web and
+ * Extension builds do not preload Electron proxy implementations.
+ */
+export { ElectronTemplateManagerProxy } from './services/template/electron-proxy'
+export { ElectronTemplateLanguageServiceProxy } from './services/template/electron-language-proxy'
+export { ElectronHistoryManagerProxy } from './services/history/electron-proxy'
+export { ElectronLLMProxy } from './services/llm/electron-proxy'
+export { ElectronModelManagerProxy } from './services/model/electron-proxy'
+export {
+  ElectronImageServiceProxy,
+  ElectronImageModelManagerProxy,
+} from './services/image/electron-proxy'
+export { ElectronPromptServiceProxy } from './services/prompt/electron-proxy'
+export { ElectronDataManagerProxy } from './services/data/electron-proxy'
+export { ElectronPreferenceServiceProxy } from './services/preference/electron-proxy'
+export { ElectronContextRepoProxy } from './services/context/electron-proxy'
+export { FavoriteManagerElectronProxy } from './services/favorite/electron-proxy'
+export { waitForElectronApi } from './utils/environment'
+export { ElectronImageUnderstandingServiceProxy } from './services/image-understanding/electron-proxy'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,15 +25,12 @@ export type { BuiltinTemplateLanguage, ITemplateLanguageService } from './servic
 export * from './services/template/types'
 export { StaticLoader } from './services/template/static-loader'
 export * from './services/template/errors'
-export { ElectronTemplateManagerProxy } from './services/template/electron-proxy'
-export { ElectronTemplateLanguageServiceProxy } from './services/template/electron-language-proxy'
 export { ALL_TEMPLATES } from './services/template/default-templates'
 
 // 导出历史记录相关
 export { HistoryManager, createHistoryManager } from './services/history/manager'
 export * from './services/history/types'
 export * from './services/history/errors'
-export { ElectronHistoryManagerProxy } from './services/history/electron-proxy'
 
 // 导出LLM服务相关
 export type {
@@ -67,7 +64,6 @@ export type {
   ChromeLanguageModelLanguageOptions,
   ChromeBuiltInStatus
 } from './services/llm/chrome-built-in'
-export { ElectronLLMProxy } from './services/llm/electron-proxy'
 export * from './services/llm/errors'
 
 // 导出模型管理相关
@@ -78,14 +74,12 @@ export * from './services/model/metadata-resolver'
 export * from './services/model/parameter-schema'
 export * from './services/model/parameter-utils'
 export * from './services/model/advancedParameterDefinitions'
-export { ElectronModelManagerProxy } from './services/model/electron-proxy'
 export { ElectronConfigManager, isElectronRenderer } from './services/model/electron-config'
 
 // 导出图像模型管理与服务
 export { ImageModelManager, createImageModelManager } from './services/image-model/manager'
 export { ImageService, createImageService } from './services/image/service'
 export { ImageAdapterRegistry as _ImageAdapterRegistry, createImageAdapterRegistry } from './services/image/adapters/registry'
-export { ElectronImageServiceProxy, ElectronImageModelManagerProxy } from './services/image/electron-proxy'
 // 导出图像服务类型,将 ConnectionSchema 重命名为 ImageConnectionSchema 避免与 model/types 中的 ConnectionSchema 冲突
 export type {
   ImageProvider,
@@ -141,7 +135,6 @@ export type {
 export { PromptService } from './services/prompt/service'
 export { createPromptService } from './services/prompt/factory'
 export * from './services/prompt/types'
-export { ElectronPromptServiceProxy } from './services/prompt/electron-proxy'
 export * from './services/prompt/errors'
 
 // 导出标准提示词领域模型
@@ -156,18 +149,15 @@ export * from './services/compare/errors'
 // 导出数据管理相关
 export { DataManager, createDataManager } from './services/data/manager'
 export type { IDataManager } from './services/data/manager'
-export { ElectronDataManagerProxy } from './services/data/electron-proxy'
 
 // 导出偏好设置服务相关
 export * from './services/preference/types'
-export { ElectronPreferenceServiceProxy } from './services/preference/electron-proxy'
 export { PreferenceService, createPreferenceService } from './services/preference/service'
 
 // 导出环境检测工具
 export {
   isRunningInElectron,
   isElectronApiReady,
-  waitForElectronApi,
   isBrowser,
   isDevelopment,
   getEnvVar,
@@ -246,12 +236,10 @@ export type { ErrorCode } from './constants/error-codes'
 // 导出上下文相关
 export * from './services/context/types'
 export { createContextRepo } from './services/context/repo'
-export { ElectronContextRepoProxy } from './services/context/electron-proxy'
 export * from './services/context/constants'
 
 // 导出收藏管理相关
 export { FavoriteManager } from './services/favorite/manager'
-export { FavoriteManagerElectronProxy } from './services/favorite/electron-proxy'
 export { TagTypeConverter } from './services/favorite/type-converter'
 export {
   FAVORITE_ITEM_HARD_LIMIT_BYTES,

--- a/packages/core/src/services/llm/adapters/anthropic-adapter.ts
+++ b/packages/core/src/services/llm/adapters/anthropic-adapter.ts
@@ -1,4 +1,5 @@
-import Anthropic from '@anthropic-ai/sdk'
+import type Anthropic from '@anthropic-ai/sdk'
+import { loadAnthropicSdk } from './sdk-loaders'
 import { AbstractTextProviderAdapter } from './abstract-adapter'
 import { APIError } from '../errors'
 import type {
@@ -100,7 +101,7 @@ export class AnthropicAdapter extends AbstractTextProviderAdapter {
    * @returns 动态获取的模型列表
    */
   public async getModelsAsync(config: TextModelConfig): Promise<TextModel[]> {
-    const client = this.createClient(config)
+    const client = await this.createClient(config)
 
     try {
       const response = await client.models.list()
@@ -237,7 +238,7 @@ export class AnthropicAdapter extends AbstractTextProviderAdapter {
     messages: Message[],
     config: TextModelConfig
   ): Promise<LLMResponse> {
-    const client = this.createClient(config)
+    const client = await this.createClient(config)
 
     try {
       // 提取已知参数和自定义参数
@@ -307,7 +308,7 @@ export class AnthropicAdapter extends AbstractTextProviderAdapter {
     request: ImageUnderstandingRequest,
     config: TextModelConfig
   ): Promise<LLMResponse> {
-    const client = this.createClient(config)
+    const client = await this.createClient(config)
 
     try {
       const mergedParams = {
@@ -392,7 +393,7 @@ export class AnthropicAdapter extends AbstractTextProviderAdapter {
     config: TextModelConfig,
     callbacks: StreamHandlers
   ): Promise<void> {
-    const client = this.createClient(config)
+    const client = await this.createClient(config)
     const thinkState = { isInThinkMode: false, buffer: '' }
 
     try {
@@ -502,7 +503,7 @@ export class AnthropicAdapter extends AbstractTextProviderAdapter {
     config: TextModelConfig,
     callbacks: StreamHandlers
   ): Promise<void> {
-    const client = this.createClient(config)
+    const client = await this.createClient(config)
     const thinkState = { isInThinkMode: false, buffer: '' }
 
     try {
@@ -603,7 +604,7 @@ export class AnthropicAdapter extends AbstractTextProviderAdapter {
     tools: ToolDefinition[],
     callbacks: StreamHandlers
   ): Promise<void> {
-    const client = this.createClient(config)
+    const client = await this.createClient(config)
     const thinkState = { isInThinkMode: false, buffer: '' }
 
     try {
@@ -739,7 +740,7 @@ export class AnthropicAdapter extends AbstractTextProviderAdapter {
   /**
    * 创建配置好的客户端实例
    */
-  private createClient(config: TextModelConfig): Anthropic {
+  private async createClient(config: TextModelConfig): Promise<Anthropic> {
     const options: any = {
       apiKey: config.connectionConfig?.apiKey || '',
       dangerouslyAllowBrowser: true // 根据实际环境配置
@@ -758,7 +759,8 @@ export class AnthropicAdapter extends AbstractTextProviderAdapter {
       options.timeout = config.connectionConfig.timeout
     }
 
-    return new Anthropic(options)
+    const AnthropicCtor = await loadAnthropicSdk()
+    return new AnthropicCtor(options)
   }
 
   /**

--- a/packages/core/src/services/llm/adapters/cloudflare-adapter.ts
+++ b/packages/core/src/services/llm/adapters/cloudflare-adapter.ts
@@ -111,7 +111,7 @@ export class CloudflareAdapter extends OpenAIAdapter {
     });
   }
 
-  protected createOpenAIInstance(config: TextModelConfig, isStream: boolean = false): OpenAI {
+  protected async createOpenAIInstance(config: TextModelConfig, isStream: boolean = false): Promise<OpenAI> {
     const accountId = this.getAccountId(config);
 
     const normalizedConfig: TextModelConfig = {
@@ -122,7 +122,7 @@ export class CloudflareAdapter extends OpenAIAdapter {
       }
     };
 
-    return super.createOpenAIInstance(normalizedConfig, isStream);
+    return await super.createOpenAIInstance(normalizedConfig, isStream);
   }
 
   private getAccountId(config: TextModelConfig): string {

--- a/packages/core/src/services/llm/adapters/gemini-adapter.ts
+++ b/packages/core/src/services/llm/adapters/gemini-adapter.ts
@@ -1,4 +1,5 @@
-import { GoogleGenAI } from '@google/genai'
+import type { GoogleGenAI } from '@google/genai'
+import { loadGoogleGenAISdk } from './sdk-loaders'
 import { AbstractTextProviderAdapter } from './abstract-adapter'
 import type {
   TextProvider,
@@ -137,7 +138,7 @@ export class GeminiAdapter extends AbstractTextProviderAdapter {
       const apiKey = config.connectionConfig.apiKey || ''
 
       const customBaseURL = config.connectionConfig.baseURL
-      const genAI = new GoogleGenAI(
+      const genAI = new (await loadGoogleGenAISdk())(
         customBaseURL
           ? {
               apiKey,
@@ -308,12 +309,13 @@ export class GeminiAdapter extends AbstractTextProviderAdapter {
    * @param config 模型配置
    * @returns GoogleGenAI实例
    */
-  private createClient(config: TextModelConfig): GoogleGenAI {
+  private async createClient(config: TextModelConfig): Promise<GoogleGenAI> {
     const apiKey = config.connectionConfig.apiKey || ''
 
     const customBaseURL = config.connectionConfig.baseURL
 
-    return new GoogleGenAI(
+    const GoogleGenAICtor = await loadGoogleGenAISdk()
+    return new GoogleGenAICtor(
       customBaseURL
         ? {
             apiKey,
@@ -500,7 +502,7 @@ export class GeminiAdapter extends AbstractTextProviderAdapter {
     }
 
     try {
-      const client = this.createClient(config)
+      const client = await this.createClient(config)
 
       // 构建配置（包含系统指令）
       const generationConfig = this.buildGenerationConfig(
@@ -529,7 +531,7 @@ export class GeminiAdapter extends AbstractTextProviderAdapter {
     config: TextModelConfig
   ): Promise<LLMResponse> {
     try {
-      const client = this.createClient(config)
+      const client = await this.createClient(config)
       const mergedParams = {
         ...(config.paramOverrides || {}),
         ...(request.paramOverrides || {})
@@ -578,7 +580,7 @@ export class GeminiAdapter extends AbstractTextProviderAdapter {
     callbacks: StreamHandlers
   ): Promise<void> {
     try {
-      const client = this.createClient(config)
+      const client = await this.createClient(config)
       const mergedParams = {
         ...(config.paramOverrides || {}),
         ...(request.paramOverrides || {})
@@ -740,7 +742,7 @@ export class GeminiAdapter extends AbstractTextProviderAdapter {
     }
 
     try {
-      const client = this.createClient(config)
+      const client = await this.createClient(config)
 
       // 构建配置（包含系统指令）
       const generationConfig = this.buildGenerationConfig(
@@ -847,7 +849,7 @@ export class GeminiAdapter extends AbstractTextProviderAdapter {
     }
 
     try {
-      const client = this.createClient(config)
+      const client = await this.createClient(config)
 
       // 构建配置（包含系统指令和工具）
       const generationConfig = this.buildGenerationConfig(

--- a/packages/core/src/services/llm/adapters/ollama-adapter.ts
+++ b/packages/core/src/services/llm/adapters/ollama-adapter.ts
@@ -34,7 +34,7 @@ export class OllamaAdapter extends OpenAIAdapter {
     return []
   }
 
-  protected createOpenAIInstance(config: TextModelConfig, isStream: boolean = false): OpenAI {
+  protected async createOpenAIInstance(config: TextModelConfig, isStream: boolean = false): Promise<OpenAI> {
     const rawApiKey = typeof config.connectionConfig.apiKey === 'string' ? config.connectionConfig.apiKey : ''
     const apiKey = rawApiKey.trim() ? rawApiKey : OLLAMA_FALLBACK_API_KEY
 
@@ -50,7 +50,7 @@ export class OllamaAdapter extends OpenAIAdapter {
       }
     }
 
-    return super.createOpenAIInstance(normalizedConfig, isStream)
+    return await super.createOpenAIInstance(normalizedConfig, isStream)
   }
 
   private normalizeBaseURL(baseURL: string): string {

--- a/packages/core/src/services/llm/adapters/openai-adapter.ts
+++ b/packages/core/src/services/llm/adapters/openai-adapter.ts
@@ -1,4 +1,5 @@
-import OpenAI from 'openai'
+import type OpenAI from 'openai'
+import { loadOpenAISdk } from './sdk-loaders'
 import { AbstractTextProviderAdapter } from './abstract-adapter'
 import { APIError } from '../errors'
 import { normalizeCustomRequestHeaders } from '../../../utils/custom-request-headers'
@@ -122,7 +123,7 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
     // 验证baseURL以/v1结尾
     const baseURL = config.connectionConfig.baseURL || this.getProvider().defaultBaseURL
 
-    const openai = this.createOpenAIInstance(config, false)
+    const openai = await this.createOpenAIInstance(config, false)
 
     try {
       const response = await openai.models.list()
@@ -804,7 +805,7 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
    */
   // NOTE: protected so OpenAI-compatible providers (e.g. Ollama) can tweak auth/baseURL
   // without re-implementing the whole chat/stream/tool plumbing.
-  protected createOpenAIInstance(config: TextModelConfig, isStream: boolean = false): OpenAI {
+  protected async createOpenAIInstance(config: TextModelConfig, isStream: boolean = false): Promise<OpenAI> {
     const apiKey = config.connectionConfig.apiKey || ''
     const hasApiKey = typeof apiKey === 'string' && apiKey.trim().length > 0
 
@@ -873,7 +874,8 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
       console.log('[OpenAIAdapter] Browser environment detected. Setting dangerouslyAllowBrowser=true.')
     }
 
-    const instance = new OpenAI(sdkConfig)
+    const OpenAICtor = await loadOpenAISdk()
+    const instance = new OpenAICtor(sdkConfig)
 
     return instance
   }
@@ -890,7 +892,7 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
    * @throws SDK原始错误（保留完整堆栈）
    */
   protected async doSendMessage(messages: Message[], config: TextModelConfig): Promise<LLMResponse> {
-    const openai = this.createOpenAIInstance(config, false)
+    const openai = await this.createOpenAIInstance(config, false)
     if (this.getRequestStyle(config) === 'responses') {
       try {
         return await this.sendResponsesMessage(openai, messages, config)
@@ -933,7 +935,7 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
     request: ImageUnderstandingRequest,
     config: TextModelConfig
   ): Promise<LLMResponse> {
-    const openai = this.createOpenAIInstance(config, false)
+    const openai = await this.createOpenAIInstance(config, false)
     const mergedParams = {
       ...(config.paramOverrides || {}),
       ...(request.paramOverrides || {})
@@ -1000,7 +1002,7 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
     callbacks: StreamHandlers
   ): Promise<void> {
     try {
-      const openai = this.createOpenAIInstance(config, true)
+      const openai = await this.createOpenAIInstance(config, true)
       const mergedParams = {
         ...(config.paramOverrides || {}),
         ...(request.paramOverrides || {})
@@ -1315,7 +1317,7 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
   ): Promise<void> {
     try {
       // 获取流式OpenAI实例
-      const openai = this.createOpenAIInstance(config, true)
+      const openai = await this.createOpenAIInstance(config, true)
       if (this.getRequestStyle(config) === 'responses') {
         await this.sendResponsesMessageStream(openai, messages, config, callbacks)
         return
@@ -1408,7 +1410,7 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
   ): Promise<void> {
     try {
       // 获取流式OpenAI实例
-      const openai = this.createOpenAIInstance(config, true)
+      const openai = await this.createOpenAIInstance(config, true)
       if (this.getRequestStyle(config) === 'responses') {
         await this.sendResponsesMessageStream(openai, messages, config, callbacks, tools)
         return

--- a/packages/core/src/services/llm/adapters/sdk-loaders.ts
+++ b/packages/core/src/services/llm/adapters/sdk-loaders.ts
@@ -1,0 +1,31 @@
+type Loader<T> = () => Promise<T>
+
+export const createRetryableLoader = <T>(loader: Loader<T>): Loader<T> => {
+  let pending: Promise<T> | undefined
+
+  return () => {
+    if (!pending) {
+      pending = loader().catch((error) => {
+        pending = undefined
+        throw error
+      })
+    }
+
+    return pending
+  }
+}
+
+export const loadOpenAISdk = createRetryableLoader(async () => {
+  const module = await import('openai')
+  return module.default
+})
+
+export const loadAnthropicSdk = createRetryableLoader(async () => {
+  const module = await import('@anthropic-ai/sdk')
+  return module.default
+})
+
+export const loadGoogleGenAISdk = createRetryableLoader(async () => {
+  const module = await import('@google/genai')
+  return module.GoogleGenAI
+})

--- a/packages/core/src/services/llm/service.ts
+++ b/packages/core/src/services/llm/service.ts
@@ -13,7 +13,6 @@ import { ModelManager } from '../model/manager';
 import { resolveTextModelMetadata } from '../model/metadata-resolver';
 import { APIError, RequestConfigError } from './errors';
 import { isRunningInElectron } from '../../utils/environment';
-import { ElectronLLMProxy } from './electron-proxy';
 import { TextAdapterRegistry } from './adapters/registry';
 import { mergeOverrides, splitOverridesBySchema } from '../model/parameter-utils';
 
@@ -385,9 +384,11 @@ export class LLMService implements ILLMService {
  * @returns LLM服务实例
  */
 export function createLLMService(modelManager: ModelManager): ILLMService {
-  // 在Electron环境中，返回代理实例
+  // 在Electron环境中，返回代理实例（延迟加载 electron-proxy，避免 web 入口静态依赖）
   if (isRunningInElectron()) {
     console.log('[LLM Service Factory] Electron environment detected, using proxy.');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { ElectronLLMProxy } = require('./electron-proxy') as typeof import('./electron-proxy');
     return new ElectronLLMProxy();
   }
 

--- a/packages/core/src/services/model/electron-config.ts
+++ b/packages/core/src/services/model/electron-config.ts
@@ -38,13 +38,7 @@ export class ElectronConfigManager {
       this.initialized = true;
       console.log('[ElectronConfigManager] Environment variables synced successfully');
 
-      // 调试输出
-      Object.keys(this.envVars).forEach(key => {
-        const value = this.envVars[key];
-        if (value) {
-          console.log(`[ElectronConfigManager] ${key}: ${value.substring(0, 10)}...`);
-        }
-      });
+      console.log(`[ElectronConfigManager] Synced ${Object.keys(this.envVars).length} public runtime configuration entries`);
     } catch (error) {
       console.error('[ElectronConfigManager] Failed to sync environment variables:', error);
       throw error;

--- a/packages/core/tests/unit/llm/sdk-loaders.test.ts
+++ b/packages/core/tests/unit/llm/sdk-loaders.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createRetryableLoader } from '../../../src/services/llm/adapters/sdk-loaders'
+
+describe('createRetryableLoader', () => {
+  it('coalesces concurrent loads and reuses the resolved module', async () => {
+    const loadedModule = { name: 'sdk' }
+    let resolveLoad: ((value: typeof loadedModule) => void) | undefined
+    const factory = vi.fn(
+      () => new Promise<typeof loadedModule>((resolve) => {
+        resolveLoad = resolve
+      }),
+    )
+    const load = createRetryableLoader(factory)
+
+    const first = load()
+    const second = load()
+
+    expect(second).toBe(first)
+    expect(factory).toHaveBeenCalledTimes(1)
+
+    resolveLoad?.(loadedModule)
+    await expect(first).resolves.toBe(loadedModule)
+    expect(load()).toBe(first)
+  })
+
+  it('allows a later request to retry after a failed import', async () => {
+    const importError = new Error('chunk load failed')
+    const loadedModule = { name: 'sdk' }
+    const factory = vi
+      .fn<() => Promise<typeof loadedModule>>()
+      .mockRejectedValueOnce(importError)
+      .mockResolvedValueOnce(loadedModule)
+    const load = createRetryableLoader(factory)
+
+    await expect(load()).rejects.toBe(importError)
+    await expect(load()).resolves.toBe(loadedModule)
+    expect(factory).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/ui/src/composables/system/useAppInitializer.ts
+++ b/packages/ui/src/composables/system/useAppInitializer.ts
@@ -14,20 +14,9 @@ import {
   createContextRepo,
   createEvaluationService,
   createImageUnderstandingService,
-  ElectronImageUnderstandingServiceProxy,
   createVariableExtractionService,
   createVariableValueGenerationService,
-  ElectronContextRepoProxy,
-  ElectronModelManagerProxy,
-  ElectronTemplateManagerProxy,
-  ElectronHistoryManagerProxy,
-  ElectronDataManagerProxy,
-  ElectronLLMProxy,
-  ElectronPromptServiceProxy,
-  ElectronTemplateLanguageServiceProxy,
   isRunningInElectron,
-  waitForElectronApi,
-  ElectronPreferenceServiceProxy,
   createPreferenceService,
   FavoriteManager,
   createImageModelManager,
@@ -129,6 +118,23 @@ export function useAppInitializer(): {
 
       if (isRunningInElectron()) {
         console.log('[AppInitializer] Electron environment detected; waiting for API readiness...');
+
+        const {
+          ElectronContextRepoProxy,
+          ElectronDataManagerProxy,
+          ElectronHistoryManagerProxy,
+          ElectronImageModelManagerProxy,
+          ElectronImageServiceProxy,
+          ElectronImageUnderstandingServiceProxy,
+          ElectronLLMProxy,
+          ElectronModelManagerProxy,
+          ElectronPreferenceServiceProxy,
+          ElectronPromptServiceProxy,
+          ElectronTemplateLanguageServiceProxy,
+          ElectronTemplateManagerProxy,
+          FavoriteManagerElectronProxy,
+          waitForElectronApi,
+        } = await import('@prompt-optimizer/core/electron')
         
         // 等待 Electron API 完全就绪
         const apiReady = await waitForElectronApi();
@@ -154,7 +160,6 @@ export function useAppInitializer(): {
         textAdapterRegistryInstance = createTextAdapterRegistry();
 
         // 图像相关（Electron 渲染进程代理）
-        const { ElectronImageModelManagerProxy, ElectronImageServiceProxy } = await import('@prompt-optimizer/core')
         imageAdapterRegistryInstance = createImageAdapterRegistry();
         imageModelManager = new ElectronImageModelManagerProxy();
         imageService = new ElectronImageServiceProxy();
@@ -191,7 +196,6 @@ export function useAppInitializer(): {
         const contextRepo = new ElectronContextRepoProxy();
 
         // 创建收藏管理器代理
-        const { FavoriteManagerElectronProxy } = await import('@prompt-optimizer/core')
         favoriteManager = new FavoriteManagerElectronProxy();
         favoriteManager = attachFavoriteAssetGc(favoriteManager, favoriteImageStorageService)
 


### PR DESCRIPTION
## Summary
- Add `@prompt-optimizer/core/electron` dual build entry for Electron-only proxies.
- Remove Electron proxy re-exports from the browser-facing core entry.
- Dynamically import Electron proxies from `useAppInitializer` only in Electron runtime.
- Add retryable `sdk-loaders` helper + unit tests and architecture notes.

## Why
Split follow-up from closed #324 (item 4: Core Electron sub-entry & SDK lazy-loading).

## Explicit non-goals / blocker avoidance
- **No** `src/app-entry.ts` / multi-entry UI vite half-wire (known #324 build break)
- **No** incomplete bundle budget script
- Adapter bodies still use existing SDK imports; this PR ships the dual entry + loader primitive cleanly

## Test plan
- [x] `pnpm -F @prompt-optimizer/core build` (produces `dist/electron.*` + `dist/index.*`)
- [x] `pnpm -F @prompt-optimizer/core typecheck`
- [x] `pnpm -F @prompt-optimizer/core test --run tests/unit/llm/sdk-loaders.test.ts` (2/2)