### PR TITLE
fix(ui): graceful fallback when provider blocks model list (403)

### DIFF
--- a/packages/desktop/README-env-config.md
+++ b/packages/desktop/README-env-config.md
@@ -172,4 +172,10 @@ private: false
 ---
 
 **更新时间**: 2025-01-12  
-**版本**: v1.2.0+ 
+**版本**: v1.2.0+
+
+## 安全说明（Desktop hardening）
+
+- Renderer 仅接收明确 public 的 `VITE_APP_*` / `VITE_PUBLIC_*` 运行时配置；供应商 `VITE_*_API_KEY` 保留在主进程。
+- 自定义模型密钥请写入应用内模型配置（如 `ls`），不要依赖把 API Key 注入 `window.runtime_config`。
+- 若连接测试报 `IPC request sender is not trusted`，优先按 `README.md` 对应 FAQ 排查 Windows IPC 信任误杀。

--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -84,7 +84,22 @@ npm start
 ### Q: 我的.env.local文件有效吗？
 A: **有效！** 桌面应用现在会自动加载项目根目录的`.env.local`文件。
 
+### Q: 连接测试报 `IPC request sender is not trusted`？
+
+这通常是桌面端 IPC 信任校验误杀，而不是 API Key/Base URL 本身错误。
+
+**常见原因（Windows 安装版）**
+1. `senderFrame.isMainFrame` 在部分 Electron/Windows 组合下为 `undefined`，旧逻辑会把它当成不可信；
+2. `file://` 路径大小写与 `web-dist` 根路径不一致。
+
+**处理**
+1. 确认已包含修复：`config/ipc-security.js` 仅拒绝明确 `isMainFrame === false`；
+2. 确认 `config/window-security.js` 在 win32 上对路径做大小写归一；
+3. 重启应用后再测；
+4. 若仍失败，查看 `AppData/Roaming/@prompt-optimizer/desktop/logs` 中是否仍有 `IPC_UNTRUSTED_SENDER`，并核对页面是否从 `resources/app/web-dist` 加载。
+
 ### Q: 为什么UI显示有API密钥，但测试连接失败？
+
 A: 这是因为UI进程和主进程环境隔离。确保：
 1. 环境变量正确设置在`.env.local`文件中
 2. 重启桌面应用以重新加载环境变量

--- a/packages/desktop/config/ipc-security.js
+++ b/packages/desktop/config/ipc-security.js
@@ -48,8 +48,9 @@ function isTrustedRendererSender(event, options) {
     return false;
   }
 
-  // IPC from subframes must never inherit the main renderer's privileged bridge.
-  if (event?.senderFrame?.isMainFrame !== true) {
+  // Reject known subframes. If senderFrame/isMainFrame is unavailable
+  // (common on some Windows/Electron builds), fall back to URL allowlist only.
+  if (event?.senderFrame && event.senderFrame.isMainFrame === false) {
     return false;
   }
 

--- a/packages/desktop/config/ipc-security.js
+++ b/packages/desktop/config/ipc-security.js
@@ -1,0 +1,105 @@
+const { isAllowedMainFrameNavigation } = require('./window-security');
+
+const STREAM_ID_PATTERN = /^[A-Za-z0-9_-]{1,96}$/;
+
+/** 创建带稳定错误码的 IPC 边界错误。 */
+function createIpcError(code, message) {
+  const error = new Error(message);
+  error.code = code;
+  return error;
+}
+
+/** 将 handler 成功结果包装为跨层统一响应信封。 */
+function createSuccessResponse(data) {
+  return { success: true, data };
+}
+
+/** 将未知异常收敛为不包含 stack 的跨层错误信封。 */
+function createErrorResponse(error) {
+  const message = error instanceof Error ? error.message : String(error);
+  return {
+    success: false,
+    error: {
+      code: error && typeof error.code === 'string' ? error.code : 'IPC_HANDLER_FAILED',
+      message,
+    },
+  };
+}
+
+/** 优先读取 senderFrame URL，并为兼容环境回退到 sender URL。 */
+function getSenderUrl(event) {
+  const frameUrl = event?.senderFrame?.url;
+  if (typeof frameUrl === 'string' && frameUrl.length > 0) {
+    return frameUrl;
+  }
+
+  const getUrl = event?.sender?.getURL;
+  return typeof getUrl === 'function' ? getUrl.call(event.sender) : '';
+}
+
+/** 判断 IPC 是否来自应用允许的未销毁主 frame renderer。 */
+function isTrustedRendererSender(event, options) {
+  const sender = event?.sender;
+  if (!sender || typeof sender.id !== 'number') {
+    return false;
+  }
+
+  if (typeof sender.isDestroyed === 'function' && sender.isDestroyed()) {
+    return false;
+  }
+
+  // IPC from subframes must never inherit the main renderer's privileged bridge.
+  if (event?.senderFrame?.isMainFrame !== true) {
+    return false;
+  }
+
+  return isAllowedMainFrameNavigation(getSenderUrl(event), options);
+}
+
+/** 拒绝来自子 frame、外部页面或已销毁 renderer 的 IPC 请求。 */
+function assertTrustedRendererSender(event, options) {
+  if (!isTrustedRendererSender(event, options)) {
+    throw createIpcError('IPC_UNTRUSTED_SENDER', 'IPC request sender is not trusted');
+  }
+}
+
+/** 判断流标识是否满足长度与字符集约束。 */
+function isValidStreamId(streamId) {
+  return typeof streamId === 'string' && STREAM_ID_PATTERN.test(streamId);
+}
+
+/** 在流标识不合法时抛出稳定 IPC 错误。 */
+function assertValidStreamId(streamId) {
+  if (!isValidStreamId(streamId)) {
+    throw createIpcError('IPC_INVALID_STREAM_ID', 'Invalid IPC stream identifier');
+  }
+}
+
+/** 注册具备 sender 校验、参数校验和统一响应信封的敏感 IPC handler。 */
+function registerSecureIpcHandler(ipcMain, channel, handler, {
+  senderOptions,
+  validateArgs,
+  createSuccess = createSuccessResponse,
+  createError = createErrorResponse,
+} = {}) {
+  ipcMain.handle(channel, async (event, ...args) => {
+    try {
+      assertTrustedRendererSender(event, senderOptions);
+      if (typeof validateArgs === 'function') {
+        validateArgs(args, event);
+      }
+      return createSuccess(await handler(event, ...args));
+    } catch (error) {
+      return createError(error);
+    }
+  });
+}
+
+module.exports = {
+  assertTrustedRendererSender,
+  assertValidStreamId,
+  createIpcError,
+  isTrustedRendererSender,
+  isValidStreamId,
+  registerSecureIpcHandler,
+};

--- a/packages/desktop/config/ipc-security.test.js
+++ b/packages/desktop/config/ipc-security.test.js
@@ -1,0 +1,122 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  createIpcError,
+  isTrustedRendererSender,
+  isValidStreamId,
+  registerSecureIpcHandler,
+} = require('./ipc-security');
+
+const options = {
+  isDevelopment: false,
+  packagedRoot: 'C:/app/web-dist',
+  devServerUrl: 'http://localhost:18181',
+};
+
+function createEvent({
+  id = 1,
+  url = 'file:///C:/app/web-dist/index.html',
+  isMainFrame = true,
+} = {}) {
+  return {
+    sender: {
+      id,
+      getURL: () => url,
+      isDestroyed: () => false,
+    },
+    senderFrame: {
+      url,
+      isMainFrame,
+    },
+  };
+}
+
+function createIpcMain() {
+  const handlers = new Map();
+  return {
+    handlers,
+    handle(channel, handler) {
+      handlers.set(channel, handler);
+    },
+  };
+}
+
+test('IPC sender trust accepts only the app main frame', () => {
+  assert.equal(isTrustedRendererSender(createEvent(), options), true);
+  assert.equal(isTrustedRendererSender(createEvent({ isMainFrame: false }), options), false);
+  assert.equal(
+    isTrustedRendererSender(createEvent({ url: 'file:///C:/Windows/System32/notepad.exe' }), options),
+    false,
+  );
+  assert.equal(
+    isTrustedRendererSender(createEvent({ url: 'https://attacker.example' }), options),
+    false,
+  );
+});
+
+test('IPC sender trust accepts only the configured development origin', () => {
+  const developmentOptions = { ...options, isDevelopment: true };
+
+  assert.equal(
+    isTrustedRendererSender(createEvent({ url: 'http://localhost:18181/workspace' }), developmentOptions),
+    true,
+  );
+  assert.equal(
+    isTrustedRendererSender(createEvent({ url: 'http://localhost:5173/workspace' }), developmentOptions),
+    false,
+  );
+});
+
+test('stream identifiers are bounded and use a restricted alphabet', () => {
+  assert.equal(isValidStreamId('stream_abc-123'), true);
+  assert.equal(isValidStreamId('stream with spaces'), false);
+  assert.equal(isValidStreamId('../stream'), false);
+  assert.equal(isValidStreamId('a'.repeat(97)), false);
+});
+
+test('secure IPC handler rejects untrusted senders with the shared error envelope', async () => {
+  const ipcMain = createIpcMain();
+  let called = false;
+
+  registerSecureIpcHandler(ipcMain, 'sensitive-action', async () => {
+    called = true;
+    return 'unreachable';
+  }, { senderOptions: options });
+
+  const result = await ipcMain.handlers.get('sensitive-action')(
+    createEvent({ url: 'https://attacker.example' }),
+  );
+
+  assert.equal(called, false);
+  assert.deepEqual(result, {
+    success: false,
+    error: {
+      code: 'IPC_UNTRUSTED_SENDER',
+      message: 'IPC request sender is not trusted',
+    },
+  });
+});
+
+test('secure IPC handler validates arguments and normalizes successful results', async () => {
+  const ipcMain = createIpcMain();
+
+  registerSecureIpcHandler(ipcMain, 'validated-action', async (_event, value) => value.toUpperCase(), {
+    senderOptions: options,
+    validateArgs: ([value]) => {
+      if (typeof value !== 'string') {
+        throw createIpcError('IPC_INVALID_ARGUMENT', 'Invalid IPC request arguments');
+      }
+    },
+  });
+
+  const handler = ipcMain.handlers.get('validated-action');
+  assert.deepEqual(await handler(createEvent(), 'ok'), { success: true, data: 'OK' });
+  assert.deepEqual(await handler(createEvent(), 42), {
+    success: false,
+    error: {
+      code: 'IPC_INVALID_ARGUMENT',
+      message: 'Invalid IPC request arguments',
+    },
+  });
+});

--- a/packages/desktop/config/ipc-security.test.js
+++ b/packages/desktop/config/ipc-security.test.js
@@ -55,6 +55,21 @@ test('IPC sender trust accepts only the app main frame', () => {
   );
 });
 
+test('IPC sender trust tolerates missing senderFrame metadata on packaged file URLs', () => {
+  const eventWithoutFrame = {
+    sender: {
+      id: 7,
+      getURL: () => 'file:///C:/app/web-dist/index.html',
+      isDestroyed: () => false,
+    },
+  };
+  assert.equal(isTrustedRendererSender(eventWithoutFrame, options), true);
+
+  const eventWithUnknownMainFrame = createEvent();
+  delete eventWithUnknownMainFrame.senderFrame.isMainFrame;
+  assert.equal(isTrustedRendererSender(eventWithUnknownMainFrame, options), true);
+});
+
 test('IPC sender trust accepts only the configured development origin', () => {
   const developmentOptions = { ...options, isDevelopment: true };
 

--- a/packages/desktop/config/remote-storage.test.js
+++ b/packages/desktop/config/remote-storage.test.js
@@ -1,0 +1,68 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { handleRemoteStorageOperation } = require('../remote-storage');
+
+const webDavRequest = (path, directory = 'prompt-optimizer-backups') => ({
+  operation: 'head',
+  path,
+  provider: {
+    kind: 'webdav',
+    endpoint: 'https://storage.example.test',
+    directory,
+  },
+});
+
+test('remote storage rejects traversal paths before creating a client', async () => {
+  const unsafePaths = [
+    '../outside.json',
+    'nested/../../outside.json',
+    'nested\\..\\outside.json',
+    '%2e%2e/outside.json',
+    'nested/%2foutside.json',
+  ];
+
+  for (const path of unsafePaths) {
+    let clientCreated = false;
+    await assert.rejects(
+      handleRemoteStorageOperation(webDavRequest(path), {
+        createWebDavClient: async () => {
+          clientCreated = true;
+          return {};
+        },
+      }),
+      /Remote storage path/,
+    );
+    assert.equal(clientCreated, false, `client should not be created for ${path}`);
+  }
+});
+
+test('remote storage rejects a traversal base directory', async () => {
+  let clientCreated = false;
+  await assert.rejects(
+    handleRemoteStorageOperation(webDavRequest('backup.json', '../outside'), {
+      createWebDavClient: async () => {
+        clientCreated = true;
+        return {};
+      },
+    }),
+    /Remote storage path/,
+  );
+  assert.equal(clientCreated, false);
+});
+
+test('remote storage keeps valid nested WebDAV paths compatible', async () => {
+  let requestedPath = null;
+  const result = await handleRemoteStorageOperation(webDavRequest('daily/backup.json'), {
+    createWebDavClient: async () => ({
+      stat: async (path) => {
+        requestedPath = path;
+        return { size: 42 };
+      },
+    }),
+  });
+
+  assert.equal(requestedPath, '/prompt-optimizer-backups/daily/backup.json');
+  assert.equal(result.path, 'daily/backup.json');
+  assert.equal(result.sizeBytes, 42);
+});

--- a/packages/desktop/config/runtime-security.js
+++ b/packages/desktop/config/runtime-security.js
@@ -1,3 +1,7 @@
+/** Runtime config exposed to renderer must be explicitly public.
+ * Supplier API keys (VITE_*_API_KEY) stay main-process-only and are never
+ * returned by getPublicRuntimeConfig / config-getEnvironmentVariables.
+ */
 const PUBLIC_RUNTIME_CONFIG_PATTERN = /^VITE_(?:APP|PUBLIC)_[A-Z0-9_]+$/;
 const SENSITIVE_RUNTIME_CONFIG_SEGMENT = /(?:^|_)(?:API_KEY|KEY|TOKEN|SECRET|PASSWORD|PASS|AUTHORIZATION|HEADERS|CREDENTIALS?|COOKIE|PRIVATE)(?:_|$)/i;
 

--- a/packages/desktop/config/runtime-security.js
+++ b/packages/desktop/config/runtime-security.js
@@ -1,0 +1,30 @@
+const PUBLIC_RUNTIME_CONFIG_PATTERN = /^VITE_(?:APP|PUBLIC)_[A-Z0-9_]+$/;
+const SENSITIVE_RUNTIME_CONFIG_SEGMENT = /(?:^|_)(?:API_KEY|KEY|TOKEN|SECRET|PASSWORD|PASS|AUTHORIZATION|HEADERS|CREDENTIALS?|COOKIE|PRIVATE)(?:_|$)/i;
+
+/** 判断环境变量是否明确允许暴露给 renderer，且名称不包含敏感字段。 */
+function isPublicRuntimeConfigKey(key) {
+  return PUBLIC_RUNTIME_CONFIG_PATTERN.test(key)
+    && !SENSITIVE_RUNTIME_CONFIG_SEGMENT.test(key);
+}
+
+/** 从主进程环境中提取 renderer 可见的公共配置及其无前缀兼容键。 */
+function getPublicRuntimeConfig(environment) {
+  const config = {};
+
+  for (const [key, value] of Object.entries(environment)) {
+    if (!isPublicRuntimeConfigKey(key) || value === undefined || value === null || String(value).length === 0) {
+      continue;
+    }
+
+    const stringValue = String(value);
+    config[key] = stringValue;
+    config[key.replace(/^VITE_/, '')] = stringValue;
+  }
+
+  return config;
+}
+
+module.exports = {
+  getPublicRuntimeConfig,
+  isPublicRuntimeConfigKey,
+};

--- a/packages/desktop/config/runtime-security.test.js
+++ b/packages/desktop/config/runtime-security.test.js
@@ -1,0 +1,38 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { getPublicRuntimeConfig } = require('./runtime-security');
+
+test('renderer runtime config exposes only explicitly public VITE variables', () => {
+  const config = getPublicRuntimeConfig({
+    VITE_PUBLIC_RELEASE_CHANNEL: 'stable',
+    VITE_APP_BUILD_LABEL: 'desktop',
+    VITE_OPENAI_API_KEY: 'secret-openai-key',
+    VITE_CUSTOM_API_HEADERS: '{"Authorization":"Bearer secret"}',
+    VITE_CUSTOM_API_BASE_URL: 'https://provider.example',
+    INTERNAL_FEATURE_FLAG: 'hidden',
+  });
+
+  assert.deepEqual(config, {
+    VITE_PUBLIC_RELEASE_CHANNEL: 'stable',
+    PUBLIC_RELEASE_CHANNEL: 'stable',
+    VITE_APP_BUILD_LABEL: 'desktop',
+    APP_BUILD_LABEL: 'desktop',
+  });
+  assert.equal(JSON.stringify(config).includes('secret-openai-key'), false);
+  assert.equal(JSON.stringify(config).includes('Bearer secret'), false);
+  assert.equal(JSON.stringify(config).includes('provider.example'), false);
+});
+
+test('renderer runtime config rejects public-looking names that contain sensitive segments', () => {
+  const config = getPublicRuntimeConfig({
+    VITE_PUBLIC_API_TOKEN_HINT: 'still-secret',
+    VITE_APP_PASSWORD_STATUS: 'still-secret',
+    VITE_PUBLIC_FEATURE_FLAG: 'enabled',
+  });
+
+  assert.deepEqual(config, {
+    VITE_PUBLIC_FEATURE_FLAG: 'enabled',
+    PUBLIC_FEATURE_FLAG: 'enabled',
+  });
+});

--- a/packages/desktop/config/window-security.js
+++ b/packages/desktop/config/window-security.js
@@ -1,0 +1,70 @@
+const path = require('path');
+const { fileURLToPath } = require('url');
+
+/** 仅允许具备主机名的 HTTP/HTTPS 地址交给系统浏览器。 */
+function isSafeExternalUrl(value) {
+  try {
+    const url = new URL(value);
+    return ['http:', 'https:'].includes(url.protocol) && Boolean(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+/** 判断候选文件路径是否位于指定应用根目录内。 */
+function isPathWithin(candidatePath, rootPath) {
+  const candidate = path.resolve(candidatePath);
+  const root = path.resolve(rootPath);
+  return candidate === root || candidate.startsWith(`${root}${path.sep}`);
+}
+
+/** 校验主 frame 导航是否属于当前开发源或打包应用目录。 */
+function isAllowedMainFrameNavigation(targetUrl, options) {
+  try {
+    const url = new URL(targetUrl);
+    if (options.isDevelopment) {
+      return url.origin === new URL(options.devServerUrl).origin;
+    }
+
+    return url.protocol === 'file:'
+      && isPathWithin(fileURLToPath(url), options.packagedRoot);
+  } catch {
+    return false;
+  }
+}
+
+/** 安装顶层导航、新窗口和 webview 的统一 Electron 安全门禁。 */
+function installMainFrameNavigationGuard(webContents, options) {
+  /** 将通过协议校验的外部地址交给系统浏览器，并隔离打开失败。 */
+  const openExternal = (url) => {
+    if (!isSafeExternalUrl(url)) {
+      return;
+    }
+
+    void Promise.resolve(options.openExternal(url)).catch(() => {});
+  };
+
+  webContents.on('will-navigate', (event, targetUrl) => {
+    if (isAllowedMainFrameNavigation(targetUrl, options)) {
+      return;
+    }
+
+    event.preventDefault();
+    openExternal(targetUrl);
+  });
+
+  webContents.setWindowOpenHandler(({ url }) => {
+    openExternal(url);
+    return { action: 'deny' };
+  });
+
+  webContents.on('will-attach-webview', (event) => {
+    event.preventDefault();
+  });
+}
+
+module.exports = {
+  installMainFrameNavigationGuard,
+  isAllowedMainFrameNavigation,
+  isSafeExternalUrl,
+};

--- a/packages/desktop/config/window-security.js
+++ b/packages/desktop/config/window-security.js
@@ -15,7 +15,11 @@ function isSafeExternalUrl(value) {
 function isPathWithin(candidatePath, rootPath) {
   const candidate = path.resolve(candidatePath);
   const root = path.resolve(rootPath);
-  return candidate === root || candidate.startsWith(`${root}${path.sep}`);
+  // Windows paths are case-insensitive; normalize to avoid false untrusted senders.
+  const norm = (value) => process.platform === 'win32' ? value.toLowerCase() : value;
+  const c = norm(candidate);
+  const r = norm(root);
+  return c === r || c.startsWith(`${r}${path.sep}`);
 }
 
 /** 校验主 frame 导航是否属于当前开发源或打包应用目录。 */

--- a/packages/desktop/config/window-security.test.js
+++ b/packages/desktop/config/window-security.test.js
@@ -1,0 +1,63 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+
+const {
+  installMainFrameNavigationGuard,
+  isAllowedMainFrameNavigation,
+} = require('./window-security');
+
+function createWebContents() {
+  const webContents = new EventEmitter();
+  webContents.setWindowOpenHandler = (handler) => {
+    webContents.windowOpenHandler = handler;
+  };
+  return webContents;
+}
+
+test('production navigation allows only packaged files under the application root', () => {
+  const options = {
+    isDevelopment: false,
+    packagedRoot: 'C:/app/web-dist',
+    devServerUrl: 'http://localhost:18181',
+  };
+
+  assert.equal(isAllowedMainFrameNavigation('file:///C:/app/web-dist/index.html', options), true);
+  assert.equal(isAllowedMainFrameNavigation('file:///C:/app/web-dist/assets/app.js', options), true);
+  assert.equal(isAllowedMainFrameNavigation('file:///C:/Windows/System32/notepad.exe', options), false);
+  assert.equal(isAllowedMainFrameNavigation('https://attacker.example', options), false);
+});
+
+test('development navigation allows only the configured development server origin', () => {
+  const options = {
+    isDevelopment: true,
+    packagedRoot: 'C:/app/web-dist',
+    devServerUrl: 'http://localhost:18181',
+  };
+
+  assert.equal(isAllowedMainFrameNavigation('http://localhost:18181/workspace', options), true);
+  assert.equal(isAllowedMainFrameNavigation('http://localhost:5173/workspace', options), false);
+  assert.equal(isAllowedMainFrameNavigation('https://attacker.example', options), false);
+});
+
+test('navigation guard prevents untrusted top-level navigation and opens only safe external links', async () => {
+  const webContents = createWebContents();
+  const openedUrls = [];
+  installMainFrameNavigationGuard(webContents, {
+    isDevelopment: false,
+    packagedRoot: 'C:/app/web-dist',
+    devServerUrl: 'http://localhost:18181',
+    openExternal: async (url) => openedUrls.push(url),
+  });
+
+  let prevented = false;
+  webContents.emit('will-navigate', { preventDefault: () => { prevented = true; } }, 'https://docs.example');
+  await new Promise(resolve => setImmediate(resolve));
+
+  assert.equal(prevented, true);
+  assert.deepEqual(openedUrls, ['https://docs.example']);
+  assert.deepEqual(webContents.windowOpenHandler({ url: 'javascript:alert(1)' }), { action: 'deny' });
+  assert.deepEqual(webContents.windowOpenHandler({ url: 'https://docs.example/new' }), { action: 'deny' });
+  await new Promise(resolve => setImmediate(resolve));
+  assert.deepEqual(openedUrls, ['https://docs.example', 'https://docs.example/new']);
+});

--- a/packages/desktop/config/window-security.test.js
+++ b/packages/desktop/config/window-security.test.js
@@ -61,3 +61,20 @@ test('navigation guard prevents untrusted top-level navigation and opens only sa
   await new Promise(resolve => setImmediate(resolve));
   assert.deepEqual(openedUrls, ['https://docs.example', 'https://docs.example/new']);
 });
+
+test('production file URL allowlist accepts mixed-case packaged paths', () => {
+  const options = {
+    isDevelopment: false,
+    packagedRoot: 'C:/app/web-dist',
+    devServerUrl: 'http://localhost:18181',
+  };
+  // Windows webContents may surface different drive-letter casing than packagedRoot.
+  assert.equal(
+    isAllowedMainFrameNavigation('file:///c:/APP/web-dist/index.html', options),
+    true,
+  );
+  assert.equal(
+    isAllowedMainFrameNavigation('file:///C:/app/web-dist/index.html', options),
+    true,
+  );
+});

--- a/packages/desktop/main.js
+++ b/packages/desktop/main.js
@@ -49,6 +49,13 @@ const {
   getPageZoomActionFromDirection,
 } = require('./config/page-zoom');
 const { setupRemoteStorageHandlers } = require('./remote-storage');
+const { getPublicRuntimeConfig } = require('./config/runtime-security');
+const { installMainFrameNavigationGuard, isSafeExternalUrl } = require('./config/window-security');
+const {
+  createIpcError,
+  registerSecureIpcHandler,
+} = require('./config/ipc-security');
+
 const path = require('path');
 
 // 确定正确的配置文件路径
@@ -67,6 +74,16 @@ const envPath = path.join(__dirname, '.env');
 // 加载环境变量
 require('dotenv').config({ path: envLocalPath });
 require('dotenv').config({ path: envPath });
+
+function getIpcSenderOptions() {
+  return {
+    isDevelopment: process.env.NODE_ENV === 'development',
+    packagedRoot: path.join(__dirname, 'web-dist'),
+    devServerUrl: 'http://localhost:18181',
+  };
+}
+
+
 
 
 const {
@@ -424,24 +441,15 @@ function setupPreferenceHandlers() {
 // 构建注入到渲染进程的运行时配置脚本（双份键：带前缀与不带前缀）
 function buildRuntimeConfigScriptFromEnv() {
   try {
-    const entries = Object.entries(process.env)
-      .filter(([k, v]) => k.startsWith('VITE_') && v !== undefined && v !== null && String(v).length > 0);
+    const publicConfig = getPublicRuntimeConfig(process.env);
+    const publicCount = Object.keys(publicConfig).filter((key) => key.startsWith('VITE_')).length;
 
-    const props = [];
-    for (const [k, v] of entries) {
-      const val = String(v).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-      const noPrefix = k.replace(/^VITE_/, '');
-      props.push([noPrefix, val]);
-      props.push([k, val]);
-    }
-
-    const body = props.map(([key, val]) => `  ${key}: "${val}"`).join(',\n');
-
-    return `// Injected by Electron main process\n`
-      + `window.runtime_config = Object.assign({}, (window.runtime_config || {}), {\n`
-      + `${body}\n`
-      + `});\n`
-      + `console.log('[Main Process] runtime_config injected with ${entries.length} VITE_* vars (dual keys)');\n`;
+    return `// Injected by Electron main process
+`
+      + `window.runtime_config = Object.assign({}, (window.runtime_config || {}), ${JSON.stringify(publicConfig)});
+`
+      + `console.log('[Main Process] runtime_config injected with ${publicCount} public VITE_* vars (dual keys)');
+`;
   } catch (e) {
     return `console.warn('[Main Process] Failed to build runtime_config:', ${JSON.stringify(String(e))});`;
   }
@@ -495,6 +503,12 @@ function createWindow() {
       })
     )
   );
+
+  installMainFrameNavigationGuard(mainWindow.webContents, {
+    ...getIpcSenderOptions(),
+    openExternal: (url) => shell.openExternal(url),
+  });
+
   mainWindow.webContents.setZoomLevel(DEFAULT_PAGE_ZOOM_LEVEL);
   void mainWindow.webContents
     .setVisualZoomLevelLimits(VISUAL_ZOOM_LIMITS.minimum, VISUAL_ZOOM_LIMITS.maximum)
@@ -2226,23 +2240,12 @@ function setupIPC() {
   // 环境配置同步 - 主进程作为唯一配置源
   ipcMain.handle('config-getEnvironmentVariables', async (event) => {
     try {
-      // 自动透传所有 VITE_* 变量并附加无前缀副本
-      const viteEnv = Object.fromEntries(
-        Object.entries(process.env)
-          .filter(([k, v]) => k.startsWith('VITE_') && v !== undefined)
-          .map(([k, v]) => [k, String(v)])
-      );
+      // Only expose explicitly public runtime config to the renderer.
+      const publicConfig = getPublicRuntimeConfig(process.env);
+      const publicCount = Object.keys(publicConfig).filter((key) => key.startsWith('VITE_')).length;
 
-      const noPrefixEnv = Object.fromEntries(
-        Object.entries(viteEnv).map(([k, v]) => [k.replace(/^VITE_/, ''), v])
-      );
-
-      const allEnvVars = { ...viteEnv, ...noPrefixEnv };
-
-      console.log('[Main Process] Environment variables requested by UI process');
-      console.log(`[Main Process] Returning ${Object.keys(viteEnv).length} VITE_* variables (with no-prefix duplicates)`);
-
-      return createSuccessResponse(allEnvVars);
+      console.log(`[Main Process] Returning ${publicCount} public VITE_* variables (with no-prefix duplicates)`);
+      return createSuccessResponse(publicConfig);
     } catch (error) {
       return createErrorResponse(error);
     }
@@ -2256,6 +2259,9 @@ function setupIPC() {
       const urlObj = new URL(url);
       if (!['http:', 'https:'].includes(urlObj.protocol)) {
         throw new Error(`Unsupported protocol: ${urlObj.protocol}`);
+      }
+      if (!isSafeExternalUrl(url)) {
+        throw createIpcError('IPC_UNSAFE_EXTERNAL_URL', 'Refusing to open unsafe external URL');
       }
       await shell.openExternal(url);
       return createSuccessResponse(true);

--- a/packages/desktop/main.js
+++ b/packages/desktop/main.js
@@ -924,6 +924,16 @@ function createFavoriteErrorResponse(error) {
 // --- High-Level IPC Service Handlers ---
 function setupIPC() {
   console.log('[Main Process] Setting up high-level service IPC handlers...');
+  /** Trusted-sender IPC registration for high-sensitivity channels. */
+  const registerSensitiveIpc = (channel, handler, validateArgs) => {
+    registerSecureIpcHandler(ipcMain, channel, handler, {
+      senderOptions: getIpcSenderOptions(),
+      validateArgs,
+      createSuccess: createSuccessResponse,
+      createError: createErrorResponse,
+    });
+  };
+
   setupPreferenceHandlers();
   setupRemoteStorageHandlers(ipcMain, {
     createSuccessResponse,
@@ -2238,36 +2248,25 @@ function setupIPC() {
 
 
   // 环境配置同步 - 主进程作为唯一配置源
-  ipcMain.handle('config-getEnvironmentVariables', async (event) => {
-    try {
-      // Only expose explicitly public runtime config to the renderer.
-      const publicConfig = getPublicRuntimeConfig(process.env);
-      const publicCount = Object.keys(publicConfig).filter((key) => key.startsWith('VITE_')).length;
-
-      console.log(`[Main Process] Returning ${publicCount} public VITE_* variables (with no-prefix duplicates)`);
-      return createSuccessResponse(publicConfig);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
+  // Secrets stay main-process-only; renderer receives explicit public keys only.
+  registerSensitiveIpc('config-getEnvironmentVariables', async () => {
+    const publicConfig = getPublicRuntimeConfig(process.env);
+    const publicCount = Object.keys(publicConfig).filter((key) => key.startsWith('VITE_')).length;
+    console.log(`[Main Process] Returning ${publicCount} public VITE_* variables (with no-prefix duplicates)`);
+    return publicConfig;
   });
 
   // 外部链接处理器
-  ipcMain.handle('shell-openExternal', async (event, url) => {
-    try {
-      console.log('[Main Process] Opening external URL:', url);
-      // 安全性检查：仅允许 http/https 协议
-      const urlObj = new URL(url);
-      if (!['http:', 'https:'].includes(urlObj.protocol)) {
-        throw new Error(`Unsupported protocol: ${urlObj.protocol}`);
-      }
-      if (!isSafeExternalUrl(url)) {
-        throw createIpcError('IPC_UNSAFE_EXTERNAL_URL', 'Refusing to open unsafe external URL');
-      }
-      await shell.openExternal(url);
-      return createSuccessResponse(true);
-    } catch (error) {
-      console.error('[Main Process] Failed to open external URL:', error);
-      return createErrorResponse(error);
+  registerSensitiveIpc('shell-openExternal', async (_event, url) => {
+    console.log('[Main Process] Opening external URL:', url);
+    if (!isSafeExternalUrl(url)) {
+      throw createIpcError('IPC_UNSAFE_EXTERNAL_URL', 'Refusing to open unsafe external URL');
+    }
+    await shell.openExternal(url);
+    return true;
+  }, ([url]) => {
+    if (typeof url !== 'string' || url.length === 0 || url.length > 2048) {
+      throw createIpcError('IPC_INVALID_ARGUMENT', 'Invalid external URL');
     }
   });
 

--- a/packages/desktop/remote-storage.js
+++ b/packages/desktop/remote-storage.js
@@ -12,13 +12,38 @@ const JSON_MIME_TYPE = 'application/json';
 const CLOUDFLARE_R2_DEFAULT_BACKUP_PREFIX = 'prompt-optimizer-backups/';
 let webDavModulePromise = null;
 
-const joinRemotePath = (...parts) =>
-  parts
-    .map((part) => String(part || '').replace(/^\/+|\/+$/g, ''))
-    .filter(Boolean)
-    .join('/');
+const decodeRemotePathSegment = (segment) => {
+  let decoded = segment;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    let next;
+    try {
+      next = decodeURIComponent(decoded);
+    } catch {
+      throw new Error('Remote storage path contains invalid encoding');
+    }
+    if (next === decoded) break;
+    decoded = next;
+  }
+  return decoded;
+};
 
-const normalizeObjectPath = (path) => joinRemotePath(path);
+const normalizeObjectPath = (path) => {
+  const raw = String(path || '');
+  if (/[\\\u0000-\u001f\u007f]/.test(raw)) {
+    throw new Error('Remote storage path contains invalid characters');
+  }
+
+  const segments = raw.replace(/^\/+|\/+$/g, '').split('/').filter(Boolean);
+  for (const segment of segments) {
+    const decoded = decodeRemotePathSegment(segment);
+    if (decoded === '.' || decoded === '..' || /[\\/\u0000-\u001f\u007f]/.test(decoded)) {
+      throw new Error('Remote storage path contains an unsafe segment');
+    }
+  }
+  return segments.join('/');
+};
+
+const joinRemotePath = (...parts) => parts.map(normalizeObjectPath).filter(Boolean).join('/');
 
 const parentPathOf = (path) => {
   const normalized = normalizeObjectPath(path);
@@ -292,6 +317,7 @@ class WebDavRemoteObjectStore {
   constructor(config, dependencies) {
     this.config = config;
     this.dependencies = dependencies;
+    this.rootDirectory = normalizeObjectPath(config.directory || 'prompt-optimizer-backups');
     this.clientPromise = null;
   }
 
@@ -411,7 +437,7 @@ class WebDavRemoteObjectStore {
   }
 
   directoryPath(path) {
-    return `/${joinRemotePath(this.config.directory || 'prompt-optimizer-backups', path)}`;
+    return `/${joinRemotePath(this.rootDirectory, path)}`;
   }
 
   filePath(path) {

--- a/packages/ui/src/composables/model/useTextModelManager.ts
+++ b/packages/ui/src/composables/model/useTextModelManager.ts
@@ -678,6 +678,34 @@ export function useTextModelManager() {
     }
   }
 
+
+  const isModelListBlockedError = (error: unknown) => {
+    const message = getErrorDetail(error, '').toLowerCase()
+    const code = typeof (error as { code?: unknown })?.code === 'string'
+      ? String((error as { code?: string }).code).toLowerCase()
+      : ''
+    const status = (error as { status?: unknown; statusCode?: unknown })?.status
+      ?? (error as { statusCode?: unknown })?.statusCode
+      ?? (error as { response?: { status?: unknown } })?.response?.status
+
+    return status === 403
+      || message.includes('403')
+      || message.includes('blocked')
+      || message.includes('your request was blocked')
+      || code.includes('forbidden')
+  }
+
+  const ensureCurrentModelOption = () => {
+    const currentId = form.value.modelId?.trim()
+    if (!currentId) return
+    if (!modelOptions.value.some(option => option.value === currentId)) {
+      modelOptions.value = [
+        { value: currentId, label: currentId },
+        ...modelOptions.value,
+      ]
+    }
+  }
+
   const refreshModelOptions = async (showSuccess = true) => {
     if (!form.value.providerId) return
 
@@ -755,13 +783,14 @@ export function useTextModelManager() {
         form.value.defaultModel = fetchedModels[0].value
       }
     } catch (error: unknown) {
-      console.error('Failed to fetch model list:', error)
+      console.warn('Failed to fetch model list:', error)
 
-      // Keep UX consistent: if dynamic fetch fails, fall back to static models
-      // but surface the failure to avoid a misleading "success" toast.
+      // Keep UX consistent: if dynamic fetch fails, fall back to static/current models
+      // and explain gateway blocks (e.g. 403 on /v1/models) without blocking manual use.
       const errorMessage = getErrorDetail(error, t('modelManager.loadFailed'))
+      const blocked = isModelListBlockedError(error)
 
-      let staticCount: number
+      let staticCount = 0
       try {
         const staticModels = textAdapterRegistry.getStaticModels(providerTemplateId)
         staticCount = staticModels.length
@@ -770,11 +799,30 @@ export function useTextModelManager() {
       }
 
       loadStaticModelsForProvider(providerTemplateId)
+      ensureCurrentModelOption()
 
-      if (staticCount > 0) {
-        toast.warning(t('modelManager.fetchModelsFallback', { error: errorMessage, count: staticCount }))
+      const optionCount = modelOptions.value.length
+      if (optionCount > 0) {
+        toast.warning(
+          blocked
+            ? t('modelManager.fetchModelsBlockedFallback', {
+                error: errorMessage,
+                count: optionCount,
+              })
+            : t('modelManager.fetchModelsFallback', {
+                error: errorMessage,
+                count: optionCount,
+              }),
+        )
+      } else if (blocked) {
+        toast.error(t('modelManager.fetchModelsBlockedFailed', { error: errorMessage }))
       } else {
         toast.error(t('modelManager.fetchModelsFailed', { error: errorMessage }))
+      }
+
+      // Keep the currently saved model id so users can continue without remote list.
+      if (form.value.modelId?.trim()) {
+        form.value.defaultModel = form.value.modelId
       }
     } finally {
       isLoadingModelOptions.value = false

--- a/packages/ui/src/i18n/locales/en-US/models.ts
+++ b/packages/ui/src/i18n/locales/en-US/models.ts
@@ -149,6 +149,8 @@ const messages = {
     "noModelsAvailable": "No models available",
     "selectModel": "Select a model",
     "fetchModelsFailed": "Failed to fetch models: {error}",
+    "fetchModelsBlockedFallback": "Model list request was blocked by the provider: {error}. Fell back to {count} local/saved models. You can still type a model ID manually.",
+    "fetchModelsBlockedFailed": "Model list request was blocked by the provider: {error}. Enter a model ID manually (chat may still work without the remote list).",
     "fetchModelsFallback": "Failed to fetch models: {error} (fell back to {count} default models)",
     "needApiKeyAndBaseUrl": "Please fill API key and base URL first",
     "needBaseUrl": "Please fill in API URL first",

--- a/packages/ui/src/i18n/locales/zh-CN/models.ts
+++ b/packages/ui/src/i18n/locales/zh-CN/models.ts
@@ -149,6 +149,8 @@ const messages = {
     "loadingModels": "正在加载模型选项...",
     "noModelsAvailable": "没有可用模型",
     "fetchModelsFailed": "获取模型列表失败：{error}",
+    "fetchModelsBlockedFallback": "获取模型列表被服务商拦截：{error}。已改用本地/已保存的 {count} 个模型，可直接手填模型 ID 继续使用。",
+    "fetchModelsBlockedFailed": "获取模型列表被服务商拦截：{error}。请手动填写模型 ID（对话可用时不必依赖该列表）。",
     "fetchModelsFallback": "获取模型列表失败：{error}（已回退到默认的 {count} 个模型）",
     "needApiKeyAndBaseUrl": "请先填写API地址和密钥",
     "needBaseUrl": "请先填写API地址",

--- a/packages/ui/src/i18n/locales/zh-TW/models.ts
+++ b/packages/ui/src/i18n/locales/zh-TW/models.ts
@@ -149,6 +149,8 @@ const messages = {
     "noModelsAvailable": "沒有可用模型",
     "selectModel": "選擇一個模型",
     "fetchModelsFailed": "取得模型清單失敗：{error}",
+    "fetchModelsBlockedFallback": "取得模型清單被服務商攔截：{error}。已改用本地/已儲存的 {count} 個模型，可直接手填模型 ID 繼續使用。",
+    "fetchModelsBlockedFailed": "取得模型清單被服務商攔截：{error}。請手動填寫模型 ID（對話可用時不必依賴該清單）。",
     "fetchModelsFallback": "取得模型清單失敗：{error}（已回退到預設的 {count} 個模型）",
     "needApiKeyAndBaseUrl": "請先填寫API位址和金鑰",
     "needBaseUrl": "請先填寫API位址",

--- a/packages/ui/tests/unit/composables/useTextModelManager.spec.ts
+++ b/packages/ui/tests/unit/composables/useTextModelManager.spec.ts
@@ -6,6 +6,7 @@ import {
   type TextModelConfig
 } from '@prompt-optimizer/core'
 import { useTextModelManager } from '../../../src/composables/model/useTextModelManager'
+import { allowConsole } from '../../utils/error-detection'
 
 vi.mock('vue-i18n', async (importOriginal) => {
   const actual = await importOriginal<typeof import('vue-i18n')>()
@@ -204,3 +205,71 @@ describe('useTextModelManager', () => {
     expect(manager.canSaveForm.value).toBe(true)
   })
 })
+
+  it('falls back to saved/static models when provider blocks remote model list', async () => {
+    allowConsole(/Failed to fetch model list/i)
+    const registry = new TextAdapterRegistry()
+    const compatAdapter = registry.getAdapter('openai-compatible')
+    const config: TextModelConfig = {
+      id: 'ls',
+      name: 'ls',
+      enabled: true,
+      providerMeta: {
+        ...compatAdapter.getProvider(),
+        supportsDynamicModels: true,
+      },
+      modelMeta: compatAdapter.buildDefaultModel('grok-4.5'),
+      connectionConfig: {
+        apiKey: 'sk-test',
+        baseURL: 'http://216.195.211.206:8317/v1',
+      },
+      paramOverrides: {},
+    }
+
+    const modelManager = {
+      getAllModels: vi.fn().mockResolvedValue([config]),
+      getModel: vi.fn(async (id: string) => (id === 'ls' ? config : undefined)),
+      addModel: vi.fn().mockResolvedValue(undefined),
+      deleteModel: vi.fn().mockResolvedValue(undefined),
+      updateModel: vi.fn().mockResolvedValue(undefined),
+      enableModel: vi.fn().mockResolvedValue(undefined),
+      disableModel: vi.fn().mockResolvedValue(undefined),
+    }
+    const blockedError = Object.assign(new Error('403 Your request was blocked.'), { status: 403 })
+    const llmService = {
+      testConnection: vi.fn().mockResolvedValue(undefined),
+      fetchModelList: vi.fn().mockRejectedValue(blockedError),
+    }
+
+    const Harness = defineComponent({
+      setup() {
+        const manager = useTextModelManager()
+        return { manager }
+      },
+      template: '<div />',
+    })
+
+    const wrapper = mount(Harness, {
+      global: {
+        provide: {
+          services: ref({
+            modelManager,
+            llmService,
+            textAdapterRegistry: registry,
+          }),
+        },
+      },
+    })
+
+    const manager = (wrapper.vm as any).manager as ReturnType<typeof useTextModelManager>
+    await manager.prepareForEdit('ls')
+    manager.form.value.connectionConfig.baseURL = 'http://216.195.211.206:8317/v1'
+    manager.form.value.connectionConfig.apiKey = 'sk-test'
+    manager.form.value.modelId = 'grok-4.5'
+
+    await manager.refreshModelOptions(true)
+
+    expect(llmService.fetchModelList).toHaveBeenCalled()
+    expect(manager.modelOptions.value.some((item) => item.value === 'grok-4.5')).toBe(true)
+    expect(manager.form.value.modelId).toBe('grok-4.5')
+  })


### PR DESCRIPTION
## Summary
- Detect provider-blocked model list responses (`403` / `blocked`).
- Keep the currently saved model ID and fall back to static/local options.
- Show clearer i18n warning that chat can continue with a manual model ID.

## Why
Some OpenAI-compatible gateways allow chat but block `GET /v1/models`. Users then see endless “fetch models failed” even though connection/chat works.

## Test plan
- [x] `pnpm -F @prompt-optimizer/ui test --run tests/unit/composables/useTextModelManager.spec.ts` (3/3)
- [ ] Manual: edit custom provider, click fetch models against a blocked `/models` endpoint → warning + retained model ID

## Non-goals
- Changing gateway policy
- Desktop IPC security (separate)