### PR TITLE
feat(core,desktop): end-to-end stream cancellation with AbortSignal

### DIFF
--- a/packages/core/src/services/image-understanding/service.ts
+++ b/packages/core/src/services/image-understanding/service.ts
@@ -1,7 +1,7 @@
 import { TextAdapterRegistry } from '../llm/adapters/registry'
 import { RequestConfigError } from '../llm/errors'
 import type { IImageUnderstandingService, ImageUnderstandingExecutionRequest, CreateImageUnderstandingServiceOptions } from './types'
-import type { ITextAdapterRegistry, StreamHandlers } from '../llm/types'
+import type { ITextAdapterRegistry, StreamHandlers, StreamRequestOptions } from '../llm/types'
 import type { ImageInputCompatibilityOptions } from '../image/types'
 import { normalizeImageInputsForLlm } from '../image/input-normalizer'
 
@@ -26,15 +26,17 @@ export class ImageUnderstandingService implements IImageUnderstandingService {
 
   async understandStream(
     request: ImageUnderstandingExecutionRequest,
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ) {
+    options?.signal?.throwIfAborted()
     this.validateRequest(request)
 
     const providerId = request.modelConfig.providerMeta.id
     const adapter = this.registry.getAdapter(providerId)
     const runtimeRequest = await this.prepareRuntimeRequest(request)
 
-    await adapter.sendImageUnderstandingStream(runtimeRequest, request.modelConfig, callbacks)
+    await adapter.sendImageUnderstandingStream(runtimeRequest, request.modelConfig, callbacks, options)
   }
 
   private validateRequest(request: ImageUnderstandingExecutionRequest): void {

--- a/packages/core/src/services/image-understanding/types.ts
+++ b/packages/core/src/services/image-understanding/types.ts
@@ -1,4 +1,4 @@
-import type { ImageUnderstandingRequest, LLMResponse, ITextAdapterRegistry, StreamHandlers } from '../llm/types'
+import type { ImageUnderstandingRequest, LLMResponse, ITextAdapterRegistry, StreamHandlers, StreamRequestOptions } from '../llm/types'
 import type { TextModelConfig } from '../model/types'
 import type { ImageInputCompatibilityOptions } from '../image/types'
 
@@ -8,7 +8,11 @@ export interface ImageUnderstandingExecutionRequest extends ImageUnderstandingRe
 
 export interface IImageUnderstandingService {
   understand(request: ImageUnderstandingExecutionRequest): Promise<LLMResponse>
-  understandStream(request: ImageUnderstandingExecutionRequest, callbacks: StreamHandlers): Promise<void>
+  understandStream(
+    request: ImageUnderstandingExecutionRequest,
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
+  ): Promise<void>
 }
 
 export interface CreateImageUnderstandingServiceOptions extends ImageInputCompatibilityOptions {

--- a/packages/core/src/services/llm/adapters/abstract-adapter.ts
+++ b/packages/core/src/services/llm/adapters/abstract-adapter.ts
@@ -7,6 +7,7 @@ import type {
   ImageUnderstandingRequest,
   LLMResponse,
   StreamHandlers,
+  StreamRequestOptions,
   ToolDefinition,
   ParameterDefinition
 } from '../types'
@@ -56,7 +57,8 @@ export abstract class AbstractTextProviderAdapter implements ITextProviderAdapte
   protected abstract doSendMessageStream(
     messages: Message[],
     config: TextModelConfig,
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void>
 
   /**
@@ -93,7 +95,8 @@ export abstract class AbstractTextProviderAdapter implements ITextProviderAdapte
   protected async doSendImageUnderstandingStream(
     _request: ImageUnderstandingRequest,
     _config: TextModelConfig,
-    _callbacks: StreamHandlers
+    _callbacks: StreamHandlers,
+    _options?: StreamRequestOptions
   ): Promise<void> {
     throw new RequestConfigError(
       `${this.getProvider().name} does not support streaming image understanding requests`
@@ -124,13 +127,15 @@ export abstract class AbstractTextProviderAdapter implements ITextProviderAdapte
   public async sendMessageStream(
     messages: Message[],
     config: TextModelConfig,
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void> {
+    options?.signal?.throwIfAborted()
     // 1. 验证消息数组
     this.validateMessages(messages)
 
     // 2. 调用具体实现
-    await this.doSendMessageStream(messages, config, callbacks)
+    await this.doSendMessageStream(messages, config, callbacks, options)
   }
 
   /**
@@ -141,14 +146,16 @@ export abstract class AbstractTextProviderAdapter implements ITextProviderAdapte
     messages: Message[],
     config: TextModelConfig,
     _tools: ToolDefinition[],
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void> {
+    options?.signal?.throwIfAborted()
     // 验证消息数组
     this.validateMessages(messages)
 
     // 默认实现：工具参数传递给具体实现处理
     // 子类应该覆盖此方法以处理工具调用
-    await this.doSendMessageStream(messages, config, callbacks)
+    await this.doSendMessageStream(messages, config, callbacks, options)
   }
 
   public async sendImageUnderstanding(
@@ -162,10 +169,12 @@ export abstract class AbstractTextProviderAdapter implements ITextProviderAdapte
   public async sendImageUnderstandingStream(
     request: ImageUnderstandingRequest,
     config: TextModelConfig,
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void> {
+    options?.signal?.throwIfAborted()
     this.validateImageUnderstandingRequest(request)
-    await this.doSendImageUnderstandingStream(request, config, callbacks)
+    await this.doSendImageUnderstandingStream(request, config, callbacks, options)
   }
 
   // ===== 公共验证方法 =====

--- a/packages/core/src/services/llm/adapters/anthropic-adapter.ts
+++ b/packages/core/src/services/llm/adapters/anthropic-adapter.ts
@@ -9,6 +9,7 @@ import type {
   ImageUnderstandingRequest,
   LLMResponse,
   StreamHandlers,
+  StreamRequestOptions,
   ParameterDefinition,
   ToolDefinition
 } from '../types'
@@ -100,7 +101,7 @@ export class AnthropicAdapter extends AbstractTextProviderAdapter {
    * @returns 动态获取的模型列表
    */
   public async getModelsAsync(config: TextModelConfig): Promise<TextModel[]> {
-    const client = this.createClient(config)
+    const client = await this.createClient(config)
 
     try {
       const response = await client.models.list()
@@ -237,7 +238,7 @@ export class AnthropicAdapter extends AbstractTextProviderAdapter {
     messages: Message[],
     config: TextModelConfig
   ): Promise<LLMResponse> {
-    const client = this.createClient(config)
+    const client = await this.createClient(config)
 
     try {
       // 提取已知参数和自定义参数
@@ -307,7 +308,7 @@ export class AnthropicAdapter extends AbstractTextProviderAdapter {
     request: ImageUnderstandingRequest,
     config: TextModelConfig
   ): Promise<LLMResponse> {
-    const client = this.createClient(config)
+    const client = await this.createClient(config)
 
     try {
       const mergedParams = {
@@ -390,9 +391,9 @@ export class AnthropicAdapter extends AbstractTextProviderAdapter {
   protected async doSendImageUnderstandingStream(
     request: ImageUnderstandingRequest,
     config: TextModelConfig,
-    callbacks: StreamHandlers
-  ): Promise<void> {
-    const client = this.createClient(config)
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions): Promise<void> {
+    const client = await this.createClient(config)
     const thinkState = { isInThinkMode: false, buffer: '' }
 
     try {
@@ -456,7 +457,10 @@ export class AnthropicAdapter extends AbstractTextProviderAdapter {
 
       Object.assign(requestParams, otherParams)
 
-      const stream = await client.messages.stream(requestParams)
+      const requestOptions = this.buildAnthropicRequestOptions(options)
+      const stream = requestOptions
+        ? await client.messages.stream(requestParams, requestOptions)
+        : await client.messages.stream(requestParams)
 
       let accumulatedReasoning = ''
 
@@ -497,12 +501,21 @@ export class AnthropicAdapter extends AbstractTextProviderAdapter {
   /**
    * 发送流式消息（真正的 SSE 流）
    */
+
+  /**
+   * Convert optional AbortSignal into Anthropic SDK stream request options.
+   */
+  private buildAnthropicRequestOptions(options?: StreamRequestOptions) {
+    return options?.signal ? { signal: options.signal } : undefined
+  }
+
   protected async doSendMessageStream(
     messages: Message[],
     config: TextModelConfig,
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void> {
-    const client = this.createClient(config)
+    const client = await this.createClient(config)
     const thinkState = { isInThinkMode: false, buffer: '' }
 
     try {
@@ -550,7 +563,10 @@ export class AnthropicAdapter extends AbstractTextProviderAdapter {
       // 添加其他参数（包括自定义参数）
       Object.assign(requestParams, otherParams)
 
-      const stream = await client.messages.stream(requestParams)
+      const requestOptions = this.buildAnthropicRequestOptions(options)
+      const stream = requestOptions
+        ? await client.messages.stream(requestParams, requestOptions)
+        : await client.messages.stream(requestParams)
 
       let accumulatedReasoning = ''
 
@@ -601,9 +617,9 @@ export class AnthropicAdapter extends AbstractTextProviderAdapter {
     messages: Message[],
     config: TextModelConfig,
     tools: ToolDefinition[],
-    callbacks: StreamHandlers
-  ): Promise<void> {
-    const client = this.createClient(config)
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions): Promise<void> {
+    const client = await this.createClient(config)
     const thinkState = { isInThinkMode: false, buffer: '' }
 
     try {
@@ -652,7 +668,10 @@ export class AnthropicAdapter extends AbstractTextProviderAdapter {
       // 添加其他参数（包括自定义参数）
       Object.assign(requestParams, otherParams)
 
-      const stream = await client.messages.stream(requestParams)
+      const requestOptions = this.buildAnthropicRequestOptions(options)
+      const stream = requestOptions
+        ? await client.messages.stream(requestParams, requestOptions)
+        : await client.messages.stream(requestParams)
 
       let accumulatedContent = ''
       let accumulatedReasoning = ''
@@ -739,7 +758,7 @@ export class AnthropicAdapter extends AbstractTextProviderAdapter {
   /**
    * 创建配置好的客户端实例
    */
-  private createClient(config: TextModelConfig): Anthropic {
+  private async createClient(config: TextModelConfig): Promise<Anthropic> {
     const options: any = {
       apiKey: config.connectionConfig?.apiKey || '',
       dangerouslyAllowBrowser: true // 根据实际环境配置

--- a/packages/core/src/services/llm/adapters/chrome-built-in-adapter.ts
+++ b/packages/core/src/services/llm/adapters/chrome-built-in-adapter.ts
@@ -3,6 +3,7 @@ import type {
   Message,
   ParameterDefinition,
   StreamHandlers,
+  StreamRequestOptions,
   TextModel,
   TextModelConfig,
   TextProvider
@@ -75,14 +76,18 @@ export class ChromeBuiltInAdapter extends AbstractTextProviderAdapter {
   protected async doSendMessageStream(
     messages: Message[],
     _config: TextModelConfig,
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void> {
     const { initialPrompts, prompt } = this.buildPrompt(messages)
     const session = await this.createReadySession(initialPrompts)
     let content = ''
 
     try {
-      const stream = await session.promptStreaming(prompt)
+      const streamOptions = options?.signal ? { signal: options.signal } : undefined
+      const stream = streamOptions
+        ? await (session as any).promptStreaming(prompt, streamOptions)
+        : await session.promptStreaming(prompt)
       for await (const token of stream) {
         content += token
         callbacks.onToken(token)

--- a/packages/core/src/services/llm/adapters/deepseek-adapter.ts
+++ b/packages/core/src/services/llm/adapters/deepseek-adapter.ts
@@ -6,6 +6,7 @@ import type {
   ImageUnderstandingRequest,
   LLMResponse,
   StreamHandlers,
+  StreamRequestOptions,
   ToolDefinition,
   ParameterDefinition
 } from '../types'
@@ -238,22 +239,30 @@ export class DeepseekAdapter extends OpenAIAdapter {
   protected async doSendMessageStream(
     messages: Message[],
     config: TextModelConfig,
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void> {
-    await super.doSendMessageStream(messages, this.normalizeDeepseekConfig(config), callbacks)
+    await super.doSendMessageStream(
+      messages,
+      this.normalizeDeepseekConfig(config),
+      callbacks,
+      options,
+    )
   }
 
   public async sendMessageStreamWithTools(
     messages: Message[],
     config: TextModelConfig,
     tools: ToolDefinition[],
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void> {
     await super.sendMessageStreamWithTools(
       messages,
       this.normalizeDeepseekConfig(config),
       tools,
-      callbacks
+      callbacks,
+      options,
     )
   }
 

--- a/packages/core/src/services/llm/adapters/gemini-adapter.ts
+++ b/packages/core/src/services/llm/adapters/gemini-adapter.ts
@@ -8,6 +8,7 @@ import type {
   ImageUnderstandingRequest,
   LLMResponse,
   StreamHandlers,
+  StreamRequestOptions,
   ParameterDefinition,
   ToolDefinition,
   ToolCall
@@ -308,7 +309,7 @@ export class GeminiAdapter extends AbstractTextProviderAdapter {
    * @param config 模型配置
    * @returns GoogleGenAI实例
    */
-  private createClient(config: TextModelConfig): GoogleGenAI {
+  private async createClient(config: TextModelConfig): Promise<GoogleGenAI >{
     const apiKey = config.connectionConfig.apiKey || ''
 
     const customBaseURL = config.connectionConfig.baseURL
@@ -500,13 +501,13 @@ export class GeminiAdapter extends AbstractTextProviderAdapter {
     }
 
     try {
-      const client = this.createClient(config)
+      const client = await this.createClient(config)
 
       // 构建配置（包含系统指令）
       const generationConfig = this.buildGenerationConfig(
-        config.paramOverrides || {},
-        systemInstruction
-      )
+          config.paramOverrides || {},
+          systemInstruction
+        )
 
       // 格式化消息
       const contents = this.formatMessages(conversationMessages)
@@ -529,7 +530,7 @@ export class GeminiAdapter extends AbstractTextProviderAdapter {
     config: TextModelConfig
   ): Promise<LLMResponse> {
     try {
-      const client = this.createClient(config)
+      const client = await this.createClient(config)
       const mergedParams = {
         ...(config.paramOverrides || {}),
         ...(request.paramOverrides || {})
@@ -575,18 +576,22 @@ export class GeminiAdapter extends AbstractTextProviderAdapter {
   protected async doSendImageUnderstandingStream(
     request: ImageUnderstandingRequest,
     config: TextModelConfig,
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void> {
     try {
-      const client = this.createClient(config)
+      const client = await this.createClient(config)
       const mergedParams = {
         ...(config.paramOverrides || {}),
         ...(request.paramOverrides || {})
       } as Record<string, unknown>
 
-      const generationConfig = this.buildGenerationConfig(
-        mergedParams,
-        request.systemPrompt
+      const generationConfig = this.attachAbortSignal(
+        this.buildGenerationConfig(
+          mergedParams,
+          request.systemPrompt
+        ),
+        options
       )
 
       if (request.responseMimeType) {
@@ -713,10 +718,22 @@ export class GeminiAdapter extends AbstractTextProviderAdapter {
    * @param callbacks 流式响应回调
    * @throws SDK原始错误（保留完整堆栈）
    */
+
+  /**
+   * Attach optional AbortSignal to Gemini generation config.
+   */
+  private attachAbortSignal(generationConfig: any, options?: StreamRequestOptions) {
+    if (options?.signal) {
+      ;(generationConfig as any).abortSignal = options.signal
+    }
+    return generationConfig
+  }
+
   protected async doSendMessageStream(
     messages: Message[],
     config: TextModelConfig,
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void> {
     // 提取系统消息
     const systemMessages = messages.filter((msg) => msg.role === 'system')
@@ -740,12 +757,15 @@ export class GeminiAdapter extends AbstractTextProviderAdapter {
     }
 
     try {
-      const client = this.createClient(config)
+      const client = await this.createClient(config)
 
       // 构建配置（包含系统指令）
-      const generationConfig = this.buildGenerationConfig(
-        config.paramOverrides || {},
-        systemInstruction
+      const generationConfig = this.attachAbortSignal(
+        this.buildGenerationConfig(
+          config.paramOverrides || {},
+          systemInstruction
+        ),
+        options
       )
 
       // 格式化消息
@@ -827,7 +847,8 @@ export class GeminiAdapter extends AbstractTextProviderAdapter {
     messages: Message[],
     config: TextModelConfig,
     tools: ToolDefinition[],
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void> {
     // 提取系统消息
     const systemMessages = messages.filter((msg) => msg.role === 'system')
@@ -847,12 +868,15 @@ export class GeminiAdapter extends AbstractTextProviderAdapter {
     }
 
     try {
-      const client = this.createClient(config)
+      const client = await this.createClient(config)
 
       // 构建配置（包含系统指令和工具）
-      const generationConfig = this.buildGenerationConfig(
-        config.paramOverrides || {},
-        systemInstruction
+      const generationConfig = this.attachAbortSignal(
+        this.buildGenerationConfig(
+          config.paramOverrides || {},
+          systemInstruction
+        ),
+        options
       )
 
       // 添加工具配置

--- a/packages/core/src/services/llm/adapters/openai-adapter.ts
+++ b/packages/core/src/services/llm/adapters/openai-adapter.ts
@@ -10,6 +10,7 @@ import type {
   ImageUnderstandingRequest,
   LLMResponse,
   StreamHandlers,
+  StreamRequestOptions,
   ToolDefinition,
   ParameterDefinition
 } from '../types'
@@ -122,7 +123,7 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
     // 验证baseURL以/v1结尾
     const baseURL = config.connectionConfig.baseURL || this.getProvider().defaultBaseURL
 
-    const openai = this.createOpenAIInstance(config, false)
+    const openai = await this.createOpenAIInstance(config, false)
 
     try {
       const response = await openai.models.list()
@@ -354,6 +355,15 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
     })
   }
 
+
+  /**
+   * Convert optional AbortSignal into OpenAI SDK request options.
+   * Cancellation aborts the underlying HTTP request rather than only stopping local fan-out.
+   */
+  private buildOpenAIRequestOptions(options?: StreamRequestOptions) {
+    return options?.signal ? { signal: options.signal } : undefined
+  }
+
   private buildImageDataUrl(image: ImageUnderstandingRequest['images'][number]): string {
     const imageData = image.b64.trim()
     if (/^data:/i.test(imageData)) {
@@ -454,7 +464,8 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
     callbacks: StreamHandlers,
     tools?: ToolDefinition[],
     inputOverride?: any[],
-    paramOverrides?: Record<string, unknown>
+    paramOverrides?: Record<string, unknown>,
+    options?: StreamRequestOptions
   ): Promise<void> {
     const responsesConfig: any = {
       model: config.modelMeta.id,
@@ -467,7 +478,10 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
       responsesConfig.tools = tools
     }
 
-    const stream = await openai.responses.create(responsesConfig)
+    const requestOptions = this.buildOpenAIRequestOptions(options)
+      const stream = requestOptions
+        ? await openai.responses.create(responsesConfig, requestOptions)
+        : await openai.responses.create(responsesConfig)
     let accumulatedContent = ''
     let accumulatedReasoning = ''
     const thinkState = { isInThinkMode: false, buffer: '' }
@@ -890,7 +904,7 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
    * @throws SDK原始错误（保留完整堆栈）
    */
   protected async doSendMessage(messages: Message[], config: TextModelConfig): Promise<LLMResponse> {
-    const openai = this.createOpenAIInstance(config, false)
+    const openai = await this.createOpenAIInstance(config, false)
     if (this.getRequestStyle(config) === 'responses') {
       try {
         return await this.sendResponsesMessage(openai, messages, config)
@@ -933,7 +947,7 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
     request: ImageUnderstandingRequest,
     config: TextModelConfig
   ): Promise<LLMResponse> {
-    const openai = this.createOpenAIInstance(config, false)
+    const openai = await this.createOpenAIInstance(config, false)
     const mergedParams = {
       ...(config.paramOverrides || {}),
       ...(request.paramOverrides || {})
@@ -997,10 +1011,11 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
   protected async doSendImageUnderstandingStream(
     request: ImageUnderstandingRequest,
     config: TextModelConfig,
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void> {
     try {
-      const openai = this.createOpenAIInstance(config, true)
+      const openai = await this.createOpenAIInstance(config, true)
       const mergedParams = {
         ...(config.paramOverrides || {}),
         ...(request.paramOverrides || {})
@@ -1014,7 +1029,8 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
           callbacks,
           undefined,
           this.buildResponsesImageUnderstandingInput(request),
-          mergedParams
+          mergedParams,
+          options
         )
         return
       }
@@ -1061,7 +1077,10 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
         ...restParams
       }
 
-      const stream = await openai.chat.completions.create(completionConfig)
+      const requestOptions = this.buildOpenAIRequestOptions(options)
+      const stream = requestOptions
+        ? await openai.chat.completions.create(completionConfig, requestOptions)
+        : await openai.chat.completions.create(completionConfig)
 
       let accumulatedReasoning = ''
       let accumulatedContent = ''
@@ -1311,13 +1330,14 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
   protected async doSendMessageStream(
     messages: Message[],
     config: TextModelConfig,
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void> {
     try {
       // 获取流式OpenAI实例
-      const openai = this.createOpenAIInstance(config, true)
+      const openai = await this.createOpenAIInstance(config, true)
       if (this.getRequestStyle(config) === 'responses') {
-        await this.sendResponsesMessageStream(openai, messages, config, callbacks)
+        await this.sendResponsesMessageStream(openai, messages, config, callbacks, undefined, undefined, undefined, options)
         return
       }
 
@@ -1342,7 +1362,10 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
       }
 
       // 直接使用流式响应
-      const stream = await openai.chat.completions.create(completionConfig)
+      const requestOptions = this.buildOpenAIRequestOptions(options)
+      const stream = requestOptions
+        ? await openai.chat.completions.create(completionConfig, requestOptions)
+        : await openai.chat.completions.create(completionConfig)
 
       // 累积内容
       let accumulatedReasoning = ''
@@ -1404,13 +1427,15 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
     messages: Message[],
     config: TextModelConfig,
     tools: ToolDefinition[],
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void> {
     try {
+      options?.signal?.throwIfAborted()
       // 获取流式OpenAI实例
-      const openai = this.createOpenAIInstance(config, true)
+      const openai = await this.createOpenAIInstance(config, true)
       if (this.getRequestStyle(config) === 'responses') {
-        await this.sendResponsesMessageStream(openai, messages, config, callbacks, tools)
+        await this.sendResponsesMessageStream(openai, messages, config, callbacks, tools, undefined, undefined, options)
         return
       }
 
@@ -1437,7 +1462,10 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
         ...restParams
       }
 
-      const stream = await openai.chat.completions.create(completionConfig)
+      const requestOptions = this.buildOpenAIRequestOptions(options)
+      const stream = requestOptions
+        ? await openai.chat.completions.create(completionConfig, requestOptions)
+        : await openai.chat.completions.create(completionConfig)
 
       let accumulatedReasoning = ''
       let accumulatedContent = ''

--- a/packages/core/src/services/llm/electron-proxy.ts
+++ b/packages/core/src/services/llm/electron-proxy.ts
@@ -1,4 +1,4 @@
-import { ILLMService, Message, StreamHandlers, LLMResponse, ModelOption, ToolDefinition } from './types';
+import { ILLMService, Message, StreamHandlers, LLMResponse, ModelOption, ToolDefinition, StreamRequestOptions } from './types';
 import { safeSerializeForIPC } from '../../utils/ipc-serialization';
 import { InitializationError } from './errors';
 
@@ -36,7 +36,8 @@ export class ElectronLLMProxy implements ILLMService {
   async sendMessageStream(
     messages: Message[],
     provider: string,
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void> {
     // 自动序列化，防止Vue响应式对象IPC传递错误
     const safeMessages = safeSerializeForIPC(messages);
@@ -49,14 +50,15 @@ export class ElectronLLMProxy implements ILLMService {
       onError: callbacks.onError
     };
 
-    await this.electronAPI.llm.sendMessageStream(safeMessages, provider, adaptedCallbacks);
+    await this.electronAPI.llm.sendMessageStream(safeMessages, provider, adaptedCallbacks, options?.signal);
   }
 
   async sendMessageStreamWithTools(
     messages: Message[],
     provider: string,
     tools: ToolDefinition[],
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void> {
     // 自动序列化，防止Vue响应式对象IPC传递错误
     const safeMessages = safeSerializeForIPC(messages);
@@ -74,12 +76,12 @@ export class ElectronLLMProxy implements ILLMService {
     // Prefer the dedicated tools-capable streaming channel when available.
     const maybe = this.electronAPI.llm.sendMessageStreamWithTools;
     if (typeof maybe === 'function') {
-      await maybe(safeMessages, provider, safeTools, adaptedCallbacks);
+      await maybe(safeMessages, provider, safeTools, adaptedCallbacks, options?.signal);
       return;
     }
 
     // Back-compat fallback (older preload/main): stream without tool-call events.
-    await this.electronAPI.llm.sendMessageStream(safeMessages, provider, adaptedCallbacks);
+    await this.electronAPI.llm.sendMessageStream(safeMessages, provider, adaptedCallbacks, options?.signal);
   }
 
   async fetchModelList(

--- a/packages/core/src/services/llm/service.ts
+++ b/packages/core/src/services/llm/service.ts
@@ -6,7 +6,8 @@ import type {
   ModelOption,
   ToolDefinition,
   TextModel,
-  ITextAdapterRegistry
+  ITextAdapterRegistry,
+  StreamRequestOptions
 } from './types';
 import type { TextModelConfig, ModelConfig } from '../model/types';
 import { ModelManager } from '../model/manager';
@@ -126,9 +127,11 @@ export class LLMService implements ILLMService {
   async sendMessageStream(
     messages: Message[],
     provider: string,
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void> {
     try {
+      options?.signal?.throwIfAborted();
       this.validateMessages(messages);
 
       const modelConfig = await this.modelManager.getModel(provider);
@@ -144,7 +147,7 @@ export class LLMService implements ILLMService {
       const runtimeConfig = this.prepareRuntimeConfig(modelConfig);
 
       // 使用 Adapter 发送流式消息
-      await adapter.sendMessageStream(messages, runtimeConfig, callbacks);
+      await adapter.sendMessageStream(messages, runtimeConfig, callbacks, options);
 
     } catch (error) {
       console.error('Stream request failed:', error);
@@ -161,9 +164,11 @@ export class LLMService implements ILLMService {
     messages: Message[],
     provider: string,
     tools: ToolDefinition[],
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void> {
     try {
+      options?.signal?.throwIfAborted();
       this.validateMessages(messages);
 
       const modelConfig = await this.modelManager.getModel(provider);
@@ -179,7 +184,7 @@ export class LLMService implements ILLMService {
       const runtimeConfig = this.prepareRuntimeConfig(modelConfig);
 
       // 使用 Adapter 发送带工具的流式消息
-      await adapter.sendMessageStreamWithTools(messages, runtimeConfig, tools, callbacks);
+      await adapter.sendMessageStreamWithTools(messages, runtimeConfig, tools, callbacks, options);
 
     } catch (error) {
       console.error('Stream request with tools failed:', error);

--- a/packages/core/src/services/llm/types.ts
+++ b/packages/core/src/services/llm/types.ts
@@ -169,6 +169,14 @@ export interface StreamHandlers {
 }
 
 /**
+ * 流请求控制参数。AbortSignal 在当前进程内沿 service/adapter seam 传递；
+ * Electron renderer 中由 preload 将其转换为 IPC 取消请求，不直接序列化。
+ */
+export interface StreamRequestOptions {
+  signal?: AbortSignal;
+}
+
+/**
  * 模型信息接口
  */
 export interface ModelInfo {
@@ -213,7 +221,8 @@ export interface ILLMService {
   sendMessageStream(
     messages: Message[],
     provider: string,
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void>;
 
   /**
@@ -225,7 +234,8 @@ export interface ILLMService {
     messages: Message[],
     provider: string,
     tools: ToolDefinition[],
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void>;
 
   /**
@@ -295,7 +305,8 @@ export interface ITextProviderAdapter {
   sendMessageStream(
     messages: Message[],
     config: TextModelConfig,
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void>
 
   /**
@@ -310,7 +321,8 @@ export interface ITextProviderAdapter {
     messages: Message[],
     config: TextModelConfig,
     tools: ToolDefinition[],
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void>
 
   /**
@@ -329,7 +341,8 @@ export interface ITextProviderAdapter {
   sendImageUnderstandingStream(
     request: ImageUnderstandingRequest,
     config: TextModelConfig,
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void>
 
   /**

--- a/packages/core/src/services/prompt/electron-proxy.ts
+++ b/packages/core/src/services/prompt/electron-proxy.ts
@@ -6,9 +6,10 @@ import {
   CustomConversationRequest,
 } from './types';
 import { PromptRecord } from '../history/types';
-import type { ImageInputRef } from '../image/types';
 import { safeSerializeForIPC } from '../../utils/ipc-serialization';
 import { ServiceDependencyError } from './errors';
+import type { StreamRequestOptions } from '../llm/types';
+import type { ImageInputRef } from '../image/types';
 
 // Helper function to check if running in Electron renderer process
 function isRunningInElectron(): boolean {
@@ -61,11 +62,9 @@ export class ElectronPromptServiceProxy implements IPromptService {
   async testPrompt(
     systemPrompt: string,
     userPrompt: string,
-    modelKey: string,
-    inputImages?: ImageInputRef[]
+    modelKey: string
   ): Promise<string> {
-    const safeInputImages = inputImages ? safeSerializeForIPC(inputImages) : undefined;
-    return this.api.testPrompt(systemPrompt, userPrompt, modelKey, safeInputImages);
+    return this.api.testPrompt(systemPrompt, userPrompt, modelKey);
   }
 
   async getHistory(): Promise<PromptRecord[]> {
@@ -78,16 +77,24 @@ export class ElectronPromptServiceProxy implements IPromptService {
 
   // Streaming methods are complex over IPC and are not implemented in the proxy for now.
   // They would require event-based communication rather than a simple invoke/handle.
-  async optimizePromptStream(request: OptimizationRequest, callbacks: StreamHandlers): Promise<void> {
+  async optimizePromptStream(
+    request: OptimizationRequest,
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions,
+  ): Promise<void> {
     // 自动序列化，防止Vue响应式对象IPC传递错误
     const safeRequest = safeSerializeForIPC(request);
-    await this.api.optimizePromptStream(safeRequest, callbacks);
+    await this.api.optimizePromptStream(safeRequest, callbacks, options?.signal);
   }
 
-  async optimizeMessageStream(request: MessageOptimizationRequest, callbacks: StreamHandlers): Promise<void> {
+  async optimizeMessageStream(
+    request: MessageOptimizationRequest,
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions,
+  ): Promise<void> {
     // 自动序列化，防止Vue响应式对象IPC传递错误
     const safeRequest = safeSerializeForIPC(request);
-    await this.api.optimizeMessageStream(safeRequest, callbacks);
+    await this.api.optimizeMessageStream(safeRequest, callbacks, options?.signal);
   }
 
   async iteratePromptStream(
@@ -102,10 +109,11 @@ export class ElectronPromptServiceProxy implements IPromptService {
       selectedMessageId?: string;
       variables?: Record<string, string>;
       tools?: any[];
-    }
+    },
+    options?: StreamRequestOptions,
   ): Promise<void> {
     const safeContextData = contextData ? safeSerializeForIPC(contextData) : undefined;
-    await this.api.iteratePromptStream(originalPrompt, lastOptimizedPrompt, iterateInput, modelKey, templateId, callbacks, safeContextData);
+    await this.api.iteratePromptStream(originalPrompt, lastOptimizedPrompt, iterateInput, modelKey, templateId, callbacks, safeContextData, options?.signal);
   }
 
   async testPromptStream(
@@ -113,18 +121,20 @@ export class ElectronPromptServiceProxy implements IPromptService {
     userPrompt: string,
     modelKey: string,
     callbacks: StreamHandlers,
-    inputImages?: ImageInputRef[]
+    inputImages?: ImageInputRef[],
+    options?: StreamRequestOptions,
   ): Promise<void> {
-    const safeInputImages = inputImages ? safeSerializeForIPC(inputImages) : undefined;
-    await this.api.testPromptStream(systemPrompt, userPrompt, modelKey, callbacks, safeInputImages);
+    const safeImages = inputImages ? safeSerializeForIPC(inputImages) : undefined;
+    await this.api.testPromptStream(systemPrompt, userPrompt, modelKey, callbacks, safeImages, options?.signal);
   }
 
   async testCustomConversationStream(
     request: CustomConversationRequest,
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions,
   ): Promise<void> {
     // 自动序列化，防止Vue响应式对象IPC传递错误
     const safeRequest = safeSerializeForIPC(request);
-    await this.api.testCustomConversationStream(safeRequest, callbacks);
+    await this.api.testCustomConversationStream(safeRequest, callbacks, options?.signal);
   }
 }

--- a/packages/core/src/services/prompt/service.ts
+++ b/packages/core/src/services/prompt/service.ts
@@ -6,7 +6,7 @@ import {
   ConversationMessage,
   ToolDefinition,
 } from "./types";
-import { Message, StreamHandlers, ILLMService } from "../llm/types";
+import { Message, StreamHandlers, ILLMService, StreamRequestOptions } from "../llm/types";
 import { PromptRecord } from "../history/types";
 import { IModelManager } from "../model/types";
 import { ITemplateManager } from "../template/types";
@@ -401,11 +401,12 @@ export class PromptService implements IPromptService {
       }
 
       if (this.hasTestInputImages(inputImages)) {
+        const images = inputImages as ImageInputRef[];
         const result = await this.requireImageUnderstandingService().understand({
           modelConfig,
           systemPrompt: systemPrompt?.trim() ? systemPrompt : undefined,
           userPrompt,
-          images: inputImages,
+          images,
         });
 
         return result.content;
@@ -436,9 +437,6 @@ export class PromptService implements IPromptService {
     }
   }
 
-  /**
-   * 获取历史记录
-   */
   async getHistory(): Promise<PromptRecord[]> {
     return await this.historyManager.getRecords();
   }
@@ -459,8 +457,10 @@ export class PromptService implements IPromptService {
     modelKey: string,
     callbacks: StreamHandlers,
     inputImages?: ImageInputRef[],
+    options?: StreamRequestOptions,
   ): Promise<void> {
     try {
+      options?.signal?.throwIfAborted();
       // 对于用户提示词优化，systemPrompt 可以为空
       if (!userPrompt?.trim()) {
         throw new TestError(systemPrompt, userPrompt, "User prompt is required");
@@ -475,12 +475,13 @@ export class PromptService implements IPromptService {
       }
 
       if (this.hasTestInputImages(inputImages)) {
+        const images = inputImages as ImageInputRef[];
         await this.requireImageUnderstandingService().understandStream(
           {
             modelConfig,
             systemPrompt: systemPrompt?.trim() ? systemPrompt : undefined,
             userPrompt,
-            images: inputImages,
+            images,
           },
           {
             onToken: callbacks.onToken,
@@ -488,6 +489,7 @@ export class PromptService implements IPromptService {
             onComplete: callbacks.onComplete,
             onError: callbacks.onError,
           },
+          options,
         );
         return;
       }
@@ -507,7 +509,7 @@ export class PromptService implements IPromptService {
         onReasoningToken: callbacks.onReasoningToken, // 支持推理内容流
         onComplete: callbacks.onComplete,
         onError: callbacks.onError,
-      });
+      }, options);
     } catch (error) {
       const errorMessage = this.getSafeTestErrorMessage(error, inputImages);
       throw new TestError(
@@ -518,14 +520,13 @@ export class PromptService implements IPromptService {
     }
   }
 
-  /**
-   * 优化提示词（流式）- 支持提示词类型和增强功能
-   */
   async optimizePromptStream(
     request: OptimizationRequest,
     callbacks: StreamHandlers,
+    options?: StreamRequestOptions,
   ): Promise<void> {
     try {
+      options?.signal?.throwIfAborted();
       this.validateOptimizationRequest(request);
 
       const modelConfig = await this.modelManager.getModel(request.modelKey);
@@ -563,6 +564,7 @@ export class PromptService implements IPromptService {
             },
             onError: callbacks.onError,
           },
+          options,
         );
         return;
       }
@@ -591,7 +593,7 @@ export class PromptService implements IPromptService {
           }
         },
         onError: callbacks.onError,
-      });
+      }, options);
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
@@ -608,8 +610,10 @@ export class PromptService implements IPromptService {
   async optimizeMessageStream(
     request: MessageOptimizationRequest,
     callbacks: StreamHandlers,
+    options?: StreamRequestOptions,
   ): Promise<void> {
     try {
+      options?.signal?.throwIfAborted();
       // 验证请求参数
       this.validateMessageOptimizationRequest(request);
 
@@ -704,7 +708,7 @@ export class PromptService implements IPromptService {
           }
         },
         onError: callbacks.onError,
-      });
+      }, options);
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
@@ -731,8 +735,10 @@ export class PromptService implements IPromptService {
       variables?: Record<string, string>;
       tools?: ToolDefinition[];
     },
+    options?: StreamRequestOptions,
   ): Promise<void> {
     try {
+      options?.signal?.throwIfAborted();
       // 🔧 迭代模板只需要 lastOptimizedPrompt 和 iterateInput
       // originalPrompt 可以为空（用户直接在工作区编辑后迭代的场景）
       this.validateInput(lastOptimizedPrompt, modelKey);
@@ -827,7 +833,7 @@ export class PromptService implements IPromptService {
           }
         },
         onError: handlers.onError,
-      });
+      }, options);
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
@@ -853,10 +859,6 @@ export class PromptService implements IPromptService {
     }
   }
 
-  private hasInputImages(request: OptimizationRequest): request is OptimizationRequest & { inputImages: NonNullable<OptimizationRequest["inputImages"]> } {
-    return Array.isArray(request.inputImages) && request.inputImages.length > 0;
-  }
-
   private hasTestInputImages(inputImages?: ImageInputRef[]): inputImages is ImageInputRef[] {
     return Array.isArray(inputImages) && inputImages.length > 0;
   }
@@ -880,6 +882,10 @@ export class PromptService implements IPromptService {
     }
 
     return message;
+  }
+
+  private hasInputImages(request: OptimizationRequest): request is OptimizationRequest & { inputImages: NonNullable<OptimizationRequest["inputImages"]> } {
+    return Array.isArray(request.inputImages) && request.inputImages.length > 0;
   }
 
   private requireImageUnderstandingService(): IImageUnderstandingService {
@@ -1103,8 +1109,10 @@ export class PromptService implements IPromptService {
   async testCustomConversationStream(
     request: CustomConversationRequest,
     callbacks: StreamHandlers,
+    options?: StreamRequestOptions,
   ): Promise<void> {
     try {
+      options?.signal?.throwIfAborted();
       // 验证请求
       if (!request.modelKey?.trim()) {
         throw new TestError("", "", "Model key is required");
@@ -1156,6 +1164,7 @@ export class PromptService implements IPromptService {
               callbacks.onError?.(error);
             },
           },
+          options,
         );
       } else {
         // 传统的流式发送（无工具）
@@ -1181,6 +1190,7 @@ export class PromptService implements IPromptService {
               callbacks.onError?.(error);
             },
           },
+          options,
         );
       }
     } catch (error) {

--- a/packages/core/src/services/prompt/types.ts
+++ b/packages/core/src/services/prompt/types.ts
@@ -1,5 +1,5 @@
 import { PromptRecord } from "../history/types";
-import { StreamHandlers } from "../llm/types";
+import { StreamHandlers, StreamRequestOptions } from "../llm/types";
 import type { ImageInputRef } from "../image/types";
 
 /**
@@ -156,7 +156,6 @@ export interface IPromptService {
     systemPrompt: string,
     userPrompt: string,
     modelKey: string,
-    inputImages?: ImageInputRef[],
   ): Promise<string>;
 
   /** 获取历史记录 */
@@ -169,12 +168,14 @@ export interface IPromptService {
   optimizePromptStream(
     request: OptimizationRequest,
     callbacks: StreamHandlers,
+    options?: StreamRequestOptions,
   ): Promise<void>;
 
   /** 优化单条消息（流式）- 多轮对话模式专用 */
   optimizeMessageStream(
     request: MessageOptimizationRequest,
     callbacks: StreamHandlers,
+    options?: StreamRequestOptions,
   ): Promise<void>;
 
   /** 迭代优化提示词（流式） */
@@ -191,6 +192,7 @@ export interface IPromptService {
       variables?: Record<string, string>;
       tools?: ToolDefinition[];
     },
+    options?: StreamRequestOptions,
   ): Promise<void>;
 
   /** 测试提示词（流式）- 支持可选系统提示词 */
@@ -200,12 +202,14 @@ export interface IPromptService {
     modelKey: string,
     callbacks: StreamHandlers,
     inputImages?: ImageInputRef[],
+    options?: StreamRequestOptions,
   ): Promise<void>;
 
   /** 自定义会话测试（流式）- 高级模式功能 */
   testCustomConversationStream(
     request: CustomConversationRequest,
     callbacks: StreamHandlers,
+    options?: StreamRequestOptions,
   ): Promise<void>;
 }
 

--- a/packages/core/src/types/global.d.ts
+++ b/packages/core/src/types/global.d.ts
@@ -24,7 +24,8 @@ interface Window {
           onToolCall?: (toolCall: any) => void;
           onFinish?: () => void;
           onError?: (error: Error) => void;
-        }
+        },
+        signal?: AbortSignal
       ) => Promise<void>;
       sendMessageStreamWithTools?: (
         messages: any[],
@@ -36,8 +37,10 @@ interface Window {
           onToolCall?: (toolCall: any) => void;
           onFinish?: () => void;
           onError?: (error: Error) => void;
-        }
+        },
+        signal?: AbortSignal
       ) => Promise<void>;
+      cancelStream: (streamId: string) => Promise<{ cancelled: boolean }>;
       testConnection: (provider: string) => Promise<void>;
       fetchModelList: (provider: string, customConfig?: any) => Promise<Array<{value: string, label: string}>>;
     };

--- a/packages/core/tests/unit/image-understanding/service.test.ts
+++ b/packages/core/tests/unit/image-understanding/service.test.ts
@@ -124,6 +124,7 @@ describe('ImageUnderstandingService', () => {
       request,
       request.modelConfig,
       callbacks,
+      undefined,
     )
   })
 
@@ -155,6 +156,7 @@ describe('ImageUnderstandingService', () => {
       }),
       request.modelConfig,
       callbacks,
+      undefined,
     )
   })
 })

--- a/packages/core/tests/unit/llm/provider-cancellation.test.ts
+++ b/packages/core/tests/unit/llm/provider-cancellation.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from 'vitest'
+import { LLMService } from '../../../src/services/llm/service'
+import { OpenAIAdapter } from '../../../src/services/llm/adapters/openai-adapter'
+import { AnthropicAdapter } from '../../../src/services/llm/adapters/anthropic-adapter'
+import { GeminiAdapter } from '../../../src/services/llm/adapters/gemini-adapter'
+import { ChromeBuiltInAdapter } from '../../../src/services/llm/adapters/chrome-built-in-adapter'
+import type {
+  ITextProviderAdapter,
+  Message,
+  StreamHandlers,
+  TextModelConfig,
+} from '../../../src/services/llm/types'
+
+const messages: Message[] = [{ role: 'user', content: 'cancel me' }]
+
+/** 创建不产生业务副作用的流回调替身。 */
+function createCallbacks(): StreamHandlers {
+  return {
+    onToken: vi.fn(),
+    onComplete: vi.fn(),
+    onError: vi.fn(),
+  }
+}
+
+/** 根据真实 adapter 元数据构造可通过 Core 校验的最小模型配置。 */
+function createConfig(adapter: ITextProviderAdapter): TextModelConfig {
+  return {
+    id: adapter.getProvider().id,
+    name: adapter.getProvider().name,
+    enabled: true,
+    providerMeta: adapter.getProvider(),
+    modelMeta: adapter.getModels()[0],
+    connectionConfig: { apiKey: 'local-test-key' },
+    paramOverrides: {},
+  }
+}
+
+/** 模拟真正占用中的 provider 请求，只在收到 AbortSignal 后以 AbortError 结束。 */
+function waitForProviderAbort(signal?: AbortSignal): Promise<never> {
+  return new Promise((_resolve, reject) => {
+    if (!signal) {
+      reject(new Error('Provider did not receive AbortSignal'))
+      return
+    }
+
+    const rejectAsAborted = () => reject(signal.reason ?? new DOMException('Aborted', 'AbortError'))
+    if (signal.aborted) {
+      rejectAsAborted()
+      return
+    }
+    signal.addEventListener('abort', rejectAsAborted, { once: true })
+  })
+}
+
+/** 启动请求、触发取消并验证 provider 观察到同一个 signal。 */
+async function expectProviderCancellation(
+  start: (signal: AbortSignal) => Promise<void>,
+): Promise<void> {
+  const controller = new AbortController()
+  const pending = start(controller.signal)
+  controller.abort()
+  await expect(pending).rejects.toMatchObject({ name: 'AbortError' })
+}
+
+describe('provider stream cancellation', () => {
+  it('forwards the LLM service signal to the selected provider adapter', async () => {
+    let receivedSignal: AbortSignal | undefined
+    const adapter = new OpenAIAdapter()
+    const config = createConfig(adapter)
+    const fakeAdapter = {
+      ...adapter,
+      sendMessageStream: async (
+        _messages: Message[],
+        _config: TextModelConfig,
+        _callbacks: StreamHandlers,
+        options?: { signal?: AbortSignal },
+      ) => {
+        receivedSignal = options?.signal
+        await waitForProviderAbort(receivedSignal)
+      },
+    } as unknown as ITextProviderAdapter
+    const modelManager = {
+      getModel: vi.fn().mockResolvedValue(config),
+    }
+    const registry = {
+      getAdapter: vi.fn().mockReturnValue(fakeAdapter),
+    }
+    const service = new LLMService(modelManager as never, registry as never)
+
+    await expectProviderCancellation(async (signal) => {
+      await service.sendMessageStream(messages, config.id, createCallbacks(), { signal })
+    })
+
+    expect(receivedSignal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('passes AbortSignal to OpenAI-compatible SDK requests', async () => {
+    const adapter = new OpenAIAdapter()
+    const config = createConfig(adapter)
+    const create = vi.fn((_body, requestOptions) => waitForProviderAbort(requestOptions?.signal))
+    ;(adapter as any).createOpenAIInstance = vi.fn().mockResolvedValue({
+      chat: { completions: { create } },
+      responses: { create: vi.fn() },
+    })
+
+    await expectProviderCancellation(async (signal) => {
+      await adapter.sendMessageStream(messages, config, createCallbacks(), { signal })
+    })
+
+    expect(create).toHaveBeenCalledWith(expect.objectContaining({ stream: true }), {
+      signal: expect.any(AbortSignal),
+    })
+  })
+
+  it('passes AbortSignal to Anthropic SDK stream requests', async () => {
+    const adapter = new AnthropicAdapter()
+    const config = createConfig(adapter)
+    const stream = vi.fn((_body, requestOptions) => waitForProviderAbort(requestOptions?.signal))
+    ;(adapter as any).createClient = vi.fn().mockResolvedValue({ messages: { stream } })
+
+    await expectProviderCancellation(async (signal) => {
+      await adapter.sendMessageStream(messages, config, createCallbacks(), { signal })
+    })
+
+    expect(stream).toHaveBeenCalledWith(expect.any(Object), {
+      signal: expect.any(AbortSignal),
+    })
+  })
+
+  it('passes AbortSignal to Gemini generation config', async () => {
+    const adapter = new GeminiAdapter()
+    const config = createConfig(adapter)
+    const generateContentStream = vi.fn((request) => (
+      waitForProviderAbort(request.config?.abortSignal)
+    ))
+    ;(adapter as any).createClient = vi.fn().mockResolvedValue({
+      models: { generateContentStream },
+    })
+
+    await expectProviderCancellation(async (signal) => {
+      await adapter.sendMessageStream(messages, config, createCallbacks(), { signal })
+    })
+
+    expect(generateContentStream).toHaveBeenCalledWith(expect.objectContaining({
+      config: expect.objectContaining({ abortSignal: expect.any(AbortSignal) }),
+    }))
+  })
+
+  it('passes AbortSignal to Chrome Prompt API and destroys the active session', async () => {
+    const adapter = new ChromeBuiltInAdapter()
+    const config = createConfig(adapter)
+    const destroy = vi.fn()
+    const promptStreaming = vi.fn((_input, options) => waitForProviderAbort(options?.signal))
+    vi.stubGlobal('LanguageModel', {
+      availability: vi.fn().mockResolvedValue('available'),
+      create: vi.fn().mockResolvedValue({ promptStreaming, destroy }),
+    })
+
+    await expectProviderCancellation(async (signal) => {
+      await adapter.sendMessageStream(messages, config, createCallbacks(), { signal })
+    })
+
+    expect(promptStreaming).toHaveBeenCalledWith('cancel me', {
+      signal: expect.any(AbortSignal),
+    })
+    expect(destroy).toHaveBeenCalled()
+    vi.unstubAllGlobals()
+  })
+})

--- a/packages/desktop/README-env-config.md
+++ b/packages/desktop/README-env-config.md
@@ -172,4 +172,10 @@ private: false
 ---
 
 **更新时间**: 2025-01-12  
-**版本**: v1.2.0+ 
+**版本**: v1.2.0+
+
+## 安全说明（Desktop hardening）
+
+- Renderer 仅接收明确 public 的 `VITE_APP_*` / `VITE_PUBLIC_*` 运行时配置；供应商 `VITE_*_API_KEY` 保留在主进程。
+- 自定义模型密钥请写入应用内模型配置（如 `ls`），不要依赖把 API Key 注入 `window.runtime_config`。
+- 若连接测试报 `IPC request sender is not trusted`，优先按 `README.md` 对应 FAQ 排查 Windows IPC 信任误杀。

--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -84,7 +84,22 @@ npm start
 ### Q: 我的.env.local文件有效吗？
 A: **有效！** 桌面应用现在会自动加载项目根目录的`.env.local`文件。
 
+### Q: 连接测试报 `IPC request sender is not trusted`？
+
+这通常是桌面端 IPC 信任校验误杀，而不是 API Key/Base URL 本身错误。
+
+**常见原因（Windows 安装版）**
+1. `senderFrame.isMainFrame` 在部分 Electron/Windows 组合下为 `undefined`，旧逻辑会把它当成不可信；
+2. `file://` 路径大小写与 `web-dist` 根路径不一致。
+
+**处理**
+1. 确认已包含修复：`config/ipc-security.js` 仅拒绝明确 `isMainFrame === false`；
+2. 确认 `config/window-security.js` 在 win32 上对路径做大小写归一；
+3. 重启应用后再测；
+4. 若仍失败，查看 `AppData/Roaming/@prompt-optimizer/desktop/logs` 中是否仍有 `IPC_UNTRUSTED_SENDER`，并核对页面是否从 `resources/app/web-dist` 加载。
+
 ### Q: 为什么UI显示有API密钥，但测试连接失败？
+
 A: 这是因为UI进程和主进程环境隔离。确保：
 1. 环境变量正确设置在`.env.local`文件中
 2. 重启桌面应用以重新加载环境变量

--- a/packages/desktop/config/ipc-security.js
+++ b/packages/desktop/config/ipc-security.js
@@ -48,8 +48,9 @@ function isTrustedRendererSender(event, options) {
     return false;
   }
 
-  // IPC from subframes must never inherit the main renderer's privileged bridge.
-  if (event?.senderFrame?.isMainFrame !== true) {
+  // Reject known subframes. If senderFrame/isMainFrame is unavailable
+  // (common on some Windows/Electron builds), fall back to URL allowlist only.
+  if (event?.senderFrame && event.senderFrame.isMainFrame === false) {
     return false;
   }
 

--- a/packages/desktop/config/ipc-security.js
+++ b/packages/desktop/config/ipc-security.js
@@ -1,0 +1,105 @@
+const { isAllowedMainFrameNavigation } = require('./window-security');
+
+const STREAM_ID_PATTERN = /^[A-Za-z0-9_-]{1,96}$/;
+
+/** 创建带稳定错误码的 IPC 边界错误。 */
+function createIpcError(code, message) {
+  const error = new Error(message);
+  error.code = code;
+  return error;
+}
+
+/** 将 handler 成功结果包装为跨层统一响应信封。 */
+function createSuccessResponse(data) {
+  return { success: true, data };
+}
+
+/** 将未知异常收敛为不包含 stack 的跨层错误信封。 */
+function createErrorResponse(error) {
+  const message = error instanceof Error ? error.message : String(error);
+  return {
+    success: false,
+    error: {
+      code: error && typeof error.code === 'string' ? error.code : 'IPC_HANDLER_FAILED',
+      message,
+    },
+  };
+}
+
+/** 优先读取 senderFrame URL，并为兼容环境回退到 sender URL。 */
+function getSenderUrl(event) {
+  const frameUrl = event?.senderFrame?.url;
+  if (typeof frameUrl === 'string' && frameUrl.length > 0) {
+    return frameUrl;
+  }
+
+  const getUrl = event?.sender?.getURL;
+  return typeof getUrl === 'function' ? getUrl.call(event.sender) : '';
+}
+
+/** 判断 IPC 是否来自应用允许的未销毁主 frame renderer。 */
+function isTrustedRendererSender(event, options) {
+  const sender = event?.sender;
+  if (!sender || typeof sender.id !== 'number') {
+    return false;
+  }
+
+  if (typeof sender.isDestroyed === 'function' && sender.isDestroyed()) {
+    return false;
+  }
+
+  // IPC from subframes must never inherit the main renderer's privileged bridge.
+  if (event?.senderFrame?.isMainFrame !== true) {
+    return false;
+  }
+
+  return isAllowedMainFrameNavigation(getSenderUrl(event), options);
+}
+
+/** 拒绝来自子 frame、外部页面或已销毁 renderer 的 IPC 请求。 */
+function assertTrustedRendererSender(event, options) {
+  if (!isTrustedRendererSender(event, options)) {
+    throw createIpcError('IPC_UNTRUSTED_SENDER', 'IPC request sender is not trusted');
+  }
+}
+
+/** 判断流标识是否满足长度与字符集约束。 */
+function isValidStreamId(streamId) {
+  return typeof streamId === 'string' && STREAM_ID_PATTERN.test(streamId);
+}
+
+/** 在流标识不合法时抛出稳定 IPC 错误。 */
+function assertValidStreamId(streamId) {
+  if (!isValidStreamId(streamId)) {
+    throw createIpcError('IPC_INVALID_STREAM_ID', 'Invalid IPC stream identifier');
+  }
+}
+
+/** 注册具备 sender 校验、参数校验和统一响应信封的敏感 IPC handler。 */
+function registerSecureIpcHandler(ipcMain, channel, handler, {
+  senderOptions,
+  validateArgs,
+  createSuccess = createSuccessResponse,
+  createError = createErrorResponse,
+} = {}) {
+  ipcMain.handle(channel, async (event, ...args) => {
+    try {
+      assertTrustedRendererSender(event, senderOptions);
+      if (typeof validateArgs === 'function') {
+        validateArgs(args, event);
+      }
+      return createSuccess(await handler(event, ...args));
+    } catch (error) {
+      return createError(error);
+    }
+  });
+}
+
+module.exports = {
+  assertTrustedRendererSender,
+  assertValidStreamId,
+  createIpcError,
+  isTrustedRendererSender,
+  isValidStreamId,
+  registerSecureIpcHandler,
+};

--- a/packages/desktop/config/ipc-security.test.js
+++ b/packages/desktop/config/ipc-security.test.js
@@ -1,0 +1,122 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  createIpcError,
+  isTrustedRendererSender,
+  isValidStreamId,
+  registerSecureIpcHandler,
+} = require('./ipc-security');
+
+const options = {
+  isDevelopment: false,
+  packagedRoot: 'C:/app/web-dist',
+  devServerUrl: 'http://localhost:18181',
+};
+
+function createEvent({
+  id = 1,
+  url = 'file:///C:/app/web-dist/index.html',
+  isMainFrame = true,
+} = {}) {
+  return {
+    sender: {
+      id,
+      getURL: () => url,
+      isDestroyed: () => false,
+    },
+    senderFrame: {
+      url,
+      isMainFrame,
+    },
+  };
+}
+
+function createIpcMain() {
+  const handlers = new Map();
+  return {
+    handlers,
+    handle(channel, handler) {
+      handlers.set(channel, handler);
+    },
+  };
+}
+
+test('IPC sender trust accepts only the app main frame', () => {
+  assert.equal(isTrustedRendererSender(createEvent(), options), true);
+  assert.equal(isTrustedRendererSender(createEvent({ isMainFrame: false }), options), false);
+  assert.equal(
+    isTrustedRendererSender(createEvent({ url: 'file:///C:/Windows/System32/notepad.exe' }), options),
+    false,
+  );
+  assert.equal(
+    isTrustedRendererSender(createEvent({ url: 'https://attacker.example' }), options),
+    false,
+  );
+});
+
+test('IPC sender trust accepts only the configured development origin', () => {
+  const developmentOptions = { ...options, isDevelopment: true };
+
+  assert.equal(
+    isTrustedRendererSender(createEvent({ url: 'http://localhost:18181/workspace' }), developmentOptions),
+    true,
+  );
+  assert.equal(
+    isTrustedRendererSender(createEvent({ url: 'http://localhost:5173/workspace' }), developmentOptions),
+    false,
+  );
+});
+
+test('stream identifiers are bounded and use a restricted alphabet', () => {
+  assert.equal(isValidStreamId('stream_abc-123'), true);
+  assert.equal(isValidStreamId('stream with spaces'), false);
+  assert.equal(isValidStreamId('../stream'), false);
+  assert.equal(isValidStreamId('a'.repeat(97)), false);
+});
+
+test('secure IPC handler rejects untrusted senders with the shared error envelope', async () => {
+  const ipcMain = createIpcMain();
+  let called = false;
+
+  registerSecureIpcHandler(ipcMain, 'sensitive-action', async () => {
+    called = true;
+    return 'unreachable';
+  }, { senderOptions: options });
+
+  const result = await ipcMain.handlers.get('sensitive-action')(
+    createEvent({ url: 'https://attacker.example' }),
+  );
+
+  assert.equal(called, false);
+  assert.deepEqual(result, {
+    success: false,
+    error: {
+      code: 'IPC_UNTRUSTED_SENDER',
+      message: 'IPC request sender is not trusted',
+    },
+  });
+});
+
+test('secure IPC handler validates arguments and normalizes successful results', async () => {
+  const ipcMain = createIpcMain();
+
+  registerSecureIpcHandler(ipcMain, 'validated-action', async (_event, value) => value.toUpperCase(), {
+    senderOptions: options,
+    validateArgs: ([value]) => {
+      if (typeof value !== 'string') {
+        throw createIpcError('IPC_INVALID_ARGUMENT', 'Invalid IPC request arguments');
+      }
+    },
+  });
+
+  const handler = ipcMain.handlers.get('validated-action');
+  assert.deepEqual(await handler(createEvent(), 'ok'), { success: true, data: 'OK' });
+  assert.deepEqual(await handler(createEvent(), 42), {
+    success: false,
+    error: {
+      code: 'IPC_INVALID_ARGUMENT',
+      message: 'Invalid IPC request arguments',
+    },
+  });
+});

--- a/packages/desktop/config/ipc-security.test.js
+++ b/packages/desktop/config/ipc-security.test.js
@@ -55,6 +55,21 @@ test('IPC sender trust accepts only the app main frame', () => {
   );
 });
 
+test('IPC sender trust tolerates missing senderFrame metadata on packaged file URLs', () => {
+  const eventWithoutFrame = {
+    sender: {
+      id: 7,
+      getURL: () => 'file:///C:/app/web-dist/index.html',
+      isDestroyed: () => false,
+    },
+  };
+  assert.equal(isTrustedRendererSender(eventWithoutFrame, options), true);
+
+  const eventWithUnknownMainFrame = createEvent();
+  delete eventWithUnknownMainFrame.senderFrame.isMainFrame;
+  assert.equal(isTrustedRendererSender(eventWithUnknownMainFrame, options), true);
+});
+
 test('IPC sender trust accepts only the configured development origin', () => {
   const developmentOptions = { ...options, isDevelopment: true };
 

--- a/packages/desktop/config/ipc/owned-stream-runner.js
+++ b/packages/desktop/config/ipc/owned-stream-runner.js
@@ -1,0 +1,51 @@
+const { createOwnedStreamHandlers } = require('../stream-registry');
+
+/**
+ * 创建绑定 renderer 所有权的流任务执行器，集中处理事件转发、错误通知和注册表清理。
+ *
+ * @param {object} dependencies 运行流任务所需的后端依赖。
+ * @param {ReturnType<import('../stream-registry').createStreamRegistry>} dependencies.streamRegistry
+ *   维护 sender 与 streamId 所有权的注册表。
+ * @returns {Function} 供各领域 IPC module 复用的流任务执行函数。
+ */
+function createOwnedStreamRunner({ streamRegistry }) {
+  if (!streamRegistry || typeof streamRegistry.register !== 'function') {
+    throw new TypeError('Owned stream runner requires a stream registry');
+  }
+
+  /**
+   * 执行单个流任务，并确保结束、异常或取消后都释放该任务的所有权记录。
+   */
+  return async function runOwnedStream(
+    event,
+    streamId,
+    channels,
+    operation,
+    notifyError = false,
+  ) {
+    const stream = streamRegistry.register(event.sender, streamId);
+    const handlers = createOwnedStreamHandlers({
+      registry: streamRegistry,
+      sender: event.sender,
+      streamId,
+      channels,
+    });
+
+    try {
+      // 将同一 AbortSignal 交给领域 service；取消后既停止 IPC 转发，也中止 provider 请求。
+      await operation(handlers, stream.signal);
+      return null;
+    } catch (error) {
+      if (notifyError) {
+        handlers.onError(error);
+      }
+      throw error;
+    } finally {
+      streamRegistry.complete(event.sender, streamId);
+    }
+  };
+}
+
+module.exports = {
+  createOwnedStreamRunner,
+};

--- a/packages/desktop/config/preload-stream-cancellation.test.js
+++ b/packages/desktop/config/preload-stream-cancellation.test.js
@@ -1,0 +1,125 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+const path = require('node:path');
+const { EventEmitter } = require('node:events');
+
+/**
+ * 使用可控的 Electron IPC 替身加载 preload，并返回暴露给前端的桥接接口。
+ */
+function loadPreloadWithElectronMock(ipcRenderer) {
+  const preloadPath = path.resolve(__dirname, '../preload.js');
+  const originalLoad = Module._load;
+  let api;
+
+  Module._load = function load(request, parent, isMain) {
+    if (request === 'electron') {
+      return {
+        contextBridge: {
+          exposeInMainWorld: (_name, exposedApi) => {
+            api = exposedApi;
+          },
+        },
+        ipcRenderer,
+      };
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  try {
+    delete require.cache[preloadPath];
+    require(preloadPath);
+    return api;
+  } finally {
+    Module._load = originalLoad;
+    delete require.cache[preloadPath];
+  }
+}
+
+test('preload AbortSignal cancels an active stream and resolves the caller promptly', async () => {
+  const calls = [];
+  const listeners = new Map();
+  const ipcRenderer = {
+    on(channel, listener) {
+      listeners.set(`${channel}:${listener.name || listeners.size}`, listener);
+    },
+    removeListener(channel, listener) {
+      listeners.delete(`${channel}:${listener.name || 0}`);
+    },
+    invoke(channel, ...args) {
+      calls.push([channel, ...args]);
+      if (channel === 'stream-cancel') {
+        return Promise.resolve({ success: true, data: { cancelled: true } });
+      }
+      return new Promise(() => {});
+    },
+  };
+  const api = loadPreloadWithElectronMock(ipcRenderer);
+  const controller = new AbortController();
+
+  const pending = api.llm.sendMessageStream([], 'provider', {}, controller.signal);
+  controller.abort();
+
+  await assert.rejects(
+    pending,
+    (error) => error && error.code === 'IPC_STREAM_CANCELLED',
+  );
+  assert.equal(calls[0][0], 'llm-sendMessageStream');
+  assert.equal(calls[1][0], 'stream-cancel');
+  assert.match(calls[1][1], /^stream_[A-Za-z0-9_]+$/);
+  assert.equal(listeners.size, 0);
+});
+
+test('preload forwards Prompt AbortSignal to the main-process cancellation channel', async () => {
+  const calls = [];
+  const ipcRenderer = new EventEmitter();
+  ipcRenderer.invoke = (channel, ...args) => {
+    calls.push([channel, ...args]);
+    if (channel === 'stream-cancel') {
+      return Promise.resolve({ success: true, data: { cancelled: true } });
+    }
+    return new Promise(() => {});
+  };
+  const api = loadPreloadWithElectronMock(ipcRenderer);
+  const controller = new AbortController();
+
+  const pending = api.prompt.optimizePromptStream({}, {}, controller.signal);
+  controller.abort();
+
+  await assert.rejects(
+    Promise.race([
+      pending,
+      new Promise((_, reject) => setTimeout(() => reject(new Error('Prompt cancellation timed out')), 100)),
+    ]),
+    (error) => error && error.code === 'IPC_STREAM_CANCELLED',
+  );
+  assert.equal(calls[0][0], 'prompt-optimizePromptStream');
+  assert.equal(calls[1][0], 'stream-cancel');
+  assert.equal(ipcRenderer.listenerCount('stream-token-' + calls[1][1]), 0);
+});
+
+test('preload on/off and disposer remove the exact wrapped listener', () => {
+  const ipcRenderer = new EventEmitter();
+  ipcRenderer.invoke = async () => ({ success: true, data: null });
+  const api = loadPreloadWithElectronMock(ipcRenderer);
+  let callCount = 0;
+
+  /** 记录前端实际收到的更新事件次数。 */
+  const callback = () => {
+    callCount += 1;
+  };
+
+  const dispose = api.on('update-error', callback);
+  assert.equal(typeof dispose, 'function');
+  ipcRenderer.emit('update-error', {}, 'first');
+  assert.equal(callCount, 1);
+
+  api.off('update-error', callback);
+  ipcRenderer.emit('update-error', {}, 'second');
+  assert.equal(callCount, 1);
+  assert.equal(ipcRenderer.listenerCount('update-error'), 0);
+
+  const disposeAgain = api.on('update-error', callback);
+  disposeAgain();
+  assert.equal(ipcRenderer.listenerCount('update-error'), 0);
+});

--- a/packages/desktop/config/remote-storage.test.js
+++ b/packages/desktop/config/remote-storage.test.js
@@ -1,0 +1,68 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { handleRemoteStorageOperation } = require('../remote-storage');
+
+const webDavRequest = (path, directory = 'prompt-optimizer-backups') => ({
+  operation: 'head',
+  path,
+  provider: {
+    kind: 'webdav',
+    endpoint: 'https://storage.example.test',
+    directory,
+  },
+});
+
+test('remote storage rejects traversal paths before creating a client', async () => {
+  const unsafePaths = [
+    '../outside.json',
+    'nested/../../outside.json',
+    'nested\\..\\outside.json',
+    '%2e%2e/outside.json',
+    'nested/%2foutside.json',
+  ];
+
+  for (const path of unsafePaths) {
+    let clientCreated = false;
+    await assert.rejects(
+      handleRemoteStorageOperation(webDavRequest(path), {
+        createWebDavClient: async () => {
+          clientCreated = true;
+          return {};
+        },
+      }),
+      /Remote storage path/,
+    );
+    assert.equal(clientCreated, false, `client should not be created for ${path}`);
+  }
+});
+
+test('remote storage rejects a traversal base directory', async () => {
+  let clientCreated = false;
+  await assert.rejects(
+    handleRemoteStorageOperation(webDavRequest('backup.json', '../outside'), {
+      createWebDavClient: async () => {
+        clientCreated = true;
+        return {};
+      },
+    }),
+    /Remote storage path/,
+  );
+  assert.equal(clientCreated, false);
+});
+
+test('remote storage keeps valid nested WebDAV paths compatible', async () => {
+  let requestedPath = null;
+  const result = await handleRemoteStorageOperation(webDavRequest('daily/backup.json'), {
+    createWebDavClient: async () => ({
+      stat: async (path) => {
+        requestedPath = path;
+        return { size: 42 };
+      },
+    }),
+  });
+
+  assert.equal(requestedPath, '/prompt-optimizer-backups/daily/backup.json');
+  assert.equal(result.path, 'daily/backup.json');
+  assert.equal(result.sizeBytes, 42);
+});

--- a/packages/desktop/config/runtime-security.js
+++ b/packages/desktop/config/runtime-security.js
@@ -1,3 +1,7 @@
+/** Runtime config exposed to renderer must be explicitly public.
+ * Supplier API keys (VITE_*_API_KEY) stay main-process-only and are never
+ * returned by getPublicRuntimeConfig / config-getEnvironmentVariables.
+ */
 const PUBLIC_RUNTIME_CONFIG_PATTERN = /^VITE_(?:APP|PUBLIC)_[A-Z0-9_]+$/;
 const SENSITIVE_RUNTIME_CONFIG_SEGMENT = /(?:^|_)(?:API_KEY|KEY|TOKEN|SECRET|PASSWORD|PASS|AUTHORIZATION|HEADERS|CREDENTIALS?|COOKIE|PRIVATE)(?:_|$)/i;
 

--- a/packages/desktop/config/runtime-security.js
+++ b/packages/desktop/config/runtime-security.js
@@ -1,0 +1,30 @@
+const PUBLIC_RUNTIME_CONFIG_PATTERN = /^VITE_(?:APP|PUBLIC)_[A-Z0-9_]+$/;
+const SENSITIVE_RUNTIME_CONFIG_SEGMENT = /(?:^|_)(?:API_KEY|KEY|TOKEN|SECRET|PASSWORD|PASS|AUTHORIZATION|HEADERS|CREDENTIALS?|COOKIE|PRIVATE)(?:_|$)/i;
+
+/** 判断环境变量是否明确允许暴露给 renderer，且名称不包含敏感字段。 */
+function isPublicRuntimeConfigKey(key) {
+  return PUBLIC_RUNTIME_CONFIG_PATTERN.test(key)
+    && !SENSITIVE_RUNTIME_CONFIG_SEGMENT.test(key);
+}
+
+/** 从主进程环境中提取 renderer 可见的公共配置及其无前缀兼容键。 */
+function getPublicRuntimeConfig(environment) {
+  const config = {};
+
+  for (const [key, value] of Object.entries(environment)) {
+    if (!isPublicRuntimeConfigKey(key) || value === undefined || value === null || String(value).length === 0) {
+      continue;
+    }
+
+    const stringValue = String(value);
+    config[key] = stringValue;
+    config[key.replace(/^VITE_/, '')] = stringValue;
+  }
+
+  return config;
+}
+
+module.exports = {
+  getPublicRuntimeConfig,
+  isPublicRuntimeConfigKey,
+};

--- a/packages/desktop/config/runtime-security.test.js
+++ b/packages/desktop/config/runtime-security.test.js
@@ -1,0 +1,38 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { getPublicRuntimeConfig } = require('./runtime-security');
+
+test('renderer runtime config exposes only explicitly public VITE variables', () => {
+  const config = getPublicRuntimeConfig({
+    VITE_PUBLIC_RELEASE_CHANNEL: 'stable',
+    VITE_APP_BUILD_LABEL: 'desktop',
+    VITE_OPENAI_API_KEY: 'secret-openai-key',
+    VITE_CUSTOM_API_HEADERS: '{"Authorization":"Bearer secret"}',
+    VITE_CUSTOM_API_BASE_URL: 'https://provider.example',
+    INTERNAL_FEATURE_FLAG: 'hidden',
+  });
+
+  assert.deepEqual(config, {
+    VITE_PUBLIC_RELEASE_CHANNEL: 'stable',
+    PUBLIC_RELEASE_CHANNEL: 'stable',
+    VITE_APP_BUILD_LABEL: 'desktop',
+    APP_BUILD_LABEL: 'desktop',
+  });
+  assert.equal(JSON.stringify(config).includes('secret-openai-key'), false);
+  assert.equal(JSON.stringify(config).includes('Bearer secret'), false);
+  assert.equal(JSON.stringify(config).includes('provider.example'), false);
+});
+
+test('renderer runtime config rejects public-looking names that contain sensitive segments', () => {
+  const config = getPublicRuntimeConfig({
+    VITE_PUBLIC_API_TOKEN_HINT: 'still-secret',
+    VITE_APP_PASSWORD_STATUS: 'still-secret',
+    VITE_PUBLIC_FEATURE_FLAG: 'enabled',
+  });
+
+  assert.deepEqual(config, {
+    VITE_PUBLIC_FEATURE_FLAG: 'enabled',
+    PUBLIC_FEATURE_FLAG: 'enabled',
+  });
+});

--- a/packages/desktop/config/stream-registry.js
+++ b/packages/desktop/config/stream-registry.js
@@ -1,0 +1,184 @@
+const { createIpcError } = require('./ipc-security');
+
+/** 获取 renderer sender 的稳定标识，并拒绝无效 sender。 */
+function getSenderId(sender) {
+  if (!sender || typeof sender.id !== 'number') {
+    throw createIpcError('IPC_UNTRUSTED_SENDER', 'IPC request sender is not trusted');
+  }
+  return sender.id;
+}
+
+/** 创建限制并发数、校验所有权并支持取消的流任务注册表。 */
+function createStreamRegistry({ maxStreamsPerSender = 4 } = {}) {
+  const streams = new Map();
+  const observedSenders = new WeakSet();
+
+  /** 注册新流任务并返回供领域执行器使用的取消信号。 */
+  function register(sender, streamId) {
+    const senderId = getSenderId(sender);
+    if (streams.has(streamId)) {
+      throw createIpcError('IPC_STREAM_ALREADY_EXISTS', 'IPC stream identifier is already active');
+    }
+
+    const activeForSender = [...streams.values()]
+      .filter((stream) => stream.senderId === senderId)
+      .length;
+    if (activeForSender >= maxStreamsPerSender) {
+      throw createIpcError('IPC_STREAM_LIMIT_REACHED', 'Too many active IPC streams');
+    }
+
+    const controller = new AbortController();
+    const stream = { sender, senderId, controller, signal: controller.signal };
+    streams.set(streamId, stream);
+
+    observeSender(sender);
+
+    return stream;
+  }
+
+  /** 判断流标识是否仍在注册表中。 */
+  function has(streamId) {
+    return streams.has(streamId);
+  }
+
+  /** 判断流是否属于指定 sender 且仍可向 renderer 转发事件。 */
+  function isOwned(sender, streamId) {
+    const stream = streams.get(streamId);
+    return Boolean(stream)
+      && stream.senderId === getSenderId(sender);
+  }
+
+  /** 流仍归该 sender 且未取消时，才转发 token/tool 事件。 */
+  function isActive(sender, streamId) {
+    const stream = streams.get(streamId);
+    return isOwned(sender, streamId) && !stream.signal.aborted;
+  }
+
+  /** 由流所有者取消任务并触发对应 AbortSignal。 */
+  function cancel(sender, streamId) {
+    const stream = streams.get(streamId);
+    if (!stream) {
+      throw createIpcError('IPC_STREAM_NOT_FOUND', 'IPC stream was not found');
+    }
+    if (stream.senderId !== getSenderId(sender)) {
+      throw createIpcError('IPC_STREAM_NOT_OWNER', 'IPC stream is not owned by this renderer');
+    }
+
+    stream.controller.abort();
+    streams.delete(streamId);
+    return true;
+  }
+
+  /** 在任务正常完成或异常结束后释放所有权记录。 */
+  function complete(sender, streamId) {
+    const stream = streams.get(streamId);
+    if (!stream) {
+      return false;
+    }
+    if (stream.senderId !== getSenderId(sender)) {
+      throw createIpcError('IPC_STREAM_NOT_OWNER', 'IPC stream is not owned by this renderer');
+    }
+
+    streams.delete(streamId);
+    return true;
+  }
+
+  /** sender 销毁时取消其全部活动流，避免后台任务继续占用资源。 */
+  function cancelAllForSender(sender) {
+    const senderId = getSenderId(sender);
+    for (const [streamId, stream] of streams) {
+      if (stream.senderId !== senderId) {
+        continue;
+      }
+      stream.controller.abort();
+      streams.delete(streamId);
+    }
+  }
+
+  /** 每个 sender 只绑定一次销毁监听，避免频繁流调用累积 EventEmitter listener。 */
+  function observeSender(sender) {
+    if (typeof sender.once !== 'function' || observedSenders.has(sender)) {
+      return;
+    }
+
+    observedSenders.add(sender);
+    sender.once('destroyed', () => {
+      try {
+        cancelAllForSender(sender);
+      } finally {
+        observedSenders.delete(sender);
+      }
+    });
+  }
+
+  return {
+    cancel,
+    cancelAllForSender,
+    complete,
+    has,
+    isActive,
+    isOwned,
+    register,
+  };
+}
+
+/** 创建只向流所有者发送 token、工具、完成和错误事件的回调集合。 */
+function createOwnedStreamHandlers({ registry, sender, streamId, channels }) {
+  /** 在流仍活动时发送单个 renderer 事件。 */
+  const send = function send(channel, payload) {
+    if (!channel || !registry.isActive(sender, streamId)) {
+      return false;
+    }
+    if (typeof sender.isDestroyed === 'function' && sender.isDestroyed()) {
+      registry.complete(sender, streamId);
+      return false;
+    }
+
+    const eventName = `${channel}-${streamId}`;
+    if (arguments.length === 1) {
+      sender.send(eventName);
+    } else {
+      sender.send(eventName, payload);
+    }
+    return true;
+  };
+
+  const sendOwned = function sendOwned(channel, payload) {
+    if (!channel || !registry.isOwned(sender, streamId)) {
+      return false;
+    }
+    if (typeof sender.isDestroyed === 'function' && sender.isDestroyed()) {
+      registry.complete(sender, streamId);
+      return false;
+    }
+    const eventName = `${channel}-${streamId}`;
+    if (arguments.length === 1) {
+      sender.send(eventName);
+    } else {
+      sender.send(eventName, payload);
+    }
+    return true;
+  };
+
+  return {
+    onToken: (token) => send(channels.token, token),
+    onReasoningToken: (token) => send(channels.reasoning, token),
+    onToolCall: (toolCall) => send(channels.toolCall, toolCall),
+    onComplete: () => {
+      if (sendOwned(channels.finish)) {
+        registry.complete(sender, streamId);
+      }
+    },
+    onError: (error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      if (sendOwned(channels.error, message)) {
+        registry.complete(sender, streamId);
+      }
+    },
+  };
+}
+
+module.exports = {
+  createOwnedStreamHandlers,
+  createStreamRegistry,
+};

--- a/packages/desktop/config/stream-registry.test.js
+++ b/packages/desktop/config/stream-registry.test.js
@@ -1,0 +1,94 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+
+const {
+  createOwnedStreamHandlers,
+  createStreamRegistry,
+} = require('./stream-registry');
+
+/** 创建具备 Electron WebContents 最小事件接口的 renderer sender 替身。 */
+function createSender(id) {
+  const sent = [];
+  const sender = new EventEmitter();
+  sender.id = id;
+  sender.sent = sent;
+  sender.isDestroyed = () => false;
+  sender.send = (...args) => sent.push(args);
+  return sender;
+}
+
+test('stream cancellation aborts the owner controller and stops further renderer events', () => {
+  const registry = createStreamRegistry();
+  const sender = createSender(1);
+  const stream = registry.register(sender, 'stream_owner');
+  const handlers = createOwnedStreamHandlers({
+    registry,
+    sender,
+    streamId: 'stream_owner',
+    channels: { token: 'stream-token', finish: 'stream-finish', error: 'stream-error' },
+  });
+
+  handlers.onToken('before-cancel');
+  assert.deepEqual(sender.sent, [['stream-token-stream_owner', 'before-cancel']]);
+
+  assert.equal(registry.cancel(sender, 'stream_owner'), true);
+  assert.equal(stream.signal.aborted, true);
+
+  handlers.onToken('after-cancel');
+  handlers.onComplete();
+  assert.deepEqual(sender.sent, [['stream-token-stream_owner', 'before-cancel']]);
+  assert.equal(registry.has('stream_owner'), false);
+});
+
+test('a non-owner cannot cancel an active stream', () => {
+  const registry = createStreamRegistry();
+  const owner = createSender(1);
+  const otherSender = createSender(2);
+  registry.register(owner, 'stream_owner');
+
+  assert.throws(
+    () => registry.cancel(otherSender, 'stream_owner'),
+    (error) => error && error.code === 'IPC_STREAM_NOT_OWNER',
+  );
+  assert.equal(registry.has('stream_owner'), true);
+});
+
+test('stream completion sends only to the registered sender and clears ownership', () => {
+  const registry = createStreamRegistry();
+  const owner = createSender(1);
+  const unrelatedWindow = createSender(2);
+  registry.register(owner, 'stream_complete');
+  const handlers = createOwnedStreamHandlers({
+    registry,
+    sender: owner,
+    streamId: 'stream_complete',
+    channels: { finish: 'stream-finish', error: 'stream-error' },
+  });
+
+  handlers.onComplete();
+
+  assert.deepEqual(owner.sent, [['stream-finish-stream_complete']]);
+  assert.deepEqual(unrelatedWindow.sent, []);
+  assert.equal(registry.has('stream_complete'), false);
+});
+
+test('stream registry binds one destroyed listener per sender and cancels active work on teardown', () => {
+  const registry = createStreamRegistry();
+  const sender = createSender(1);
+
+  for (let index = 0; index < 12; index += 1) {
+    const streamId = `stream_completed_${index}`;
+    registry.register(sender, streamId);
+    registry.complete(sender, streamId);
+  }
+
+  const activeStream = registry.register(sender, 'stream_active');
+  assert.equal(sender.listenerCount('destroyed'), 1);
+
+  sender.emit('destroyed');
+
+  assert.equal(activeStream.signal.aborted, true);
+  assert.equal(registry.has('stream_active'), false);
+  assert.equal(sender.listenerCount('destroyed'), 0);
+});

--- a/packages/desktop/config/window-security.js
+++ b/packages/desktop/config/window-security.js
@@ -1,0 +1,70 @@
+const path = require('path');
+const { fileURLToPath } = require('url');
+
+/** 仅允许具备主机名的 HTTP/HTTPS 地址交给系统浏览器。 */
+function isSafeExternalUrl(value) {
+  try {
+    const url = new URL(value);
+    return ['http:', 'https:'].includes(url.protocol) && Boolean(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+/** 判断候选文件路径是否位于指定应用根目录内。 */
+function isPathWithin(candidatePath, rootPath) {
+  const candidate = path.resolve(candidatePath);
+  const root = path.resolve(rootPath);
+  return candidate === root || candidate.startsWith(`${root}${path.sep}`);
+}
+
+/** 校验主 frame 导航是否属于当前开发源或打包应用目录。 */
+function isAllowedMainFrameNavigation(targetUrl, options) {
+  try {
+    const url = new URL(targetUrl);
+    if (options.isDevelopment) {
+      return url.origin === new URL(options.devServerUrl).origin;
+    }
+
+    return url.protocol === 'file:'
+      && isPathWithin(fileURLToPath(url), options.packagedRoot);
+  } catch {
+    return false;
+  }
+}
+
+/** 安装顶层导航、新窗口和 webview 的统一 Electron 安全门禁。 */
+function installMainFrameNavigationGuard(webContents, options) {
+  /** 将通过协议校验的外部地址交给系统浏览器，并隔离打开失败。 */
+  const openExternal = (url) => {
+    if (!isSafeExternalUrl(url)) {
+      return;
+    }
+
+    void Promise.resolve(options.openExternal(url)).catch(() => {});
+  };
+
+  webContents.on('will-navigate', (event, targetUrl) => {
+    if (isAllowedMainFrameNavigation(targetUrl, options)) {
+      return;
+    }
+
+    event.preventDefault();
+    openExternal(targetUrl);
+  });
+
+  webContents.setWindowOpenHandler(({ url }) => {
+    openExternal(url);
+    return { action: 'deny' };
+  });
+
+  webContents.on('will-attach-webview', (event) => {
+    event.preventDefault();
+  });
+}
+
+module.exports = {
+  installMainFrameNavigationGuard,
+  isAllowedMainFrameNavigation,
+  isSafeExternalUrl,
+};

--- a/packages/desktop/config/window-security.js
+++ b/packages/desktop/config/window-security.js
@@ -15,7 +15,11 @@ function isSafeExternalUrl(value) {
 function isPathWithin(candidatePath, rootPath) {
   const candidate = path.resolve(candidatePath);
   const root = path.resolve(rootPath);
-  return candidate === root || candidate.startsWith(`${root}${path.sep}`);
+  // Windows paths are case-insensitive; normalize to avoid false untrusted senders.
+  const norm = (value) => process.platform === 'win32' ? value.toLowerCase() : value;
+  const c = norm(candidate);
+  const r = norm(root);
+  return c === r || c.startsWith(`${r}${path.sep}`);
 }
 
 /** 校验主 frame 导航是否属于当前开发源或打包应用目录。 */

--- a/packages/desktop/config/window-security.test.js
+++ b/packages/desktop/config/window-security.test.js
@@ -1,0 +1,63 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+
+const {
+  installMainFrameNavigationGuard,
+  isAllowedMainFrameNavigation,
+} = require('./window-security');
+
+function createWebContents() {
+  const webContents = new EventEmitter();
+  webContents.setWindowOpenHandler = (handler) => {
+    webContents.windowOpenHandler = handler;
+  };
+  return webContents;
+}
+
+test('production navigation allows only packaged files under the application root', () => {
+  const options = {
+    isDevelopment: false,
+    packagedRoot: 'C:/app/web-dist',
+    devServerUrl: 'http://localhost:18181',
+  };
+
+  assert.equal(isAllowedMainFrameNavigation('file:///C:/app/web-dist/index.html', options), true);
+  assert.equal(isAllowedMainFrameNavigation('file:///C:/app/web-dist/assets/app.js', options), true);
+  assert.equal(isAllowedMainFrameNavigation('file:///C:/Windows/System32/notepad.exe', options), false);
+  assert.equal(isAllowedMainFrameNavigation('https://attacker.example', options), false);
+});
+
+test('development navigation allows only the configured development server origin', () => {
+  const options = {
+    isDevelopment: true,
+    packagedRoot: 'C:/app/web-dist',
+    devServerUrl: 'http://localhost:18181',
+  };
+
+  assert.equal(isAllowedMainFrameNavigation('http://localhost:18181/workspace', options), true);
+  assert.equal(isAllowedMainFrameNavigation('http://localhost:5173/workspace', options), false);
+  assert.equal(isAllowedMainFrameNavigation('https://attacker.example', options), false);
+});
+
+test('navigation guard prevents untrusted top-level navigation and opens only safe external links', async () => {
+  const webContents = createWebContents();
+  const openedUrls = [];
+  installMainFrameNavigationGuard(webContents, {
+    isDevelopment: false,
+    packagedRoot: 'C:/app/web-dist',
+    devServerUrl: 'http://localhost:18181',
+    openExternal: async (url) => openedUrls.push(url),
+  });
+
+  let prevented = false;
+  webContents.emit('will-navigate', { preventDefault: () => { prevented = true; } }, 'https://docs.example');
+  await new Promise(resolve => setImmediate(resolve));
+
+  assert.equal(prevented, true);
+  assert.deepEqual(openedUrls, ['https://docs.example']);
+  assert.deepEqual(webContents.windowOpenHandler({ url: 'javascript:alert(1)' }), { action: 'deny' });
+  assert.deepEqual(webContents.windowOpenHandler({ url: 'https://docs.example/new' }), { action: 'deny' });
+  await new Promise(resolve => setImmediate(resolve));
+  assert.deepEqual(openedUrls, ['https://docs.example', 'https://docs.example/new']);
+});

--- a/packages/desktop/config/window-security.test.js
+++ b/packages/desktop/config/window-security.test.js
@@ -61,3 +61,20 @@ test('navigation guard prevents untrusted top-level navigation and opens only sa
   await new Promise(resolve => setImmediate(resolve));
   assert.deepEqual(openedUrls, ['https://docs.example', 'https://docs.example/new']);
 });
+
+test('production file URL allowlist accepts mixed-case packaged paths', () => {
+  const options = {
+    isDevelopment: false,
+    packagedRoot: 'C:/app/web-dist',
+    devServerUrl: 'http://localhost:18181',
+  };
+  // Windows webContents may surface different drive-letter casing than packagedRoot.
+  assert.equal(
+    isAllowedMainFrameNavigation('file:///c:/APP/web-dist/index.html', options),
+    true,
+  );
+  assert.equal(
+    isAllowedMainFrameNavigation('file:///C:/app/web-dist/index.html', options),
+    true,
+  );
+});

--- a/packages/desktop/main.js
+++ b/packages/desktop/main.js
@@ -49,6 +49,13 @@ const {
   getPageZoomActionFromDirection,
 } = require('./config/page-zoom');
 const { setupRemoteStorageHandlers } = require('./remote-storage');
+const { getPublicRuntimeConfig } = require('./config/runtime-security');
+const { installMainFrameNavigationGuard, isSafeExternalUrl } = require('./config/window-security');
+const {
+  createIpcError,
+  registerSecureIpcHandler,
+} = require('./config/ipc-security');
+
 const path = require('path');
 
 // 确定正确的配置文件路径
@@ -67,6 +74,16 @@ const envPath = path.join(__dirname, '.env');
 // 加载环境变量
 require('dotenv').config({ path: envLocalPath });
 require('dotenv').config({ path: envPath });
+
+function getIpcSenderOptions() {
+  return {
+    isDevelopment: process.env.NODE_ENV === 'development',
+    packagedRoot: path.join(__dirname, 'web-dist'),
+    devServerUrl: 'http://localhost:18181',
+  };
+}
+
+
 
 
 const {
@@ -424,24 +441,15 @@ function setupPreferenceHandlers() {
 // 构建注入到渲染进程的运行时配置脚本（双份键：带前缀与不带前缀）
 function buildRuntimeConfigScriptFromEnv() {
   try {
-    const entries = Object.entries(process.env)
-      .filter(([k, v]) => k.startsWith('VITE_') && v !== undefined && v !== null && String(v).length > 0);
+    const publicConfig = getPublicRuntimeConfig(process.env);
+    const publicCount = Object.keys(publicConfig).filter((key) => key.startsWith('VITE_')).length;
 
-    const props = [];
-    for (const [k, v] of entries) {
-      const val = String(v).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-      const noPrefix = k.replace(/^VITE_/, '');
-      props.push([noPrefix, val]);
-      props.push([k, val]);
-    }
-
-    const body = props.map(([key, val]) => `  ${key}: "${val}"`).join(',\n');
-
-    return `// Injected by Electron main process\n`
-      + `window.runtime_config = Object.assign({}, (window.runtime_config || {}), {\n`
-      + `${body}\n`
-      + `});\n`
-      + `console.log('[Main Process] runtime_config injected with ${entries.length} VITE_* vars (dual keys)');\n`;
+    return `// Injected by Electron main process
+`
+      + `window.runtime_config = Object.assign({}, (window.runtime_config || {}), ${JSON.stringify(publicConfig)});
+`
+      + `console.log('[Main Process] runtime_config injected with ${publicCount} public VITE_* vars (dual keys)');
+`;
   } catch (e) {
     return `console.warn('[Main Process] Failed to build runtime_config:', ${JSON.stringify(String(e))});`;
   }
@@ -495,6 +503,12 @@ function createWindow() {
       })
     )
   );
+
+  installMainFrameNavigationGuard(mainWindow.webContents, {
+    ...getIpcSenderOptions(),
+    openExternal: (url) => shell.openExternal(url),
+  });
+
   mainWindow.webContents.setZoomLevel(DEFAULT_PAGE_ZOOM_LEVEL);
   void mainWindow.webContents
     .setVisualZoomLevelLimits(VISUAL_ZOOM_LIMITS.minimum, VISUAL_ZOOM_LIMITS.maximum)
@@ -2226,23 +2240,12 @@ function setupIPC() {
   // 环境配置同步 - 主进程作为唯一配置源
   ipcMain.handle('config-getEnvironmentVariables', async (event) => {
     try {
-      // 自动透传所有 VITE_* 变量并附加无前缀副本
-      const viteEnv = Object.fromEntries(
-        Object.entries(process.env)
-          .filter(([k, v]) => k.startsWith('VITE_') && v !== undefined)
-          .map(([k, v]) => [k, String(v)])
-      );
+      // Only expose explicitly public runtime config to the renderer.
+      const publicConfig = getPublicRuntimeConfig(process.env);
+      const publicCount = Object.keys(publicConfig).filter((key) => key.startsWith('VITE_')).length;
 
-      const noPrefixEnv = Object.fromEntries(
-        Object.entries(viteEnv).map(([k, v]) => [k.replace(/^VITE_/, ''), v])
-      );
-
-      const allEnvVars = { ...viteEnv, ...noPrefixEnv };
-
-      console.log('[Main Process] Environment variables requested by UI process');
-      console.log(`[Main Process] Returning ${Object.keys(viteEnv).length} VITE_* variables (with no-prefix duplicates)`);
-
-      return createSuccessResponse(allEnvVars);
+      console.log(`[Main Process] Returning ${publicCount} public VITE_* variables (with no-prefix duplicates)`);
+      return createSuccessResponse(publicConfig);
     } catch (error) {
       return createErrorResponse(error);
     }
@@ -2256,6 +2259,9 @@ function setupIPC() {
       const urlObj = new URL(url);
       if (!['http:', 'https:'].includes(urlObj.protocol)) {
         throw new Error(`Unsupported protocol: ${urlObj.protocol}`);
+      }
+      if (!isSafeExternalUrl(url)) {
+        throw createIpcError('IPC_UNSAFE_EXTERNAL_URL', 'Refusing to open unsafe external URL');
       }
       await shell.openExternal(url);
       return createSuccessResponse(true);

--- a/packages/desktop/main.js
+++ b/packages/desktop/main.js
@@ -55,6 +55,7 @@ const {
   createIpcError,
   registerSecureIpcHandler,
 } = require('./config/ipc-security');
+const { createStreamRegistry } = require('./config/stream-registry');
 
 const path = require('path');
 
@@ -82,6 +83,9 @@ function getIpcSenderOptions() {
     devServerUrl: 'http://localhost:18181',
   };
 }
+
+const streamRegistry = createStreamRegistry();
+
 
 
 
@@ -987,8 +991,19 @@ function setupIPC() {
   });
 
   // Streaming handler - more complex due to callbacks
+  
+  ipcMain.handle('stream-cancel', async (event, streamId) => {
+    try {
+      streamRegistry.cancel(event.sender, streamId);
+      return createSuccessResponse(true);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
   ipcMain.handle('llm-sendMessageStream', async (event, messages, provider, streamId) => {
     try {
+      const stream = streamRegistry.register(event.sender, streamId);
       // 使用符合 StreamHandlers 接口的回调名称
       const callbacks = {
         onToken: (token) => {
@@ -1013,16 +1028,19 @@ function setupIPC() {
         }
       };
 
-      await llmService.sendMessageStream(messages, provider, callbacks);
+      await llmService.sendMessageStream(messages, provider, callbacks, { signal: stream.signal });
       return createSuccessResponse(null);
     } catch (error) {
       return createErrorResponse(error);
+    } finally {
+      streamRegistry.complete(event.sender, streamId);
     }
   });
 
   // Streaming handler with tools - supports tool-call events
   ipcMain.handle('llm-sendMessageStreamWithTools', async (event, messages, provider, tools, streamId) => {
     try {
+      const stream = streamRegistry.register(event.sender, streamId);
       const callbacks = {
         onToken: (token) => {
           if (mainWindow && !mainWindow.isDestroyed()) {
@@ -1051,10 +1069,12 @@ function setupIPC() {
         }
       };
 
-      await llmService.sendMessageStreamWithTools(messages, provider, tools, callbacks);
+      await llmService.sendMessageStreamWithTools(messages, provider, tools, callbacks, { signal: stream.signal });
       return createSuccessResponse(null);
     } catch (error) {
       return createErrorResponse(error);
+    } finally {
+      streamRegistry.complete(event.sender, streamId);
     }
   });
 
@@ -1146,44 +1166,72 @@ function setupIPC() {
   ipcMain.handle('prompt-optimizePromptStream', async (event, request, streamId) => {
     const streamHandlers = createIpcStreamHandlers(mainWindow, streamId);
     try {
-      await promptService.optimizePromptStream(request, streamHandlers);
+      const stream = streamRegistry.register(event.sender, streamId);
+      await promptService.optimizePromptStream(request, streamHandlers, { signal: stream.signal });
       return createSuccessResponse(null);
     } catch (error) {
       streamHandlers.onError(error);
       return createErrorResponse(error);
+    } finally {
+      streamRegistry.complete(event.sender, streamId);
     }
   });
 
   ipcMain.handle('prompt-optimizeMessageStream', async (event, request, streamId) => {
     const streamHandlers = createIpcStreamHandlers(mainWindow, streamId);
     try {
-      await promptService.optimizeMessageStream(request, streamHandlers);
+      const stream = streamRegistry.register(event.sender, streamId);
+      await promptService.optimizeMessageStream(request, streamHandlers, { signal: stream.signal });
       return createSuccessResponse(null);
     } catch (error) {
       streamHandlers.onError(error);
       return createErrorResponse(error);
+    } finally {
+      streamRegistry.complete(event.sender, streamId);
     }
   });
 
   ipcMain.handle('prompt-iteratePromptStream', async (event, originalPrompt, lastOptimizedPrompt, iterateInput, modelKey, templateId, streamId, contextData) => {
     const streamHandlers = createIpcStreamHandlers(mainWindow, streamId);
     try {
-      await promptService.iteratePromptStream(originalPrompt, lastOptimizedPrompt, iterateInput, modelKey, streamHandlers, templateId, contextData);
+      const stream = streamRegistry.register(event.sender, streamId);
+      await promptService.iteratePromptStream(
+        originalPrompt,
+        lastOptimizedPrompt,
+        iterateInput,
+        modelKey,
+        streamHandlers,
+        templateId,
+        contextData,
+        { signal: stream.signal },
+      );
       return createSuccessResponse(null);
     } catch (error) {
       streamHandlers.onError(error);
       return createErrorResponse(error);
+    } finally {
+      streamRegistry.complete(event.sender, streamId);
     }
   });
 
   ipcMain.handle('prompt-testPromptStream', async (event, systemPrompt, userPrompt, modelKey, streamId, inputImages) => {
     const streamHandlers = createIpcStreamHandlers(mainWindow, streamId);
     try {
-      await promptService.testPromptStream(systemPrompt, userPrompt, modelKey, streamHandlers, inputImages);
+      const stream = streamRegistry.register(event.sender, streamId);
+      await promptService.testPromptStream(
+        systemPrompt,
+        userPrompt,
+        modelKey,
+        streamHandlers,
+        inputImages,
+        { signal: stream.signal },
+      );
       return createSuccessResponse(null);
     } catch (error) {
       streamHandlers.onError(error);
       return createErrorResponse(error);
+    } finally {
+      streamRegistry.complete(event.sender, streamId);
     }
   });
 
@@ -1210,11 +1258,18 @@ function setupIPC() {
   ipcMain.handle('prompt-testCustomConversationStream', async (event, request, streamId) => {
     const streamHandlers = createIpcStreamHandlers(mainWindow, streamId);
     try {
-      await promptService.testCustomConversationStream(request, streamHandlers);
+      const stream = streamRegistry.register(event.sender, streamId);
+      await promptService.testCustomConversationStream(
+        request,
+        streamHandlers,
+        { signal: stream.signal },
+      );
       return createSuccessResponse(null);
     } catch (error) {
       streamHandlers.onError(error);
       return createErrorResponse(error);
+    } finally {
+      streamRegistry.complete(event.sender, streamId);
     }
   });
 

--- a/packages/desktop/main.js
+++ b/packages/desktop/main.js
@@ -924,6 +924,16 @@ function createFavoriteErrorResponse(error) {
 // --- High-Level IPC Service Handlers ---
 function setupIPC() {
   console.log('[Main Process] Setting up high-level service IPC handlers...');
+  /** Trusted-sender IPC registration for high-sensitivity channels. */
+  const registerSensitiveIpc = (channel, handler, validateArgs) => {
+    registerSecureIpcHandler(ipcMain, channel, handler, {
+      senderOptions: getIpcSenderOptions(),
+      validateArgs,
+      createSuccess: createSuccessResponse,
+      createError: createErrorResponse,
+    });
+  };
+
   setupPreferenceHandlers();
   setupRemoteStorageHandlers(ipcMain, {
     createSuccessResponse,
@@ -2238,36 +2248,25 @@ function setupIPC() {
 
 
   // 环境配置同步 - 主进程作为唯一配置源
-  ipcMain.handle('config-getEnvironmentVariables', async (event) => {
-    try {
-      // Only expose explicitly public runtime config to the renderer.
-      const publicConfig = getPublicRuntimeConfig(process.env);
-      const publicCount = Object.keys(publicConfig).filter((key) => key.startsWith('VITE_')).length;
-
-      console.log(`[Main Process] Returning ${publicCount} public VITE_* variables (with no-prefix duplicates)`);
-      return createSuccessResponse(publicConfig);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
+  // Secrets stay main-process-only; renderer receives explicit public keys only.
+  registerSensitiveIpc('config-getEnvironmentVariables', async () => {
+    const publicConfig = getPublicRuntimeConfig(process.env);
+    const publicCount = Object.keys(publicConfig).filter((key) => key.startsWith('VITE_')).length;
+    console.log(`[Main Process] Returning ${publicCount} public VITE_* variables (with no-prefix duplicates)`);
+    return publicConfig;
   });
 
   // 外部链接处理器
-  ipcMain.handle('shell-openExternal', async (event, url) => {
-    try {
-      console.log('[Main Process] Opening external URL:', url);
-      // 安全性检查：仅允许 http/https 协议
-      const urlObj = new URL(url);
-      if (!['http:', 'https:'].includes(urlObj.protocol)) {
-        throw new Error(`Unsupported protocol: ${urlObj.protocol}`);
-      }
-      if (!isSafeExternalUrl(url)) {
-        throw createIpcError('IPC_UNSAFE_EXTERNAL_URL', 'Refusing to open unsafe external URL');
-      }
-      await shell.openExternal(url);
-      return createSuccessResponse(true);
-    } catch (error) {
-      console.error('[Main Process] Failed to open external URL:', error);
-      return createErrorResponse(error);
+  registerSensitiveIpc('shell-openExternal', async (_event, url) => {
+    console.log('[Main Process] Opening external URL:', url);
+    if (!isSafeExternalUrl(url)) {
+      throw createIpcError('IPC_UNSAFE_EXTERNAL_URL', 'Refusing to open unsafe external URL');
+    }
+    await shell.openExternal(url);
+    return true;
+  }, ([url]) => {
+    if (typeof url !== 'string' || url.length === 0 || url.length > 2048) {
+      throw createIpcError('IPC_INVALID_ARGUMENT', 'Invalid external URL');
     }
   });
 

--- a/packages/desktop/preload.js
+++ b/packages/desktop/preload.js
@@ -3,7 +3,6 @@ const { contextBridge, ipcRenderer } = require('electron');
 // IPC事件名称常量 - 直接内联避免沙箱环境的模块加载问题
 const IPC_EVENTS = {
   UPDATE_CHECK: 'updater-check-update',
-  UPDATE_OPEN_RELEASE_PAGE: 'updater-open-release-page',
   UPDATE_START_DOWNLOAD: 'updater-start-download',
   UPDATE_INSTALL: 'updater-install-update',
   UPDATE_IGNORE_VERSION: 'updater-ignore-version',
@@ -22,6 +21,7 @@ const IPC_EVENTS = {
 };
 
 const REMOTE_STORAGE_CHANNEL = 'remote-storage:invoke';
+const ipcListenerWrappers = new Map();
 
 // 简单的超时包装器，避免过度设计
 const withTimeout = (promise, timeoutMs = 30000) => {
@@ -80,6 +80,105 @@ function createIpcError(payload) {
   return new Error(String(payload));
 }
 
+/** 请求主进程取消当前 renderer 所拥有的流任务。 */
+async function cancelMainProcessStream(streamId) {
+  const result = await ipcRenderer.invoke('stream-cancel', streamId);
+  if (!result.success) {
+    throw createIpcError(result.error);
+  }
+  return result.data;
+}
+
+/** 将前端 AbortSignal 转换为 IPC 取消请求和可参与竞速的拒绝 Promise。 */
+function createStreamAbortRace(streamId, cleanup, signal) {
+  if (!signal) {
+    return { abortPromise: null, dispose: () => {} };
+  }
+
+  let rejectAbort;
+  let cancelled = false;
+  const abortPromise = new Promise((_, reject) => {
+    rejectAbort = reject;
+  });
+  const abortListener = () => {
+    if (cancelled) {
+      return;
+    }
+    cancelled = true;
+    cleanup();
+
+    void cancelMainProcessStream(streamId)
+      .catch(() => {})
+      .finally(() => {
+        rejectAbort(createIpcError({
+          code: 'IPC_STREAM_CANCELLED',
+          message: 'IPC stream was cancelled',
+        }));
+      });
+  };
+
+  if (signal.aborted) {
+    abortListener();
+  } else {
+    signal.addEventListener('abort', abortListener, { once: true });
+  }
+
+  return {
+    abortPromise,
+    dispose: () => signal.removeEventListener('abort', abortListener),
+  };
+}
+
+/**
+ * 为前端回调创建并保存唯一的 Electron 监听器包装，返回可重复调用的注销函数。
+ */
+function subscribeIpcEvent(channel, callback) {
+  if (typeof channel !== 'string' || typeof callback !== 'function') {
+    throw new TypeError('IPC event subscription requires a channel and callback');
+  }
+
+  let channelListeners = ipcListenerWrappers.get(channel);
+  if (!channelListeners) {
+    channelListeners = new Map();
+    ipcListenerWrappers.set(channel, channelListeners);
+  }
+
+  const existingListener = channelListeners.get(callback);
+  if (existingListener) {
+    ipcRenderer.removeListener(channel, existingListener);
+  }
+
+  /** 去除 Electron event 参数，仅向前端传递业务载荷。 */
+  const wrappedListener = (_event, ...args) => callback(...args);
+  channelListeners.set(callback, wrappedListener);
+  ipcRenderer.on(channel, wrappedListener);
+
+  let disposed = false;
+  return () => {
+    if (disposed) return;
+    disposed = true;
+    unsubscribeIpcEvent(channel, callback);
+  };
+}
+
+/**
+ * 使用注册时保存的同一函数引用移除 Electron 监听器，并清理空映射。
+ */
+function unsubscribeIpcEvent(channel, callback) {
+  const channelListeners = ipcListenerWrappers.get(channel);
+  const wrappedListener = channelListeners?.get(callback);
+  if (!wrappedListener) {
+    return false;
+  }
+
+  ipcRenderer.removeListener(channel, wrappedListener);
+  channelListeners.delete(callback);
+  if (channelListeners.size === 0) {
+    ipcListenerWrappers.delete(channel);
+  }
+  return true;
+}
+
 async function invokeFavorite(channel, ...args) {
   const result = await ipcRenderer.invoke(channel, ...args);
   if (!result.success) {
@@ -90,12 +189,8 @@ async function invokeFavorite(channel, ...args) {
 
 contextBridge.exposeInMainWorld('electronAPI', {
   // IPC event listeners
-  on: (channel, callback) => {
-    ipcRenderer.on(channel, (event, ...args) => callback(...args));
-  },
-  off: (channel, callback) => {
-    ipcRenderer.removeListener(channel, callback);
-  },
+  on: subscribeIpcEvent,
+  off: unsubscribeIpcEvent,
 
   // High-level LLM service interface
   llm: {
@@ -136,8 +231,15 @@ contextBridge.exposeInMainWorld('electronAPI', {
     },
 
     // Send streaming message
-    sendMessageStream: async (messages, provider, callbacks) => {
+    sendMessageStream: async (messages, provider, callbacks, signal) => {
       const streamId = generateStreamId();
+
+      if (signal?.aborted) {
+        throw createIpcError({
+          code: 'IPC_STREAM_CANCELLED',
+          message: 'IPC stream was cancelled',
+        });
+      }
       
       // Set up event listeners for streaming responses
       const contentListener = (event, content) => {
@@ -170,21 +272,31 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.on(`stream-error-${streamId}`, errorListener);
 
       // Send the streaming request
+      const cancellation = createStreamAbortRace(streamId, cleanup, signal);
       try {
-        const result = await ipcRenderer.invoke('llm-sendMessageStream', messages, provider, streamId);
+        const request = ipcRenderer.invoke('llm-sendMessageStream', messages, provider, streamId);
+        const result = cancellation.abortPromise
+          ? await Promise.race([request, cancellation.abortPromise])
+          : await request;
         if (!result.success) {
-          cleanup();
           throw createIpcError(result.error);
         }
-      } catch (error) {
+      } finally {
         cleanup();
-        throw error;
+        cancellation.dispose();
       }
     },
 
     // Send streaming message with tools (supports tool-call events)
-    sendMessageStreamWithTools: async (messages, provider, tools, callbacks) => {
+    sendMessageStreamWithTools: async (messages, provider, tools, callbacks, signal) => {
       const streamId = generateStreamId();
+
+      if (signal?.aborted) {
+        throw createIpcError({
+          code: 'IPC_STREAM_CANCELLED',
+          message: 'IPC stream was cancelled',
+        });
+      }
 
       // Set up event listeners for streaming responses
       const contentListener = (event, content) => {
@@ -222,22 +334,29 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.on(`stream-error-${streamId}`, errorListener);
 
       // Send the streaming request
+      const cancellation = createStreamAbortRace(streamId, cleanup, signal);
       try {
-        const result = await ipcRenderer.invoke(
+        const request = ipcRenderer.invoke(
           'llm-sendMessageStreamWithTools',
           messages,
           provider,
           tools,
           streamId
         );
+        const result = cancellation.abortPromise
+          ? await Promise.race([request, cancellation.abortPromise])
+          : await request;
         if (!result.success) {
-          cleanup();
           throw createIpcError(result.error);
         }
-      } catch (error) {
+      } finally {
         cleanup();
-        throw error;
+        cancellation.dispose();
       }
+    },
+
+    cancelStream: async (streamId) => {
+      return cancelMainProcessStream(streamId);
     }
   },
 
@@ -830,8 +949,16 @@ contextBridge.exposeInMainWorld('electronAPI', {
       return result.data;
     },
     // 统一的流式封装（与 llm.sendMessageStream 同模式）
-    optimizePromptStream: async (request, callbacks) => {
+    // signal 为可选位置参数，保持既有调用方兼容
+    optimizePromptStream: async (request, callbacks, signal) => {
       const streamId = generateStreamId();
+
+      if (signal?.aborted) {
+        throw createIpcError({
+          code: 'IPC_STREAM_CANCELLED',
+          message: 'IPC stream was cancelled',
+        });
+      }
 
       const tokenListener = (event, token) => {
         if (callbacks?.onToken) callbacks.onToken(token);
@@ -860,14 +987,29 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.on(`stream-finish-${streamId}`, finishListener);
       ipcRenderer.on(`stream-error-${streamId}`, errorListener);
 
-      const result = await ipcRenderer.invoke('prompt-optimizePromptStream', request, streamId);
-      if (!result.success) {
+      const cancellation = createStreamAbortRace(streamId, cleanup, signal);
+      try {
+        const requestPromise = ipcRenderer.invoke('prompt-optimizePromptStream', request, streamId);
+        const result = cancellation.abortPromise
+          ? await Promise.race([requestPromise, cancellation.abortPromise])
+          : await requestPromise;
+        if (!result.success) {
+          throw createIpcError(result.error);
+        }
+      } finally {
         cleanup();
-        throw createIpcError(result.error);
+        cancellation.dispose();
       }
     },
-    optimizeMessageStream: async (request, callbacks) => {
+    optimizeMessageStream: async (request, callbacks, signal) => {
       const streamId = generateStreamId();
+
+      if (signal?.aborted) {
+        throw createIpcError({
+          code: 'IPC_STREAM_CANCELLED',
+          message: 'IPC stream was cancelled',
+        });
+      }
 
       const tokenListener = (event, token) => {
         if (callbacks?.onToken) callbacks.onToken(token);
@@ -896,14 +1038,29 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.on(`stream-finish-${streamId}`, finishListener);
       ipcRenderer.on(`stream-error-${streamId}`, errorListener);
 
-      const result = await ipcRenderer.invoke('prompt-optimizeMessageStream', request, streamId);
-      if (!result.success) {
+      const cancellation = createStreamAbortRace(streamId, cleanup, signal);
+      try {
+        const requestPromise = ipcRenderer.invoke('prompt-optimizeMessageStream', request, streamId);
+        const result = cancellation.abortPromise
+          ? await Promise.race([requestPromise, cancellation.abortPromise])
+          : await requestPromise;
+        if (!result.success) {
+          throw createIpcError(result.error);
+        }
+      } finally {
         cleanup();
-        throw createIpcError(result.error);
+        cancellation.dispose();
       }
     },
-    iteratePromptStream: async (originalPrompt, lastOptimizedPrompt, iterateInput, modelKey, templateId, callbacks, contextData) => {
+    iteratePromptStream: async (originalPrompt, lastOptimizedPrompt, iterateInput, modelKey, templateId, callbacks, contextData, signal) => {
       const streamId = generateStreamId();
+
+      if (signal?.aborted) {
+        throw createIpcError({
+          code: 'IPC_STREAM_CANCELLED',
+          message: 'IPC stream was cancelled',
+        });
+      }
 
       const tokenListener = (event, token) => {
         if (callbacks?.onToken) callbacks.onToken(token);
@@ -932,14 +1089,43 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.on(`stream-finish-${streamId}`, finishListener);
       ipcRenderer.on(`stream-error-${streamId}`, errorListener);
 
-      const result = await ipcRenderer.invoke('prompt-iteratePromptStream', originalPrompt, lastOptimizedPrompt, iterateInput, modelKey, templateId, streamId, contextData);
-      if (!result.success) {
+      const cancellation = createStreamAbortRace(streamId, cleanup, signal);
+      try {
+        const requestPromise = ipcRenderer.invoke(
+          'prompt-iteratePromptStream',
+          originalPrompt,
+          lastOptimizedPrompt,
+          iterateInput,
+          modelKey,
+          templateId,
+          streamId,
+          contextData,
+        );
+        const result = cancellation.abortPromise
+          ? await Promise.race([requestPromise, cancellation.abortPromise])
+          : await requestPromise;
+        if (!result.success) {
+          throw createIpcError(result.error);
+        }
+      } finally {
         cleanup();
-        throw createIpcError(result.error);
+        cancellation.dispose();
       }
     },
-    testPromptStream: async (systemPrompt, userPrompt, modelKey, callbacks, inputImages) => {
+    testPromptStream: async (systemPrompt, userPrompt, modelKey, callbacks, inputImages, signal) => {
+      // Back-compat: allow (callbacks, signal) without images.
+      if (inputImages && typeof inputImages === 'object' && typeof inputImages.aborted === 'boolean' && signal === undefined) {
+        signal = inputImages;
+        inputImages = undefined;
+      }
       const streamId = generateStreamId();
+
+      if (signal?.aborted) {
+        throw createIpcError({
+          code: 'IPC_STREAM_CANCELLED',
+          message: 'IPC stream was cancelled',
+        });
+      }
 
       const tokenListener = (event, token) => {
         if (callbacks?.onToken) callbacks.onToken(token);
@@ -968,15 +1154,37 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.on(`stream-finish-${streamId}`, finishListener);
       ipcRenderer.on(`stream-error-${streamId}`, errorListener);
 
-      const result = await ipcRenderer.invoke('prompt-testPromptStream', systemPrompt, userPrompt, modelKey, streamId, inputImages);
-      if (!result.success) {
+      const cancellation = createStreamAbortRace(streamId, cleanup, signal);
+      try {
+        const requestPromise = ipcRenderer.invoke(
+          'prompt-testPromptStream',
+          systemPrompt,
+          userPrompt,
+          modelKey,
+          streamId,
+          inputImages,
+        );
+        const result = cancellation.abortPromise
+          ? await Promise.race([requestPromise, cancellation.abortPromise])
+          : await requestPromise;
+        if (!result.success) {
+          throw createIpcError(result.error);
+        }
+      } finally {
         cleanup();
-        throw createIpcError(result.error);
+        cancellation.dispose();
       }
     },
     // 自定义会话测试（支持工具调用）
-    testCustomConversationStream: async (request, callbacks) => {
+    testCustomConversationStream: async (request, callbacks, signal) => {
       const streamId = generateStreamId();
+
+      if (signal?.aborted) {
+        throw createIpcError({
+          code: 'IPC_STREAM_CANCELLED',
+          message: 'IPC stream was cancelled',
+        });
+      }
 
       const tokenListener = (event, token) => {
         if (callbacks?.onToken) callbacks.onToken(token);
@@ -1010,10 +1218,22 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.on(`stream-finish-${streamId}`, finishListener);
       ipcRenderer.on(`stream-error-${streamId}`, errorListener);
 
-      const result = await ipcRenderer.invoke('prompt-testCustomConversationStream', request, streamId);
-      if (!result.success) {
+      const cancellation = createStreamAbortRace(streamId, cleanup, signal);
+      try {
+        const requestPromise = ipcRenderer.invoke(
+          'prompt-testCustomConversationStream',
+          request,
+          streamId,
+        );
+        const result = cancellation.abortPromise
+          ? await Promise.race([requestPromise, cancellation.abortPromise])
+          : await requestPromise;
+        if (!result.success) {
+          throw createIpcError(result.error);
+        }
+      } finally {
         cleanup();
-        throw createIpcError(result.error);
+        cancellation.dispose();
       }
     },
     iteratePrompt: async (originalPrompt, lastOptimizedPrompt, iterateInput, modelKey, templateId, contextData) => {
@@ -1381,17 +1601,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
       }
       return result.data;
     },
-
-    openReleasePage: async (version) => {
-      const result = await withTimeout(
-        ipcRenderer.invoke(IPC_EVENTS.UPDATE_OPEN_RELEASE_PAGE, version),
-        10000
-      );
-      if (!result.success) {
-        throw createIpcError(result.error);
-      }
-      return result.data;
-    },
     
     startDownload: async () => {
       const result = await withTimeout(
@@ -1399,7 +1608,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
         10000 // 10秒超时，启动下载应该很快
       );
       if (!result.success) {
-        throw createIpcError(result.error);
+        // 保留完整的错误信息
+        const error = new Error(result.error);
+        error.originalError = result.error;
+        error.detailedMessage = result.error;
+        throw error;
       }
       return result.data;
     },
@@ -1409,7 +1622,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
         10000 // 10秒超时，安装启动应该很快
       );
       if (!result.success) {
-        throw createIpcError(result.error);
+        // 保留完整的错误信息
+        const error = new Error(result.error);
+        error.originalError = result.error;
+        error.detailedMessage = result.error;
+        throw error;
       }
       return result.data;
     },
@@ -1462,7 +1679,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
         30000 // 30秒超时，现在只等待下载启动，不等待完成，所以30秒足够
       );
       if (!result.success) {
-        throw createIpcError(result.error || 'Failed to download specific version');
+        const error = new Error(result.error || 'Failed to download specific version');
+        error.originalError = result.error;
+        error.detailedMessage = result.error;
+        throw error;
       }
       return result.data;
     },

--- a/packages/desktop/remote-storage.js
+++ b/packages/desktop/remote-storage.js
@@ -12,13 +12,38 @@ const JSON_MIME_TYPE = 'application/json';
 const CLOUDFLARE_R2_DEFAULT_BACKUP_PREFIX = 'prompt-optimizer-backups/';
 let webDavModulePromise = null;
 
-const joinRemotePath = (...parts) =>
-  parts
-    .map((part) => String(part || '').replace(/^\/+|\/+$/g, ''))
-    .filter(Boolean)
-    .join('/');
+const decodeRemotePathSegment = (segment) => {
+  let decoded = segment;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    let next;
+    try {
+      next = decodeURIComponent(decoded);
+    } catch {
+      throw new Error('Remote storage path contains invalid encoding');
+    }
+    if (next === decoded) break;
+    decoded = next;
+  }
+  return decoded;
+};
 
-const normalizeObjectPath = (path) => joinRemotePath(path);
+const normalizeObjectPath = (path) => {
+  const raw = String(path || '');
+  if (/[\\\u0000-\u001f\u007f]/.test(raw)) {
+    throw new Error('Remote storage path contains invalid characters');
+  }
+
+  const segments = raw.replace(/^\/+|\/+$/g, '').split('/').filter(Boolean);
+  for (const segment of segments) {
+    const decoded = decodeRemotePathSegment(segment);
+    if (decoded === '.' || decoded === '..' || /[\\/\u0000-\u001f\u007f]/.test(decoded)) {
+      throw new Error('Remote storage path contains an unsafe segment');
+    }
+  }
+  return segments.join('/');
+};
+
+const joinRemotePath = (...parts) => parts.map(normalizeObjectPath).filter(Boolean).join('/');
 
 const parentPathOf = (path) => {
   const normalized = normalizeObjectPath(path);
@@ -292,6 +317,7 @@ class WebDavRemoteObjectStore {
   constructor(config, dependencies) {
     this.config = config;
     this.dependencies = dependencies;
+    this.rootDirectory = normalizeObjectPath(config.directory || 'prompt-optimizer-backups');
     this.clientPromise = null;
   }
 
@@ -411,7 +437,7 @@ class WebDavRemoteObjectStore {
   }
 
   directoryPath(path) {
-    return `/${joinRemotePath(this.config.directory || 'prompt-optimizer-backups', path)}`;
+    return `/${joinRemotePath(this.rootDirectory, path)}`;
   }
 
   filePath(path) {


### PR DESCRIPTION
## Summary
Re-submit of retracted #327 (closed by author without merge).

**Stack:** base includes `xvyimu:resubmit/01-window-runtime-ipc-security` (open as #333). Please merge **#333 before this PR**, or allow GitHub to show the stacked commits.

### Changes
- Core `StreamRequestOptions` through LLM/prompt services and provider adapters
- Preserve **#196** `inputImages` path; AbortSignal is trailing `options`
- Desktop ownership-guarded stream registry + preload cancel race
- Wire `stream-cancel` and `{ signal }` into main process stream handlers

### Test plan
- [x] `node --test` stream-registry + preload-stream-cancellation + ipc-security → **13/13**
- [x] core `provider-cancellation.test.ts` → **5/5**

### Notes
- No `.pipeline/*`, no local paths
- Recommended order: **#332 → #333 → this PR → electron/mcp → IPC split**