### PR TITLE
refactor(desktop): mechanical IPC domain split (updater isolated, keep #313)

### DIFF
--- a/packages/core/src/services/image-understanding/service.ts
+++ b/packages/core/src/services/image-understanding/service.ts
@@ -1,7 +1,7 @@
 import { TextAdapterRegistry } from '../llm/adapters/registry'
 import { RequestConfigError } from '../llm/errors'
 import type { IImageUnderstandingService, ImageUnderstandingExecutionRequest, CreateImageUnderstandingServiceOptions } from './types'
-import type { ITextAdapterRegistry, StreamHandlers } from '../llm/types'
+import type { ITextAdapterRegistry, StreamHandlers, StreamRequestOptions } from '../llm/types'
 import type { ImageInputCompatibilityOptions } from '../image/types'
 import { normalizeImageInputsForLlm } from '../image/input-normalizer'
 
@@ -26,15 +26,17 @@ export class ImageUnderstandingService implements IImageUnderstandingService {
 
   async understandStream(
     request: ImageUnderstandingExecutionRequest,
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ) {
+    options?.signal?.throwIfAborted()
     this.validateRequest(request)
 
     const providerId = request.modelConfig.providerMeta.id
     const adapter = this.registry.getAdapter(providerId)
     const runtimeRequest = await this.prepareRuntimeRequest(request)
 
-    await adapter.sendImageUnderstandingStream(runtimeRequest, request.modelConfig, callbacks)
+    await adapter.sendImageUnderstandingStream(runtimeRequest, request.modelConfig, callbacks, options)
   }
 
   private validateRequest(request: ImageUnderstandingExecutionRequest): void {

--- a/packages/core/src/services/image-understanding/types.ts
+++ b/packages/core/src/services/image-understanding/types.ts
@@ -1,4 +1,4 @@
-import type { ImageUnderstandingRequest, LLMResponse, ITextAdapterRegistry, StreamHandlers } from '../llm/types'
+import type { ImageUnderstandingRequest, LLMResponse, ITextAdapterRegistry, StreamHandlers, StreamRequestOptions } from '../llm/types'
 import type { TextModelConfig } from '../model/types'
 import type { ImageInputCompatibilityOptions } from '../image/types'
 
@@ -8,7 +8,11 @@ export interface ImageUnderstandingExecutionRequest extends ImageUnderstandingRe
 
 export interface IImageUnderstandingService {
   understand(request: ImageUnderstandingExecutionRequest): Promise<LLMResponse>
-  understandStream(request: ImageUnderstandingExecutionRequest, callbacks: StreamHandlers): Promise<void>
+  understandStream(
+    request: ImageUnderstandingExecutionRequest,
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
+  ): Promise<void>
 }
 
 export interface CreateImageUnderstandingServiceOptions extends ImageInputCompatibilityOptions {

--- a/packages/core/src/services/llm/adapters/abstract-adapter.ts
+++ b/packages/core/src/services/llm/adapters/abstract-adapter.ts
@@ -7,6 +7,7 @@ import type {
   ImageUnderstandingRequest,
   LLMResponse,
   StreamHandlers,
+  StreamRequestOptions,
   ToolDefinition,
   ParameterDefinition
 } from '../types'
@@ -56,7 +57,8 @@ export abstract class AbstractTextProviderAdapter implements ITextProviderAdapte
   protected abstract doSendMessageStream(
     messages: Message[],
     config: TextModelConfig,
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void>
 
   /**
@@ -93,7 +95,8 @@ export abstract class AbstractTextProviderAdapter implements ITextProviderAdapte
   protected async doSendImageUnderstandingStream(
     _request: ImageUnderstandingRequest,
     _config: TextModelConfig,
-    _callbacks: StreamHandlers
+    _callbacks: StreamHandlers,
+    _options?: StreamRequestOptions
   ): Promise<void> {
     throw new RequestConfigError(
       `${this.getProvider().name} does not support streaming image understanding requests`
@@ -124,13 +127,15 @@ export abstract class AbstractTextProviderAdapter implements ITextProviderAdapte
   public async sendMessageStream(
     messages: Message[],
     config: TextModelConfig,
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void> {
+    options?.signal?.throwIfAborted()
     // 1. 验证消息数组
     this.validateMessages(messages)
 
     // 2. 调用具体实现
-    await this.doSendMessageStream(messages, config, callbacks)
+    await this.doSendMessageStream(messages, config, callbacks, options)
   }
 
   /**
@@ -141,14 +146,16 @@ export abstract class AbstractTextProviderAdapter implements ITextProviderAdapte
     messages: Message[],
     config: TextModelConfig,
     _tools: ToolDefinition[],
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void> {
+    options?.signal?.throwIfAborted()
     // 验证消息数组
     this.validateMessages(messages)
 
     // 默认实现：工具参数传递给具体实现处理
     // 子类应该覆盖此方法以处理工具调用
-    await this.doSendMessageStream(messages, config, callbacks)
+    await this.doSendMessageStream(messages, config, callbacks, options)
   }
 
   public async sendImageUnderstanding(
@@ -162,10 +169,12 @@ export abstract class AbstractTextProviderAdapter implements ITextProviderAdapte
   public async sendImageUnderstandingStream(
     request: ImageUnderstandingRequest,
     config: TextModelConfig,
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void> {
+    options?.signal?.throwIfAborted()
     this.validateImageUnderstandingRequest(request)
-    await this.doSendImageUnderstandingStream(request, config, callbacks)
+    await this.doSendImageUnderstandingStream(request, config, callbacks, options)
   }
 
   // ===== 公共验证方法 =====

--- a/packages/core/src/services/llm/adapters/anthropic-adapter.ts
+++ b/packages/core/src/services/llm/adapters/anthropic-adapter.ts
@@ -9,6 +9,7 @@ import type {
   ImageUnderstandingRequest,
   LLMResponse,
   StreamHandlers,
+  StreamRequestOptions,
   ParameterDefinition,
   ToolDefinition
 } from '../types'
@@ -100,7 +101,7 @@ export class AnthropicAdapter extends AbstractTextProviderAdapter {
    * @returns 动态获取的模型列表
    */
   public async getModelsAsync(config: TextModelConfig): Promise<TextModel[]> {
-    const client = this.createClient(config)
+    const client = await this.createClient(config)
 
     try {
       const response = await client.models.list()
@@ -237,7 +238,7 @@ export class AnthropicAdapter extends AbstractTextProviderAdapter {
     messages: Message[],
     config: TextModelConfig
   ): Promise<LLMResponse> {
-    const client = this.createClient(config)
+    const client = await this.createClient(config)
 
     try {
       // 提取已知参数和自定义参数
@@ -307,7 +308,7 @@ export class AnthropicAdapter extends AbstractTextProviderAdapter {
     request: ImageUnderstandingRequest,
     config: TextModelConfig
   ): Promise<LLMResponse> {
-    const client = this.createClient(config)
+    const client = await this.createClient(config)
 
     try {
       const mergedParams = {
@@ -390,9 +391,9 @@ export class AnthropicAdapter extends AbstractTextProviderAdapter {
   protected async doSendImageUnderstandingStream(
     request: ImageUnderstandingRequest,
     config: TextModelConfig,
-    callbacks: StreamHandlers
-  ): Promise<void> {
-    const client = this.createClient(config)
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions): Promise<void> {
+    const client = await this.createClient(config)
     const thinkState = { isInThinkMode: false, buffer: '' }
 
     try {
@@ -456,7 +457,10 @@ export class AnthropicAdapter extends AbstractTextProviderAdapter {
 
       Object.assign(requestParams, otherParams)
 
-      const stream = await client.messages.stream(requestParams)
+      const requestOptions = this.buildAnthropicRequestOptions(options)
+      const stream = requestOptions
+        ? await client.messages.stream(requestParams, requestOptions)
+        : await client.messages.stream(requestParams)
 
       let accumulatedReasoning = ''
 
@@ -497,12 +501,21 @@ export class AnthropicAdapter extends AbstractTextProviderAdapter {
   /**
    * 发送流式消息（真正的 SSE 流）
    */
+
+  /**
+   * Convert optional AbortSignal into Anthropic SDK stream request options.
+   */
+  private buildAnthropicRequestOptions(options?: StreamRequestOptions) {
+    return options?.signal ? { signal: options.signal } : undefined
+  }
+
   protected async doSendMessageStream(
     messages: Message[],
     config: TextModelConfig,
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void> {
-    const client = this.createClient(config)
+    const client = await this.createClient(config)
     const thinkState = { isInThinkMode: false, buffer: '' }
 
     try {
@@ -550,7 +563,10 @@ export class AnthropicAdapter extends AbstractTextProviderAdapter {
       // 添加其他参数（包括自定义参数）
       Object.assign(requestParams, otherParams)
 
-      const stream = await client.messages.stream(requestParams)
+      const requestOptions = this.buildAnthropicRequestOptions(options)
+      const stream = requestOptions
+        ? await client.messages.stream(requestParams, requestOptions)
+        : await client.messages.stream(requestParams)
 
       let accumulatedReasoning = ''
 
@@ -601,9 +617,9 @@ export class AnthropicAdapter extends AbstractTextProviderAdapter {
     messages: Message[],
     config: TextModelConfig,
     tools: ToolDefinition[],
-    callbacks: StreamHandlers
-  ): Promise<void> {
-    const client = this.createClient(config)
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions): Promise<void> {
+    const client = await this.createClient(config)
     const thinkState = { isInThinkMode: false, buffer: '' }
 
     try {
@@ -652,7 +668,10 @@ export class AnthropicAdapter extends AbstractTextProviderAdapter {
       // 添加其他参数（包括自定义参数）
       Object.assign(requestParams, otherParams)
 
-      const stream = await client.messages.stream(requestParams)
+      const requestOptions = this.buildAnthropicRequestOptions(options)
+      const stream = requestOptions
+        ? await client.messages.stream(requestParams, requestOptions)
+        : await client.messages.stream(requestParams)
 
       let accumulatedContent = ''
       let accumulatedReasoning = ''
@@ -739,7 +758,7 @@ export class AnthropicAdapter extends AbstractTextProviderAdapter {
   /**
    * 创建配置好的客户端实例
    */
-  private createClient(config: TextModelConfig): Anthropic {
+  private async createClient(config: TextModelConfig): Promise<Anthropic> {
     const options: any = {
       apiKey: config.connectionConfig?.apiKey || '',
       dangerouslyAllowBrowser: true // 根据实际环境配置

--- a/packages/core/src/services/llm/adapters/chrome-built-in-adapter.ts
+++ b/packages/core/src/services/llm/adapters/chrome-built-in-adapter.ts
@@ -3,6 +3,7 @@ import type {
   Message,
   ParameterDefinition,
   StreamHandlers,
+  StreamRequestOptions,
   TextModel,
   TextModelConfig,
   TextProvider
@@ -75,14 +76,18 @@ export class ChromeBuiltInAdapter extends AbstractTextProviderAdapter {
   protected async doSendMessageStream(
     messages: Message[],
     _config: TextModelConfig,
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void> {
     const { initialPrompts, prompt } = this.buildPrompt(messages)
     const session = await this.createReadySession(initialPrompts)
     let content = ''
 
     try {
-      const stream = await session.promptStreaming(prompt)
+      const streamOptions = options?.signal ? { signal: options.signal } : undefined
+      const stream = streamOptions
+        ? await (session as any).promptStreaming(prompt, streamOptions)
+        : await session.promptStreaming(prompt)
       for await (const token of stream) {
         content += token
         callbacks.onToken(token)

--- a/packages/core/src/services/llm/adapters/deepseek-adapter.ts
+++ b/packages/core/src/services/llm/adapters/deepseek-adapter.ts
@@ -6,6 +6,7 @@ import type {
   ImageUnderstandingRequest,
   LLMResponse,
   StreamHandlers,
+  StreamRequestOptions,
   ToolDefinition,
   ParameterDefinition
 } from '../types'
@@ -238,22 +239,30 @@ export class DeepseekAdapter extends OpenAIAdapter {
   protected async doSendMessageStream(
     messages: Message[],
     config: TextModelConfig,
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void> {
-    await super.doSendMessageStream(messages, this.normalizeDeepseekConfig(config), callbacks)
+    await super.doSendMessageStream(
+      messages,
+      this.normalizeDeepseekConfig(config),
+      callbacks,
+      options,
+    )
   }
 
   public async sendMessageStreamWithTools(
     messages: Message[],
     config: TextModelConfig,
     tools: ToolDefinition[],
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void> {
     await super.sendMessageStreamWithTools(
       messages,
       this.normalizeDeepseekConfig(config),
       tools,
-      callbacks
+      callbacks,
+      options,
     )
   }
 

--- a/packages/core/src/services/llm/adapters/gemini-adapter.ts
+++ b/packages/core/src/services/llm/adapters/gemini-adapter.ts
@@ -8,6 +8,7 @@ import type {
   ImageUnderstandingRequest,
   LLMResponse,
   StreamHandlers,
+  StreamRequestOptions,
   ParameterDefinition,
   ToolDefinition,
   ToolCall
@@ -308,7 +309,7 @@ export class GeminiAdapter extends AbstractTextProviderAdapter {
    * @param config 模型配置
    * @returns GoogleGenAI实例
    */
-  private createClient(config: TextModelConfig): GoogleGenAI {
+  private async createClient(config: TextModelConfig): Promise<GoogleGenAI >{
     const apiKey = config.connectionConfig.apiKey || ''
 
     const customBaseURL = config.connectionConfig.baseURL
@@ -500,13 +501,13 @@ export class GeminiAdapter extends AbstractTextProviderAdapter {
     }
 
     try {
-      const client = this.createClient(config)
+      const client = await this.createClient(config)
 
       // 构建配置（包含系统指令）
       const generationConfig = this.buildGenerationConfig(
-        config.paramOverrides || {},
-        systemInstruction
-      )
+          config.paramOverrides || {},
+          systemInstruction
+        )
 
       // 格式化消息
       const contents = this.formatMessages(conversationMessages)
@@ -529,7 +530,7 @@ export class GeminiAdapter extends AbstractTextProviderAdapter {
     config: TextModelConfig
   ): Promise<LLMResponse> {
     try {
-      const client = this.createClient(config)
+      const client = await this.createClient(config)
       const mergedParams = {
         ...(config.paramOverrides || {}),
         ...(request.paramOverrides || {})
@@ -575,18 +576,22 @@ export class GeminiAdapter extends AbstractTextProviderAdapter {
   protected async doSendImageUnderstandingStream(
     request: ImageUnderstandingRequest,
     config: TextModelConfig,
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void> {
     try {
-      const client = this.createClient(config)
+      const client = await this.createClient(config)
       const mergedParams = {
         ...(config.paramOverrides || {}),
         ...(request.paramOverrides || {})
       } as Record<string, unknown>
 
-      const generationConfig = this.buildGenerationConfig(
-        mergedParams,
-        request.systemPrompt
+      const generationConfig = this.attachAbortSignal(
+        this.buildGenerationConfig(
+          mergedParams,
+          request.systemPrompt
+        ),
+        options
       )
 
       if (request.responseMimeType) {
@@ -713,10 +718,22 @@ export class GeminiAdapter extends AbstractTextProviderAdapter {
    * @param callbacks 流式响应回调
    * @throws SDK原始错误（保留完整堆栈）
    */
+
+  /**
+   * Attach optional AbortSignal to Gemini generation config.
+   */
+  private attachAbortSignal(generationConfig: any, options?: StreamRequestOptions) {
+    if (options?.signal) {
+      ;(generationConfig as any).abortSignal = options.signal
+    }
+    return generationConfig
+  }
+
   protected async doSendMessageStream(
     messages: Message[],
     config: TextModelConfig,
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void> {
     // 提取系统消息
     const systemMessages = messages.filter((msg) => msg.role === 'system')
@@ -740,12 +757,15 @@ export class GeminiAdapter extends AbstractTextProviderAdapter {
     }
 
     try {
-      const client = this.createClient(config)
+      const client = await this.createClient(config)
 
       // 构建配置（包含系统指令）
-      const generationConfig = this.buildGenerationConfig(
-        config.paramOverrides || {},
-        systemInstruction
+      const generationConfig = this.attachAbortSignal(
+        this.buildGenerationConfig(
+          config.paramOverrides || {},
+          systemInstruction
+        ),
+        options
       )
 
       // 格式化消息
@@ -827,7 +847,8 @@ export class GeminiAdapter extends AbstractTextProviderAdapter {
     messages: Message[],
     config: TextModelConfig,
     tools: ToolDefinition[],
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void> {
     // 提取系统消息
     const systemMessages = messages.filter((msg) => msg.role === 'system')
@@ -847,12 +868,15 @@ export class GeminiAdapter extends AbstractTextProviderAdapter {
     }
 
     try {
-      const client = this.createClient(config)
+      const client = await this.createClient(config)
 
       // 构建配置（包含系统指令和工具）
-      const generationConfig = this.buildGenerationConfig(
-        config.paramOverrides || {},
-        systemInstruction
+      const generationConfig = this.attachAbortSignal(
+        this.buildGenerationConfig(
+          config.paramOverrides || {},
+          systemInstruction
+        ),
+        options
       )
 
       // 添加工具配置

--- a/packages/core/src/services/llm/adapters/openai-adapter.ts
+++ b/packages/core/src/services/llm/adapters/openai-adapter.ts
@@ -10,6 +10,7 @@ import type {
   ImageUnderstandingRequest,
   LLMResponse,
   StreamHandlers,
+  StreamRequestOptions,
   ToolDefinition,
   ParameterDefinition
 } from '../types'
@@ -122,7 +123,7 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
     // 验证baseURL以/v1结尾
     const baseURL = config.connectionConfig.baseURL || this.getProvider().defaultBaseURL
 
-    const openai = this.createOpenAIInstance(config, false)
+    const openai = await this.createOpenAIInstance(config, false)
 
     try {
       const response = await openai.models.list()
@@ -354,6 +355,15 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
     })
   }
 
+
+  /**
+   * Convert optional AbortSignal into OpenAI SDK request options.
+   * Cancellation aborts the underlying HTTP request rather than only stopping local fan-out.
+   */
+  private buildOpenAIRequestOptions(options?: StreamRequestOptions) {
+    return options?.signal ? { signal: options.signal } : undefined
+  }
+
   private buildImageDataUrl(image: ImageUnderstandingRequest['images'][number]): string {
     const imageData = image.b64.trim()
     if (/^data:/i.test(imageData)) {
@@ -454,7 +464,8 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
     callbacks: StreamHandlers,
     tools?: ToolDefinition[],
     inputOverride?: any[],
-    paramOverrides?: Record<string, unknown>
+    paramOverrides?: Record<string, unknown>,
+    options?: StreamRequestOptions
   ): Promise<void> {
     const responsesConfig: any = {
       model: config.modelMeta.id,
@@ -467,7 +478,10 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
       responsesConfig.tools = tools
     }
 
-    const stream = await openai.responses.create(responsesConfig)
+    const requestOptions = this.buildOpenAIRequestOptions(options)
+      const stream = requestOptions
+        ? await openai.responses.create(responsesConfig, requestOptions)
+        : await openai.responses.create(responsesConfig)
     let accumulatedContent = ''
     let accumulatedReasoning = ''
     const thinkState = { isInThinkMode: false, buffer: '' }
@@ -890,7 +904,7 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
    * @throws SDK原始错误（保留完整堆栈）
    */
   protected async doSendMessage(messages: Message[], config: TextModelConfig): Promise<LLMResponse> {
-    const openai = this.createOpenAIInstance(config, false)
+    const openai = await this.createOpenAIInstance(config, false)
     if (this.getRequestStyle(config) === 'responses') {
       try {
         return await this.sendResponsesMessage(openai, messages, config)
@@ -933,7 +947,7 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
     request: ImageUnderstandingRequest,
     config: TextModelConfig
   ): Promise<LLMResponse> {
-    const openai = this.createOpenAIInstance(config, false)
+    const openai = await this.createOpenAIInstance(config, false)
     const mergedParams = {
       ...(config.paramOverrides || {}),
       ...(request.paramOverrides || {})
@@ -997,10 +1011,11 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
   protected async doSendImageUnderstandingStream(
     request: ImageUnderstandingRequest,
     config: TextModelConfig,
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void> {
     try {
-      const openai = this.createOpenAIInstance(config, true)
+      const openai = await this.createOpenAIInstance(config, true)
       const mergedParams = {
         ...(config.paramOverrides || {}),
         ...(request.paramOverrides || {})
@@ -1014,7 +1029,8 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
           callbacks,
           undefined,
           this.buildResponsesImageUnderstandingInput(request),
-          mergedParams
+          mergedParams,
+          options
         )
         return
       }
@@ -1061,7 +1077,10 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
         ...restParams
       }
 
-      const stream = await openai.chat.completions.create(completionConfig)
+      const requestOptions = this.buildOpenAIRequestOptions(options)
+      const stream = requestOptions
+        ? await openai.chat.completions.create(completionConfig, requestOptions)
+        : await openai.chat.completions.create(completionConfig)
 
       let accumulatedReasoning = ''
       let accumulatedContent = ''
@@ -1311,13 +1330,14 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
   protected async doSendMessageStream(
     messages: Message[],
     config: TextModelConfig,
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void> {
     try {
       // 获取流式OpenAI实例
-      const openai = this.createOpenAIInstance(config, true)
+      const openai = await this.createOpenAIInstance(config, true)
       if (this.getRequestStyle(config) === 'responses') {
-        await this.sendResponsesMessageStream(openai, messages, config, callbacks)
+        await this.sendResponsesMessageStream(openai, messages, config, callbacks, undefined, undefined, undefined, options)
         return
       }
 
@@ -1342,7 +1362,10 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
       }
 
       // 直接使用流式响应
-      const stream = await openai.chat.completions.create(completionConfig)
+      const requestOptions = this.buildOpenAIRequestOptions(options)
+      const stream = requestOptions
+        ? await openai.chat.completions.create(completionConfig, requestOptions)
+        : await openai.chat.completions.create(completionConfig)
 
       // 累积内容
       let accumulatedReasoning = ''
@@ -1404,13 +1427,15 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
     messages: Message[],
     config: TextModelConfig,
     tools: ToolDefinition[],
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void> {
     try {
+      options?.signal?.throwIfAborted()
       // 获取流式OpenAI实例
-      const openai = this.createOpenAIInstance(config, true)
+      const openai = await this.createOpenAIInstance(config, true)
       if (this.getRequestStyle(config) === 'responses') {
-        await this.sendResponsesMessageStream(openai, messages, config, callbacks, tools)
+        await this.sendResponsesMessageStream(openai, messages, config, callbacks, tools, undefined, undefined, options)
         return
       }
 
@@ -1437,7 +1462,10 @@ export class OpenAIAdapter extends AbstractTextProviderAdapter {
         ...restParams
       }
 
-      const stream = await openai.chat.completions.create(completionConfig)
+      const requestOptions = this.buildOpenAIRequestOptions(options)
+      const stream = requestOptions
+        ? await openai.chat.completions.create(completionConfig, requestOptions)
+        : await openai.chat.completions.create(completionConfig)
 
       let accumulatedReasoning = ''
       let accumulatedContent = ''

--- a/packages/core/src/services/llm/electron-proxy.ts
+++ b/packages/core/src/services/llm/electron-proxy.ts
@@ -1,4 +1,4 @@
-import { ILLMService, Message, StreamHandlers, LLMResponse, ModelOption, ToolDefinition } from './types';
+import { ILLMService, Message, StreamHandlers, LLMResponse, ModelOption, ToolDefinition, StreamRequestOptions } from './types';
 import { safeSerializeForIPC } from '../../utils/ipc-serialization';
 import { InitializationError } from './errors';
 
@@ -36,7 +36,8 @@ export class ElectronLLMProxy implements ILLMService {
   async sendMessageStream(
     messages: Message[],
     provider: string,
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void> {
     // 自动序列化，防止Vue响应式对象IPC传递错误
     const safeMessages = safeSerializeForIPC(messages);
@@ -49,14 +50,15 @@ export class ElectronLLMProxy implements ILLMService {
       onError: callbacks.onError
     };
 
-    await this.electronAPI.llm.sendMessageStream(safeMessages, provider, adaptedCallbacks);
+    await this.electronAPI.llm.sendMessageStream(safeMessages, provider, adaptedCallbacks, options?.signal);
   }
 
   async sendMessageStreamWithTools(
     messages: Message[],
     provider: string,
     tools: ToolDefinition[],
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void> {
     // 自动序列化，防止Vue响应式对象IPC传递错误
     const safeMessages = safeSerializeForIPC(messages);
@@ -74,12 +76,12 @@ export class ElectronLLMProxy implements ILLMService {
     // Prefer the dedicated tools-capable streaming channel when available.
     const maybe = this.electronAPI.llm.sendMessageStreamWithTools;
     if (typeof maybe === 'function') {
-      await maybe(safeMessages, provider, safeTools, adaptedCallbacks);
+      await maybe(safeMessages, provider, safeTools, adaptedCallbacks, options?.signal);
       return;
     }
 
     // Back-compat fallback (older preload/main): stream without tool-call events.
-    await this.electronAPI.llm.sendMessageStream(safeMessages, provider, adaptedCallbacks);
+    await this.electronAPI.llm.sendMessageStream(safeMessages, provider, adaptedCallbacks, options?.signal);
   }
 
   async fetchModelList(

--- a/packages/core/src/services/llm/service.ts
+++ b/packages/core/src/services/llm/service.ts
@@ -6,7 +6,8 @@ import type {
   ModelOption,
   ToolDefinition,
   TextModel,
-  ITextAdapterRegistry
+  ITextAdapterRegistry,
+  StreamRequestOptions
 } from './types';
 import type { TextModelConfig, ModelConfig } from '../model/types';
 import { ModelManager } from '../model/manager';
@@ -126,9 +127,11 @@ export class LLMService implements ILLMService {
   async sendMessageStream(
     messages: Message[],
     provider: string,
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void> {
     try {
+      options?.signal?.throwIfAborted();
       this.validateMessages(messages);
 
       const modelConfig = await this.modelManager.getModel(provider);
@@ -144,7 +147,7 @@ export class LLMService implements ILLMService {
       const runtimeConfig = this.prepareRuntimeConfig(modelConfig);
 
       // 使用 Adapter 发送流式消息
-      await adapter.sendMessageStream(messages, runtimeConfig, callbacks);
+      await adapter.sendMessageStream(messages, runtimeConfig, callbacks, options);
 
     } catch (error) {
       console.error('Stream request failed:', error);
@@ -161,9 +164,11 @@ export class LLMService implements ILLMService {
     messages: Message[],
     provider: string,
     tools: ToolDefinition[],
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void> {
     try {
+      options?.signal?.throwIfAborted();
       this.validateMessages(messages);
 
       const modelConfig = await this.modelManager.getModel(provider);
@@ -179,7 +184,7 @@ export class LLMService implements ILLMService {
       const runtimeConfig = this.prepareRuntimeConfig(modelConfig);
 
       // 使用 Adapter 发送带工具的流式消息
-      await adapter.sendMessageStreamWithTools(messages, runtimeConfig, tools, callbacks);
+      await adapter.sendMessageStreamWithTools(messages, runtimeConfig, tools, callbacks, options);
 
     } catch (error) {
       console.error('Stream request with tools failed:', error);

--- a/packages/core/src/services/llm/types.ts
+++ b/packages/core/src/services/llm/types.ts
@@ -169,6 +169,14 @@ export interface StreamHandlers {
 }
 
 /**
+ * 流请求控制参数。AbortSignal 在当前进程内沿 service/adapter seam 传递；
+ * Electron renderer 中由 preload 将其转换为 IPC 取消请求，不直接序列化。
+ */
+export interface StreamRequestOptions {
+  signal?: AbortSignal;
+}
+
+/**
  * 模型信息接口
  */
 export interface ModelInfo {
@@ -213,7 +221,8 @@ export interface ILLMService {
   sendMessageStream(
     messages: Message[],
     provider: string,
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void>;
 
   /**
@@ -225,7 +234,8 @@ export interface ILLMService {
     messages: Message[],
     provider: string,
     tools: ToolDefinition[],
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void>;
 
   /**
@@ -295,7 +305,8 @@ export interface ITextProviderAdapter {
   sendMessageStream(
     messages: Message[],
     config: TextModelConfig,
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void>
 
   /**
@@ -310,7 +321,8 @@ export interface ITextProviderAdapter {
     messages: Message[],
     config: TextModelConfig,
     tools: ToolDefinition[],
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void>
 
   /**
@@ -329,7 +341,8 @@ export interface ITextProviderAdapter {
   sendImageUnderstandingStream(
     request: ImageUnderstandingRequest,
     config: TextModelConfig,
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions
   ): Promise<void>
 
   /**

--- a/packages/core/src/services/prompt/electron-proxy.ts
+++ b/packages/core/src/services/prompt/electron-proxy.ts
@@ -6,9 +6,10 @@ import {
   CustomConversationRequest,
 } from './types';
 import { PromptRecord } from '../history/types';
-import type { ImageInputRef } from '../image/types';
 import { safeSerializeForIPC } from '../../utils/ipc-serialization';
 import { ServiceDependencyError } from './errors';
+import type { StreamRequestOptions } from '../llm/types';
+import type { ImageInputRef } from '../image/types';
 
 // Helper function to check if running in Electron renderer process
 function isRunningInElectron(): boolean {
@@ -61,11 +62,9 @@ export class ElectronPromptServiceProxy implements IPromptService {
   async testPrompt(
     systemPrompt: string,
     userPrompt: string,
-    modelKey: string,
-    inputImages?: ImageInputRef[]
+    modelKey: string
   ): Promise<string> {
-    const safeInputImages = inputImages ? safeSerializeForIPC(inputImages) : undefined;
-    return this.api.testPrompt(systemPrompt, userPrompt, modelKey, safeInputImages);
+    return this.api.testPrompt(systemPrompt, userPrompt, modelKey);
   }
 
   async getHistory(): Promise<PromptRecord[]> {
@@ -78,16 +77,24 @@ export class ElectronPromptServiceProxy implements IPromptService {
 
   // Streaming methods are complex over IPC and are not implemented in the proxy for now.
   // They would require event-based communication rather than a simple invoke/handle.
-  async optimizePromptStream(request: OptimizationRequest, callbacks: StreamHandlers): Promise<void> {
+  async optimizePromptStream(
+    request: OptimizationRequest,
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions,
+  ): Promise<void> {
     // 自动序列化，防止Vue响应式对象IPC传递错误
     const safeRequest = safeSerializeForIPC(request);
-    await this.api.optimizePromptStream(safeRequest, callbacks);
+    await this.api.optimizePromptStream(safeRequest, callbacks, options?.signal);
   }
 
-  async optimizeMessageStream(request: MessageOptimizationRequest, callbacks: StreamHandlers): Promise<void> {
+  async optimizeMessageStream(
+    request: MessageOptimizationRequest,
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions,
+  ): Promise<void> {
     // 自动序列化，防止Vue响应式对象IPC传递错误
     const safeRequest = safeSerializeForIPC(request);
-    await this.api.optimizeMessageStream(safeRequest, callbacks);
+    await this.api.optimizeMessageStream(safeRequest, callbacks, options?.signal);
   }
 
   async iteratePromptStream(
@@ -102,10 +109,11 @@ export class ElectronPromptServiceProxy implements IPromptService {
       selectedMessageId?: string;
       variables?: Record<string, string>;
       tools?: any[];
-    }
+    },
+    options?: StreamRequestOptions,
   ): Promise<void> {
     const safeContextData = contextData ? safeSerializeForIPC(contextData) : undefined;
-    await this.api.iteratePromptStream(originalPrompt, lastOptimizedPrompt, iterateInput, modelKey, templateId, callbacks, safeContextData);
+    await this.api.iteratePromptStream(originalPrompt, lastOptimizedPrompt, iterateInput, modelKey, templateId, callbacks, safeContextData, options?.signal);
   }
 
   async testPromptStream(
@@ -113,18 +121,20 @@ export class ElectronPromptServiceProxy implements IPromptService {
     userPrompt: string,
     modelKey: string,
     callbacks: StreamHandlers,
-    inputImages?: ImageInputRef[]
+    inputImages?: ImageInputRef[],
+    options?: StreamRequestOptions,
   ): Promise<void> {
-    const safeInputImages = inputImages ? safeSerializeForIPC(inputImages) : undefined;
-    await this.api.testPromptStream(systemPrompt, userPrompt, modelKey, callbacks, safeInputImages);
+    const safeImages = inputImages ? safeSerializeForIPC(inputImages) : undefined;
+    await this.api.testPromptStream(systemPrompt, userPrompt, modelKey, callbacks, safeImages, options?.signal);
   }
 
   async testCustomConversationStream(
     request: CustomConversationRequest,
-    callbacks: StreamHandlers
+    callbacks: StreamHandlers,
+    options?: StreamRequestOptions,
   ): Promise<void> {
     // 自动序列化，防止Vue响应式对象IPC传递错误
     const safeRequest = safeSerializeForIPC(request);
-    await this.api.testCustomConversationStream(safeRequest, callbacks);
+    await this.api.testCustomConversationStream(safeRequest, callbacks, options?.signal);
   }
 }

--- a/packages/core/src/services/prompt/service.ts
+++ b/packages/core/src/services/prompt/service.ts
@@ -6,7 +6,7 @@ import {
   ConversationMessage,
   ToolDefinition,
 } from "./types";
-import { Message, StreamHandlers, ILLMService } from "../llm/types";
+import { Message, StreamHandlers, ILLMService, StreamRequestOptions } from "../llm/types";
 import { PromptRecord } from "../history/types";
 import { IModelManager } from "../model/types";
 import { ITemplateManager } from "../template/types";
@@ -401,11 +401,12 @@ export class PromptService implements IPromptService {
       }
 
       if (this.hasTestInputImages(inputImages)) {
+        const images = inputImages as ImageInputRef[];
         const result = await this.requireImageUnderstandingService().understand({
           modelConfig,
           systemPrompt: systemPrompt?.trim() ? systemPrompt : undefined,
           userPrompt,
-          images: inputImages,
+          images,
         });
 
         return result.content;
@@ -436,9 +437,6 @@ export class PromptService implements IPromptService {
     }
   }
 
-  /**
-   * 获取历史记录
-   */
   async getHistory(): Promise<PromptRecord[]> {
     return await this.historyManager.getRecords();
   }
@@ -459,8 +457,10 @@ export class PromptService implements IPromptService {
     modelKey: string,
     callbacks: StreamHandlers,
     inputImages?: ImageInputRef[],
+    options?: StreamRequestOptions,
   ): Promise<void> {
     try {
+      options?.signal?.throwIfAborted();
       // 对于用户提示词优化，systemPrompt 可以为空
       if (!userPrompt?.trim()) {
         throw new TestError(systemPrompt, userPrompt, "User prompt is required");
@@ -475,12 +475,13 @@ export class PromptService implements IPromptService {
       }
 
       if (this.hasTestInputImages(inputImages)) {
+        const images = inputImages as ImageInputRef[];
         await this.requireImageUnderstandingService().understandStream(
           {
             modelConfig,
             systemPrompt: systemPrompt?.trim() ? systemPrompt : undefined,
             userPrompt,
-            images: inputImages,
+            images,
           },
           {
             onToken: callbacks.onToken,
@@ -488,6 +489,7 @@ export class PromptService implements IPromptService {
             onComplete: callbacks.onComplete,
             onError: callbacks.onError,
           },
+          options,
         );
         return;
       }
@@ -507,7 +509,7 @@ export class PromptService implements IPromptService {
         onReasoningToken: callbacks.onReasoningToken, // 支持推理内容流
         onComplete: callbacks.onComplete,
         onError: callbacks.onError,
-      });
+      }, options);
     } catch (error) {
       const errorMessage = this.getSafeTestErrorMessage(error, inputImages);
       throw new TestError(
@@ -518,14 +520,13 @@ export class PromptService implements IPromptService {
     }
   }
 
-  /**
-   * 优化提示词（流式）- 支持提示词类型和增强功能
-   */
   async optimizePromptStream(
     request: OptimizationRequest,
     callbacks: StreamHandlers,
+    options?: StreamRequestOptions,
   ): Promise<void> {
     try {
+      options?.signal?.throwIfAborted();
       this.validateOptimizationRequest(request);
 
       const modelConfig = await this.modelManager.getModel(request.modelKey);
@@ -563,6 +564,7 @@ export class PromptService implements IPromptService {
             },
             onError: callbacks.onError,
           },
+          options,
         );
         return;
       }
@@ -591,7 +593,7 @@ export class PromptService implements IPromptService {
           }
         },
         onError: callbacks.onError,
-      });
+      }, options);
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
@@ -608,8 +610,10 @@ export class PromptService implements IPromptService {
   async optimizeMessageStream(
     request: MessageOptimizationRequest,
     callbacks: StreamHandlers,
+    options?: StreamRequestOptions,
   ): Promise<void> {
     try {
+      options?.signal?.throwIfAborted();
       // 验证请求参数
       this.validateMessageOptimizationRequest(request);
 
@@ -704,7 +708,7 @@ export class PromptService implements IPromptService {
           }
         },
         onError: callbacks.onError,
-      });
+      }, options);
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
@@ -731,8 +735,10 @@ export class PromptService implements IPromptService {
       variables?: Record<string, string>;
       tools?: ToolDefinition[];
     },
+    options?: StreamRequestOptions,
   ): Promise<void> {
     try {
+      options?.signal?.throwIfAborted();
       // 🔧 迭代模板只需要 lastOptimizedPrompt 和 iterateInput
       // originalPrompt 可以为空（用户直接在工作区编辑后迭代的场景）
       this.validateInput(lastOptimizedPrompt, modelKey);
@@ -827,7 +833,7 @@ export class PromptService implements IPromptService {
           }
         },
         onError: handlers.onError,
-      });
+      }, options);
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
@@ -853,10 +859,6 @@ export class PromptService implements IPromptService {
     }
   }
 
-  private hasInputImages(request: OptimizationRequest): request is OptimizationRequest & { inputImages: NonNullable<OptimizationRequest["inputImages"]> } {
-    return Array.isArray(request.inputImages) && request.inputImages.length > 0;
-  }
-
   private hasTestInputImages(inputImages?: ImageInputRef[]): inputImages is ImageInputRef[] {
     return Array.isArray(inputImages) && inputImages.length > 0;
   }
@@ -880,6 +882,10 @@ export class PromptService implements IPromptService {
     }
 
     return message;
+  }
+
+  private hasInputImages(request: OptimizationRequest): request is OptimizationRequest & { inputImages: NonNullable<OptimizationRequest["inputImages"]> } {
+    return Array.isArray(request.inputImages) && request.inputImages.length > 0;
   }
 
   private requireImageUnderstandingService(): IImageUnderstandingService {
@@ -1103,8 +1109,10 @@ export class PromptService implements IPromptService {
   async testCustomConversationStream(
     request: CustomConversationRequest,
     callbacks: StreamHandlers,
+    options?: StreamRequestOptions,
   ): Promise<void> {
     try {
+      options?.signal?.throwIfAborted();
       // 验证请求
       if (!request.modelKey?.trim()) {
         throw new TestError("", "", "Model key is required");
@@ -1156,6 +1164,7 @@ export class PromptService implements IPromptService {
               callbacks.onError?.(error);
             },
           },
+          options,
         );
       } else {
         // 传统的流式发送（无工具）
@@ -1181,6 +1190,7 @@ export class PromptService implements IPromptService {
               callbacks.onError?.(error);
             },
           },
+          options,
         );
       }
     } catch (error) {

--- a/packages/core/src/services/prompt/types.ts
+++ b/packages/core/src/services/prompt/types.ts
@@ -1,5 +1,5 @@
 import { PromptRecord } from "../history/types";
-import { StreamHandlers } from "../llm/types";
+import { StreamHandlers, StreamRequestOptions } from "../llm/types";
 import type { ImageInputRef } from "../image/types";
 
 /**
@@ -156,7 +156,6 @@ export interface IPromptService {
     systemPrompt: string,
     userPrompt: string,
     modelKey: string,
-    inputImages?: ImageInputRef[],
   ): Promise<string>;
 
   /** 获取历史记录 */
@@ -169,12 +168,14 @@ export interface IPromptService {
   optimizePromptStream(
     request: OptimizationRequest,
     callbacks: StreamHandlers,
+    options?: StreamRequestOptions,
   ): Promise<void>;
 
   /** 优化单条消息（流式）- 多轮对话模式专用 */
   optimizeMessageStream(
     request: MessageOptimizationRequest,
     callbacks: StreamHandlers,
+    options?: StreamRequestOptions,
   ): Promise<void>;
 
   /** 迭代优化提示词（流式） */
@@ -191,6 +192,7 @@ export interface IPromptService {
       variables?: Record<string, string>;
       tools?: ToolDefinition[];
     },
+    options?: StreamRequestOptions,
   ): Promise<void>;
 
   /** 测试提示词（流式）- 支持可选系统提示词 */
@@ -200,12 +202,14 @@ export interface IPromptService {
     modelKey: string,
     callbacks: StreamHandlers,
     inputImages?: ImageInputRef[],
+    options?: StreamRequestOptions,
   ): Promise<void>;
 
   /** 自定义会话测试（流式）- 高级模式功能 */
   testCustomConversationStream(
     request: CustomConversationRequest,
     callbacks: StreamHandlers,
+    options?: StreamRequestOptions,
   ): Promise<void>;
 }
 

--- a/packages/core/src/types/global.d.ts
+++ b/packages/core/src/types/global.d.ts
@@ -24,7 +24,8 @@ interface Window {
           onToolCall?: (toolCall: any) => void;
           onFinish?: () => void;
           onError?: (error: Error) => void;
-        }
+        },
+        signal?: AbortSignal
       ) => Promise<void>;
       sendMessageStreamWithTools?: (
         messages: any[],
@@ -36,8 +37,10 @@ interface Window {
           onToolCall?: (toolCall: any) => void;
           onFinish?: () => void;
           onError?: (error: Error) => void;
-        }
+        },
+        signal?: AbortSignal
       ) => Promise<void>;
+      cancelStream: (streamId: string) => Promise<{ cancelled: boolean }>;
       testConnection: (provider: string) => Promise<void>;
       fetchModelList: (provider: string, customConfig?: any) => Promise<Array<{value: string, label: string}>>;
     };

--- a/packages/core/tests/unit/image-understanding/service.test.ts
+++ b/packages/core/tests/unit/image-understanding/service.test.ts
@@ -124,6 +124,7 @@ describe('ImageUnderstandingService', () => {
       request,
       request.modelConfig,
       callbacks,
+      undefined,
     )
   })
 
@@ -155,6 +156,7 @@ describe('ImageUnderstandingService', () => {
       }),
       request.modelConfig,
       callbacks,
+      undefined,
     )
   })
 })

--- a/packages/core/tests/unit/llm/provider-cancellation.test.ts
+++ b/packages/core/tests/unit/llm/provider-cancellation.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from 'vitest'
+import { LLMService } from '../../../src/services/llm/service'
+import { OpenAIAdapter } from '../../../src/services/llm/adapters/openai-adapter'
+import { AnthropicAdapter } from '../../../src/services/llm/adapters/anthropic-adapter'
+import { GeminiAdapter } from '../../../src/services/llm/adapters/gemini-adapter'
+import { ChromeBuiltInAdapter } from '../../../src/services/llm/adapters/chrome-built-in-adapter'
+import type {
+  ITextProviderAdapter,
+  Message,
+  StreamHandlers,
+  TextModelConfig,
+} from '../../../src/services/llm/types'
+
+const messages: Message[] = [{ role: 'user', content: 'cancel me' }]
+
+/** 创建不产生业务副作用的流回调替身。 */
+function createCallbacks(): StreamHandlers {
+  return {
+    onToken: vi.fn(),
+    onComplete: vi.fn(),
+    onError: vi.fn(),
+  }
+}
+
+/** 根据真实 adapter 元数据构造可通过 Core 校验的最小模型配置。 */
+function createConfig(adapter: ITextProviderAdapter): TextModelConfig {
+  return {
+    id: adapter.getProvider().id,
+    name: adapter.getProvider().name,
+    enabled: true,
+    providerMeta: adapter.getProvider(),
+    modelMeta: adapter.getModels()[0],
+    connectionConfig: { apiKey: 'local-test-key' },
+    paramOverrides: {},
+  }
+}
+
+/** 模拟真正占用中的 provider 请求，只在收到 AbortSignal 后以 AbortError 结束。 */
+function waitForProviderAbort(signal?: AbortSignal): Promise<never> {
+  return new Promise((_resolve, reject) => {
+    if (!signal) {
+      reject(new Error('Provider did not receive AbortSignal'))
+      return
+    }
+
+    const rejectAsAborted = () => reject(signal.reason ?? new DOMException('Aborted', 'AbortError'))
+    if (signal.aborted) {
+      rejectAsAborted()
+      return
+    }
+    signal.addEventListener('abort', rejectAsAborted, { once: true })
+  })
+}
+
+/** 启动请求、触发取消并验证 provider 观察到同一个 signal。 */
+async function expectProviderCancellation(
+  start: (signal: AbortSignal) => Promise<void>,
+): Promise<void> {
+  const controller = new AbortController()
+  const pending = start(controller.signal)
+  controller.abort()
+  await expect(pending).rejects.toMatchObject({ name: 'AbortError' })
+}
+
+describe('provider stream cancellation', () => {
+  it('forwards the LLM service signal to the selected provider adapter', async () => {
+    let receivedSignal: AbortSignal | undefined
+    const adapter = new OpenAIAdapter()
+    const config = createConfig(adapter)
+    const fakeAdapter = {
+      ...adapter,
+      sendMessageStream: async (
+        _messages: Message[],
+        _config: TextModelConfig,
+        _callbacks: StreamHandlers,
+        options?: { signal?: AbortSignal },
+      ) => {
+        receivedSignal = options?.signal
+        await waitForProviderAbort(receivedSignal)
+      },
+    } as unknown as ITextProviderAdapter
+    const modelManager = {
+      getModel: vi.fn().mockResolvedValue(config),
+    }
+    const registry = {
+      getAdapter: vi.fn().mockReturnValue(fakeAdapter),
+    }
+    const service = new LLMService(modelManager as never, registry as never)
+
+    await expectProviderCancellation(async (signal) => {
+      await service.sendMessageStream(messages, config.id, createCallbacks(), { signal })
+    })
+
+    expect(receivedSignal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('passes AbortSignal to OpenAI-compatible SDK requests', async () => {
+    const adapter = new OpenAIAdapter()
+    const config = createConfig(adapter)
+    const create = vi.fn((_body, requestOptions) => waitForProviderAbort(requestOptions?.signal))
+    ;(adapter as any).createOpenAIInstance = vi.fn().mockResolvedValue({
+      chat: { completions: { create } },
+      responses: { create: vi.fn() },
+    })
+
+    await expectProviderCancellation(async (signal) => {
+      await adapter.sendMessageStream(messages, config, createCallbacks(), { signal })
+    })
+
+    expect(create).toHaveBeenCalledWith(expect.objectContaining({ stream: true }), {
+      signal: expect.any(AbortSignal),
+    })
+  })
+
+  it('passes AbortSignal to Anthropic SDK stream requests', async () => {
+    const adapter = new AnthropicAdapter()
+    const config = createConfig(adapter)
+    const stream = vi.fn((_body, requestOptions) => waitForProviderAbort(requestOptions?.signal))
+    ;(adapter as any).createClient = vi.fn().mockResolvedValue({ messages: { stream } })
+
+    await expectProviderCancellation(async (signal) => {
+      await adapter.sendMessageStream(messages, config, createCallbacks(), { signal })
+    })
+
+    expect(stream).toHaveBeenCalledWith(expect.any(Object), {
+      signal: expect.any(AbortSignal),
+    })
+  })
+
+  it('passes AbortSignal to Gemini generation config', async () => {
+    const adapter = new GeminiAdapter()
+    const config = createConfig(adapter)
+    const generateContentStream = vi.fn((request) => (
+      waitForProviderAbort(request.config?.abortSignal)
+    ))
+    ;(adapter as any).createClient = vi.fn().mockResolvedValue({
+      models: { generateContentStream },
+    })
+
+    await expectProviderCancellation(async (signal) => {
+      await adapter.sendMessageStream(messages, config, createCallbacks(), { signal })
+    })
+
+    expect(generateContentStream).toHaveBeenCalledWith(expect.objectContaining({
+      config: expect.objectContaining({ abortSignal: expect.any(AbortSignal) }),
+    }))
+  })
+
+  it('passes AbortSignal to Chrome Prompt API and destroys the active session', async () => {
+    const adapter = new ChromeBuiltInAdapter()
+    const config = createConfig(adapter)
+    const destroy = vi.fn()
+    const promptStreaming = vi.fn((_input, options) => waitForProviderAbort(options?.signal))
+    vi.stubGlobal('LanguageModel', {
+      availability: vi.fn().mockResolvedValue('available'),
+      create: vi.fn().mockResolvedValue({ promptStreaming, destroy }),
+    })
+
+    await expectProviderCancellation(async (signal) => {
+      await adapter.sendMessageStream(messages, config, createCallbacks(), { signal })
+    })
+
+    expect(promptStreaming).toHaveBeenCalledWith('cancel me', {
+      signal: expect.any(AbortSignal),
+    })
+    expect(destroy).toHaveBeenCalled()
+    vi.unstubAllGlobals()
+  })
+})

--- a/packages/desktop/README-env-config.md
+++ b/packages/desktop/README-env-config.md
@@ -172,4 +172,10 @@ private: false
 ---
 
 **更新时间**: 2025-01-12  
-**版本**: v1.2.0+ 
+**版本**: v1.2.0+
+
+## 安全说明（Desktop hardening）
+
+- Renderer 仅接收明确 public 的 `VITE_APP_*` / `VITE_PUBLIC_*` 运行时配置；供应商 `VITE_*_API_KEY` 保留在主进程。
+- 自定义模型密钥请写入应用内模型配置（如 `ls`），不要依赖把 API Key 注入 `window.runtime_config`。
+- 若连接测试报 `IPC request sender is not trusted`，优先按 `README.md` 对应 FAQ 排查 Windows IPC 信任误杀。

--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -84,7 +84,22 @@ npm start
 ### Q: 我的.env.local文件有效吗？
 A: **有效！** 桌面应用现在会自动加载项目根目录的`.env.local`文件。
 
+### Q: 连接测试报 `IPC request sender is not trusted`？
+
+这通常是桌面端 IPC 信任校验误杀，而不是 API Key/Base URL 本身错误。
+
+**常见原因（Windows 安装版）**
+1. `senderFrame.isMainFrame` 在部分 Electron/Windows 组合下为 `undefined`，旧逻辑会把它当成不可信；
+2. `file://` 路径大小写与 `web-dist` 根路径不一致。
+
+**处理**
+1. 确认已包含修复：`config/ipc-security.js` 仅拒绝明确 `isMainFrame === false`；
+2. 确认 `config/window-security.js` 在 win32 上对路径做大小写归一；
+3. 重启应用后再测；
+4. 若仍失败，查看 `AppData/Roaming/@prompt-optimizer/desktop/logs` 中是否仍有 `IPC_UNTRUSTED_SENDER`，并核对页面是否从 `resources/app/web-dist` 加载。
+
 ### Q: 为什么UI显示有API密钥，但测试连接失败？
+
 A: 这是因为UI进程和主进程环境隔离。确保：
 1. 环境变量正确设置在`.env.local`文件中
 2. 重启桌面应用以重新加载环境变量

--- a/packages/desktop/config/ipc-domain-handlers.test.js
+++ b/packages/desktop/config/ipc-domain-handlers.test.js
@@ -1,0 +1,717 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createStreamRegistry } = require('./stream-registry');
+const { createOwnedStreamRunner } = require('./ipc/owned-stream-runner');
+const { registerLlmIpcHandlers } = require('./ipc/llm-handlers');
+const { registerPromptStreamIpcHandlers } = require('./ipc/prompt-stream-handlers');
+const { registerModelIpcHandlers } = require('./ipc/model-handlers');
+const { registerImageIpcHandlers } = require('./ipc/image-handlers');
+const { registerTemplateIpcHandlers } = require('./ipc/template-handlers');
+const { registerHistoryIpcHandlers } = require('./ipc/history-handlers');
+const { registerFavoriteIpcHandlers } = require('./ipc/favorite-handlers');
+const { registerContextIpcHandlers } = require('./ipc/context-handlers');
+const { registerDataIpcHandlers } = require('./ipc/data-handlers');
+const { registerPromptSyncIpcHandlers } = require('./ipc/prompt-sync-handlers');
+const { registerPreferenceIpcHandlers } = require('./ipc/preference-handlers');
+const { registerSystemIpcHandlers } = require('./ipc/system-handlers');
+const { ALL_DOMAIN_CHANNELS } = require('./ipc/channel-manifest');
+
+/**
+ * 创建只记录通道与处理函数的安全 IPC 注册替身。
+ */
+function createRegistrar() {
+  const handlers = new Map();
+  const validators = new Map();
+  return {
+    handlers,
+    validators,
+    registerSensitiveIpc(channel, handler, validateArgs) {
+      handlers.set(channel, handler);
+      validators.set(channel, validateArgs);
+    },
+  };
+}
+
+/**
+ * 创建可观察流事件的 renderer sender 替身。
+ */
+function createSender(id = 1) {
+  const sent = [];
+  return {
+    id,
+    sent,
+    isDestroyed: () => false,
+    send: (...args) => sent.push(args),
+  };
+}
+
+test('LLM backend module registers the stable IPC interface and forwards owned stream events', async () => {
+  const registrar = createRegistrar();
+  const sender = createSender();
+  const streamRegistry = createStreamRegistry();
+  const runOwnedStream = createOwnedStreamRunner({ streamRegistry });
+  const llmService = {
+    testConnection: async () => {},
+    sendMessage: async () => 'plain-response',
+    sendMessageStructured: async () => ({ content: 'structured-response' }),
+    fetchModelList: async () => [{ value: 'model', label: 'Model' }],
+    sendMessageStream: async (_messages, _provider, callbacks) => {
+      callbacks.onToken('token');
+      callbacks.onComplete();
+    },
+    sendMessageStreamWithTools: async (_messages, _provider, _tools, callbacks) => {
+      callbacks.onToolCall({ name: 'tool' });
+      callbacks.onComplete();
+    },
+  };
+
+  registerLlmIpcHandlers({
+    registerSensitiveIpc: registrar.registerSensitiveIpc,
+    llmService,
+    streamRegistry,
+    runOwnedStream,
+  });
+
+  assert.deepEqual([...registrar.handlers.keys()], [
+    'llm-testConnection',
+    'llm-sendMessage',
+    'llm-sendMessageStructured',
+    'llm-fetchModelList',
+    'llm-sendMessageStream',
+    'llm-sendMessageStreamWithTools',
+    'stream-cancel',
+  ]);
+  assert.equal(
+    await registrar.handlers.get('llm-sendMessage')({}, [], 'provider'),
+    'plain-response',
+  );
+
+  await registrar.handlers.get('llm-sendMessageStream')(
+    { sender },
+    [],
+    'provider',
+    'stream_domain',
+  );
+  assert.deepEqual(sender.sent, [
+    ['stream-content-stream_domain', 'token'],
+    ['stream-finish-stream_domain'],
+  ]);
+});
+
+test('LLM backend module forwards the owner AbortSignal to Core', async () => {
+  const registrar = createRegistrar();
+  const sender = createSender();
+  const streamRegistry = createStreamRegistry();
+  const runOwnedStream = createOwnedStreamRunner({ streamRegistry });
+  let receivedSignal;
+  const llmService = {
+    testConnection: async () => {},
+    sendMessage: async () => '',
+    sendMessageStructured: async () => ({ content: '' }),
+    fetchModelList: async () => [],
+    sendMessageStream: async (_messages, _provider, callbacks, options) => {
+      receivedSignal = options?.signal;
+      callbacks.onComplete();
+    },
+    sendMessageStreamWithTools: async () => {},
+  };
+
+  registerLlmIpcHandlers({
+    registerSensitiveIpc: registrar.registerSensitiveIpc,
+    llmService,
+    streamRegistry,
+    runOwnedStream,
+  });
+
+  await registrar.handlers.get('llm-sendMessageStream')(
+    { sender },
+    [],
+    'provider',
+    'stream_signal',
+  );
+
+  assert.equal(receivedSignal instanceof AbortSignal, true);
+});
+
+test('Prompt backend module keeps stream channels sender-owned', async () => {
+  const registrar = createRegistrar();
+  const sender = createSender();
+  const runOwnedStream = createOwnedStreamRunner({
+    streamRegistry: createStreamRegistry(),
+  });
+  const promptService = {
+    optimizePromptStream: async (_request, callbacks) => {
+      callbacks.onToken('optimized');
+      callbacks.onComplete();
+    },
+    optimizeMessageStream: async () => {},
+    iteratePromptStream: async () => {},
+    testPromptStream: async () => {},
+    testCustomConversationStream: async () => {},
+  };
+
+  registerPromptStreamIpcHandlers({
+    registerSensitiveIpc: registrar.registerSensitiveIpc,
+    promptService,
+    runOwnedStream,
+  });
+
+  assert.deepEqual([...registrar.handlers.keys()], [
+    'prompt-optimizePromptStream',
+    'prompt-optimizeMessageStream',
+    'prompt-iteratePromptStream',
+    'prompt-testPromptStream',
+    'prompt-testCustomConversationStream',
+  ]);
+
+  // 锁定位置参数式 interface 的 streamId 索引，避免拆分后误校验 contextData。
+  assert.doesNotThrow(() => registrar.validators.get('prompt-iteratePromptStream')([
+    'original',
+    'last-optimized',
+    'iterate-input',
+    'model',
+    'template',
+    'stream_iterate',
+    { variables: {} },
+  ]));
+  assert.doesNotThrow(() => registrar.validators.get('prompt-testPromptStream')([
+    'system',
+    'user',
+    'model',
+    'stream_test',
+  ]));
+  assert.throws(
+    () => registrar.validators.get('prompt-testPromptStream')([
+      'system',
+      'user',
+      'model',
+      undefined,
+    ]),
+    /Invalid IPC stream identifier/,
+  );
+
+  await registrar.handlers.get('prompt-optimizePromptStream')(
+    { sender },
+    {},
+    'stream_prompt',
+  );
+  assert.deepEqual(sender.sent, [
+    ['stream-token-stream_prompt', 'optimized'],
+    ['stream-finish-stream_prompt'],
+  ]);
+});
+
+test('Prompt backend module forwards the owner AbortSignal to Core', async () => {
+  const registrar = createRegistrar();
+  const sender = createSender();
+  const runOwnedStream = createOwnedStreamRunner({
+    streamRegistry: createStreamRegistry(),
+  });
+  let receivedSignal;
+  const promptService = {
+    optimizePromptStream: async (_request, callbacks, options) => {
+      receivedSignal = options?.signal;
+      callbacks.onComplete();
+    },
+    optimizeMessageStream: async () => {},
+    iteratePromptStream: async () => {},
+    testPromptStream: async () => {},
+    testCustomConversationStream: async () => {},
+  };
+
+  registerPromptStreamIpcHandlers({
+    registerSensitiveIpc: registrar.registerSensitiveIpc,
+    promptService,
+    runOwnedStream,
+  });
+
+  await registrar.handlers.get('prompt-optimizePromptStream')(
+    { sender },
+    {},
+    'stream_prompt_signal',
+  );
+
+  assert.equal(receivedSignal instanceof AbortSignal, true);
+});
+
+/**
+ * 创建与 main.js 一致的成功/失败响应信封替身。
+ */
+function createEnvelopeHelpers() {
+  return {
+    safeSerialize: (value) => value,
+    createSuccessResponse: (data) => ({ success: true, data }),
+    createErrorResponse: (error) => ({
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    }),
+    createStructuredErrorResponse: (error) => ({
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    }),
+  };
+}
+
+/**
+ * 创建可记录已注册 channel 的 ipcMain 替身。
+ */
+function createIpcMainStub() {
+  const handlers = new Map();
+  return {
+    handlers,
+    handle(channel, handler) {
+      handlers.set(channel, handler);
+    },
+  };
+}
+
+test('Model backend module registers the stable model IPC interface', async () => {
+  const ipcMain = createIpcMainStub();
+  const envelopes = createEnvelopeHelpers();
+  const calls = [];
+  const modelManager = {
+    getAllModels: async () => {
+      calls.push('getAllModels');
+      return [{ id: 'm1' }];
+    },
+    addModel: async (key, config) => {
+      calls.push(['addModel', key, config]);
+    },
+    updateModel: async (id, updates) => {
+      calls.push(['updateModel', id, updates]);
+    },
+    deleteModel: async (id) => {
+      calls.push(['deleteModel', id]);
+    },
+    ensureInitialized: async () => {
+      calls.push('ensureInitialized');
+    },
+    isInitialized: async () => true,
+    getEnabledModels: async () => [{ id: 'm1', enabled: true }],
+    exportData: async () => ({ models: [] }),
+    importData: async (data) => {
+      calls.push(['importData', data]);
+    },
+    getDataType: () => 'model',
+    validateData: async (data) => ({ valid: true, data }),
+  };
+
+  registerModelIpcHandlers({
+    ipcMain,
+    modelManager,
+    ...envelopes,
+  });
+
+  assert.deepEqual([...ipcMain.handlers.keys()].sort(), [
+    'model-addModel',
+    'model-deleteModel',
+    'model-ensureInitialized',
+    'model-exportData',
+    'model-getAllModels',
+    'model-getDataType',
+    'model-getEnabledModels',
+    'model-getModels',
+    'model-importData',
+    'model-isInitialized',
+    'model-updateModel',
+    'model-validateData',
+  ]);
+
+  assert.deepEqual(
+    await ipcMain.handlers.get('model-getAllModels')({}),
+    { success: true, data: [{ id: 'm1' }] },
+  );
+  assert.deepEqual(
+    await ipcMain.handlers.get('model-addModel')({}, { key: 'k1', name: 'Model' }),
+    { success: true, data: null },
+  );
+  assert.deepEqual(calls, [
+    'getAllModels',
+    ['addModel', 'k1', { name: 'Model' }],
+  ]);
+});
+
+test('Image backend module registers the stable image IPC interface', async () => {
+  const ipcMain = createIpcMainStub();
+  const envelopes = createEnvelopeHelpers();
+  const imageModelManager = {
+    ensureInitialized: async () => {},
+    isInitialized: async () => true,
+    getAllConfigs: async () => [{ id: 'img-1' }],
+    getConfig: async (id) => ({ id }),
+    addConfig: async () => {},
+    updateConfig: async () => {},
+    deleteConfig: async () => {},
+    getEnabledConfigs: async () => [{ id: 'img-1', enabled: true }],
+    exportData: async () => ({ configs: [] }),
+    importData: async () => {},
+    getDataType: () => 'image-model',
+    validateData: async () => true,
+  };
+  const imageService = {
+    generate: async (request) => ({ ok: true, request }),
+    generateText2Image: async () => ({ mode: 't2i' }),
+    generateImage2Image: async () => ({ mode: 'i2i' }),
+    generateMultiImage: async () => ({ mode: 'multi' }),
+    validateRequest: async () => ({ valid: true }),
+    validateText2ImageRequest: async () => ({ valid: true }),
+    validateImage2ImageRequest: async () => ({ valid: true }),
+    validateMultiImageRequest: async () => ({ valid: true }),
+    testConnection: async (config) => ({ connected: true, config }),
+  };
+  const imageAdapterRegistry = {
+    getDynamicModels: async (providerId) => [{ id: `${providerId}-dynamic` }],
+  };
+
+  registerImageIpcHandlers({
+    ipcMain,
+    imageModelManager,
+    imageService,
+    imageAdapterRegistry,
+    ...envelopes,
+  });
+
+  assert.equal(ipcMain.handlers.has('image-model-getAllConfigs'), true);
+  assert.equal(ipcMain.handlers.has('image-generate'), true);
+  assert.equal(ipcMain.handlers.has('image-testConnection'), true);
+  assert.equal(ipcMain.handlers.has('image-getDynamicModels'), true);
+
+  assert.deepEqual(
+    await ipcMain.handlers.get('image-generate')({}, { prompt: 'cat' }),
+    { success: true, data: { ok: true, request: { prompt: 'cat' } } },
+  );
+  assert.deepEqual(
+    await ipcMain.handlers.get('image-getDynamicModels')({}, 'openai', { apiKey: 'x' }),
+    { success: true, data: [{ id: 'openai-dynamic' }] },
+  );
+});
+
+test('Template backend module registers the stable template IPC interface', async () => {
+  const ipcMain = createIpcMainStub();
+  const envelopes = createEnvelopeHelpers();
+  const calls = [];
+  const templateManager = {
+    listTemplates: async () => [{ id: 't1' }],
+    getTemplate: async (id) => ({ id, content: 'old' }),
+    saveTemplate: async (template) => {
+      calls.push(['saveTemplate', template]);
+    },
+    deleteTemplate: async (id) => {
+      calls.push(['deleteTemplate', id]);
+    },
+    listTemplatesByType: async (type) => [{ id: 't1', type }],
+    exportTemplate: async (id) => JSON.stringify({ id }),
+    importTemplate: async () => {},
+    exportData: async () => ({ templates: [] }),
+    importData: async () => {},
+    getDataType: () => 'template',
+    validateData: (data) => ({ valid: true, data }),
+    changeBuiltinTemplateLanguage: async () => {},
+    getCurrentBuiltinTemplateLanguage: async () => 'zh',
+    getSupportedBuiltinTemplateLanguages: async () => ['zh', 'en'],
+    getSupportedLanguages: (template) => Object.keys(template || {}),
+  };
+
+  registerTemplateIpcHandlers({
+    ipcMain,
+    templateManager,
+    ...envelopes,
+  });
+
+  assert.equal(ipcMain.handlers.has('template-getTemplates'), true);
+  assert.equal(ipcMain.handlers.has('template-updateTemplate'), true);
+  assert.equal(ipcMain.handlers.has('template-getSupportedLanguages'), true);
+
+  assert.deepEqual(
+    await ipcMain.handlers.get('template-getTemplates')({}),
+    { success: true, data: [{ id: 't1' }] },
+  );
+  assert.deepEqual(
+    await ipcMain.handlers.get('template-updateTemplate')({}, 't1', { content: 'new' }),
+    { success: true, data: null },
+  );
+  assert.deepEqual(calls, [
+    ['saveTemplate', { id: 't1', content: 'new' }],
+  ]);
+});
+
+test('History backend module registers the stable history IPC interface', async () => {
+  const ipcMain = createIpcMainStub();
+  const envelopes = createEnvelopeHelpers();
+  const historyManager = {
+    getRecords: async () => [{ id: 'h1' }],
+    addRecord: async (record) => ({ ...record, id: 'h2' }),
+    deleteRecord: async () => {},
+    clearHistory: async () => {},
+    getIterationChain: async (recordId) => [{ id: recordId }],
+    getAllChains: async () => [],
+    getChain: async (chainId) => ({ id: chainId }),
+    createNewChain: async (record) => ({ chainId: 'c1', record }),
+    addIteration: async (params) => ({ ok: true, params }),
+    deleteChain: async () => {},
+    exportData: async () => ({ history: [] }),
+    importData: async () => {},
+    getDataType: () => 'history',
+    validateData: async () => true,
+  };
+
+  registerHistoryIpcHandlers({
+    ipcMain,
+    historyManager,
+    ...envelopes,
+  });
+
+  assert.equal(ipcMain.handlers.has('history-getHistory'), true);
+  assert.equal(ipcMain.handlers.has('history-addIteration'), true);
+  assert.deepEqual(
+    await ipcMain.handlers.get('history-getHistory')({}),
+    { success: true, data: [{ id: 'h1' }] },
+  );
+  assert.deepEqual(
+    await ipcMain.handlers.get('history-createNewChain')({}, { prompt: 'p' }),
+    { success: true, data: { chainId: 'c1', record: { prompt: 'p' } } },
+  );
+});
+
+test('Favorite backend module registers the stable favorite IPC interface', async () => {
+  const ipcMain = createIpcMainStub();
+  const envelopes = createEnvelopeHelpers();
+  const favoriteManager = {
+    addFavorite: async (favorite) => ({ id: 'f1', ...favorite }),
+    getFavorites: async () => [{ id: 'f1' }],
+    getFavorite: async (id) => ({ id }),
+    updateFavorite: async () => {},
+    setFavoritePromptAssetCurrentVersion: async () => {},
+    deleteFavoritePromptAssetVersion: async () => {},
+    deleteFavorite: async () => {},
+    deleteFavorites: async () => {},
+    incrementUseCount: async () => {},
+    getCategories: async () => [{ id: 'c1' }],
+    addCategory: async (category) => ({ id: 'c2', ...category }),
+    updateCategory: async () => {},
+    deleteCategory: async (id) => ({ deleted: id }),
+    getStats: async () => ({ total: 1 }),
+    searchFavorites: async (keyword) => [{ id: 'f1', keyword }],
+    exportFavorites: async () => ({ favorites: [] }),
+    importFavorites: async (data) => ({ imported: true, data }),
+    getAllTags: async () => ['tag'],
+    addTag: async () => {},
+    renameTag: async (oldTag, newTag) => ({ oldTag, newTag }),
+    mergeTags: async (sourceTags, targetTag) => ({ sourceTags, targetTag }),
+    deleteTag: async (tag) => ({ deleted: tag }),
+    reorderCategories: async () => {},
+    getCategoryUsage: async (categoryId) => ({ categoryId, count: 1 }),
+    ensureDefaultCategories: async () => {},
+  };
+
+  registerFavoriteIpcHandlers({
+    ipcMain,
+    favoriteManager,
+    safeSerialize: envelopes.safeSerialize,
+    createSuccessResponse: envelopes.createSuccessResponse,
+  });
+
+  assert.equal(ipcMain.handlers.has('favorite-addFavorite'), true);
+  assert.equal(ipcMain.handlers.has('favorite-importFavorites'), true);
+  assert.deepEqual(
+    await ipcMain.handlers.get('favorite-addFavorite')({}, { title: 't' }),
+    { success: true, data: { id: 'f1', title: 't' } },
+  );
+  assert.deepEqual(
+    await ipcMain.handlers.get('favorite-importFavorites')({}, '{"a":1}', { merge: true }),
+    { success: true, data: { imported: true, data: '{"a":1}' } },
+  );
+});
+
+test('Context backend module registers the stable context IPC interface', async () => {
+  const ipcMain = createIpcMainStub();
+  const envelopes = createEnvelopeHelpers();
+  const contextRepo = {
+    list: async () => [{ id: 'c1' }],
+    getCurrentId: async () => 'c1',
+    setCurrentId: async () => {},
+    get: async (id) => ({ id }),
+    create: async (meta) => ({ id: 'c2', ...meta }),
+    duplicate: async (id) => ({ id: `${id}-copy` }),
+    rename: async () => {},
+    save: async () => {},
+    update: async () => {},
+    remove: async () => {},
+    exportAll: async () => ({ items: [] }),
+    importAll: async () => ({ imported: 1 }),
+    exportData: async () => ({ contexts: [] }),
+    importData: async () => {},
+    getDataType: () => 'context',
+    validateData: async () => true,
+  };
+
+  registerContextIpcHandlers({
+    ipcMain,
+    contextRepo,
+    ...envelopes,
+  });
+
+  assert.equal(ipcMain.handlers.has('context-list'), true);
+  assert.deepEqual(
+    await ipcMain.handlers.get('context-create')({}, { title: 'new' }),
+    { success: true, data: { id: 'c2', title: 'new' } },
+  );
+});
+
+test('Data backend module registers the stable data IPC interface', async () => {
+  const ipcMain = createIpcMainStub();
+  const envelopes = createEnvelopeHelpers();
+  const opened = [];
+  const dataManager = {
+    exportAllData: async () => ({ all: true }),
+    importAllData: async () => {},
+  };
+  const app = {
+    getPath: () => 'C:\\user-data',
+  };
+  const shell = {
+    openPath: async (target) => {
+      opened.push(target);
+      return '';
+    },
+  };
+
+  registerDataIpcHandlers({
+    ipcMain,
+    dataManager,
+    app,
+    shell,
+    ...envelopes,
+  });
+
+  assert.deepEqual(
+    await ipcMain.handlers.get('data-exportAllData')({}),
+    { success: true, data: { all: true } },
+  );
+  assert.deepEqual(
+    await ipcMain.handlers.get('data-openStorageDirectory')({}),
+    { success: true, data: true },
+  );
+  assert.deepEqual(opened, ['C:\\user-data']);
+});
+
+test('Prompt sync backend module registers non-stream prompt channels', async () => {
+  const ipcMain = createIpcMainStub();
+  const envelopes = createEnvelopeHelpers();
+  const promptService = {
+    optimizePrompt: async () => 'optimized',
+    optimizeMessage: async () => 'message',
+    iteratePrompt: async () => 'iterated',
+    testPrompt: async () => 'tested',
+  };
+  const historyManager = {
+    getHistory: async () => [{ id: 'h1' }],
+    getIterationChain: async (id) => [{ id }],
+  };
+
+  registerPromptSyncIpcHandlers({
+    ipcMain,
+    promptService,
+    historyManager,
+    createSuccessResponse: envelopes.createSuccessResponse,
+    createErrorResponse: envelopes.createErrorResponse,
+  });
+
+  assert.deepEqual(
+    await ipcMain.handlers.get('prompt-optimizePrompt')({}, { target: 'x' }),
+    { success: true, data: 'optimized' },
+  );
+  assert.deepEqual(
+    await ipcMain.handlers.get('prompt-getHistory')({}),
+    { success: true, data: [{ id: 'h1' }] },
+  );
+});
+
+test('Preference backend module registers the stable preference IPC interface', async () => {
+  const ipcMain = createIpcMainStub();
+  const envelopes = createEnvelopeHelpers();
+  const preferenceService = {
+    get: async (_key, defaultValue) => defaultValue,
+    set: async () => {},
+    delete: async () => {},
+    keys: async () => ['a'],
+    clear: async () => {},
+    getAll: async () => ({ a: 1 }),
+    exportData: async () => ({ prefs: true }),
+    importData: async () => {},
+    getDataType: () => 'preference',
+    validateData: async () => true,
+  };
+
+  registerPreferenceIpcHandlers({
+    ipcMain,
+    preferenceService,
+    ...envelopes,
+  });
+
+  assert.deepEqual(
+    await ipcMain.handlers.get('preference-get')({}, 'theme', 'dark'),
+    { success: true, data: 'dark' },
+  );
+  assert.deepEqual(
+    await ipcMain.handlers.get('preference-keys')({}),
+    { success: true, data: ['a'] },
+  );
+});
+
+test('System backend module registers config/app/log channels', async () => {
+  const ipcMain = createIpcMainStub();
+  const envelopes = createEnvelopeHelpers();
+  const registrar = createRegistrar();
+  const opened = [];
+  let locale = null;
+
+  registerSystemIpcHandlers({
+    ipcMain,
+    shell: {
+      openExternal: async () => {},
+      openPath: async (target) => {
+        opened.push(target);
+        return '';
+      },
+    },
+    consoleLogger: {
+      getLogPaths: () => ({ logDir: 'C:\\logs', mainLog: 'C:\\logs\\main.log' }),
+    },
+    registerSensitiveIpc: registrar.registerSensitiveIpc,
+    getPublicRuntimeConfig: () => ({ VITE_APP_TITLE: 'PO', APP_TITLE: 'PO' }),
+    isSafeExternalUrl: (url) => url.startsWith('https://'),
+    createIpcError: (code, message) => {
+      const error = new Error(message);
+      error.code = code;
+      return error;
+    },
+    createSuccessResponse: envelopes.createSuccessResponse,
+    createErrorResponse: envelopes.createErrorResponse,
+    setUiLocale: (value) => {
+      locale = value;
+    },
+    normalizeUiLocale: (value) => value,
+    packageJsonPath: require('path').join(__dirname, '../package.json'),
+  });
+
+  assert.equal(registrar.handlers.has('config-getEnvironmentVariables'), true);
+  assert.equal(ipcMain.handlers.has('app-get-version'), true);
+  assert.deepEqual(
+    await ipcMain.handlers.get('logs-open-directory')({}),
+    { success: true, data: true },
+  );
+  assert.deepEqual(opened, ['C:\\logs']);
+
+  await ipcMain.handlers.get('app-set-locale')({}, 'zh-CN');
+  assert.equal(locale, 'zh-CN');
+});
+
+test('channel manifest enumerates unique domain channels', () => {
+  assert.equal(new Set(ALL_DOMAIN_CHANNELS).size, ALL_DOMAIN_CHANNELS.length);
+  assert.ok(ALL_DOMAIN_CHANNELS.includes('context-list'));
+  assert.ok(ALL_DOMAIN_CHANNELS.includes('data-exportAllData'));
+  assert.ok(ALL_DOMAIN_CHANNELS.includes('preference-get'));
+  assert.ok(ALL_DOMAIN_CHANNELS.includes('app-get-version'));
+});

--- a/packages/desktop/config/ipc-security.js
+++ b/packages/desktop/config/ipc-security.js
@@ -48,8 +48,9 @@ function isTrustedRendererSender(event, options) {
     return false;
   }
 
-  // IPC from subframes must never inherit the main renderer's privileged bridge.
-  if (event?.senderFrame?.isMainFrame !== true) {
+  // Reject known subframes. If senderFrame/isMainFrame is unavailable
+  // (common on some Windows/Electron builds), fall back to URL allowlist only.
+  if (event?.senderFrame && event.senderFrame.isMainFrame === false) {
     return false;
   }
 

--- a/packages/desktop/config/ipc-security.js
+++ b/packages/desktop/config/ipc-security.js
@@ -1,0 +1,105 @@
+const { isAllowedMainFrameNavigation } = require('./window-security');
+
+const STREAM_ID_PATTERN = /^[A-Za-z0-9_-]{1,96}$/;
+
+/** 创建带稳定错误码的 IPC 边界错误。 */
+function createIpcError(code, message) {
+  const error = new Error(message);
+  error.code = code;
+  return error;
+}
+
+/** 将 handler 成功结果包装为跨层统一响应信封。 */
+function createSuccessResponse(data) {
+  return { success: true, data };
+}
+
+/** 将未知异常收敛为不包含 stack 的跨层错误信封。 */
+function createErrorResponse(error) {
+  const message = error instanceof Error ? error.message : String(error);
+  return {
+    success: false,
+    error: {
+      code: error && typeof error.code === 'string' ? error.code : 'IPC_HANDLER_FAILED',
+      message,
+    },
+  };
+}
+
+/** 优先读取 senderFrame URL，并为兼容环境回退到 sender URL。 */
+function getSenderUrl(event) {
+  const frameUrl = event?.senderFrame?.url;
+  if (typeof frameUrl === 'string' && frameUrl.length > 0) {
+    return frameUrl;
+  }
+
+  const getUrl = event?.sender?.getURL;
+  return typeof getUrl === 'function' ? getUrl.call(event.sender) : '';
+}
+
+/** 判断 IPC 是否来自应用允许的未销毁主 frame renderer。 */
+function isTrustedRendererSender(event, options) {
+  const sender = event?.sender;
+  if (!sender || typeof sender.id !== 'number') {
+    return false;
+  }
+
+  if (typeof sender.isDestroyed === 'function' && sender.isDestroyed()) {
+    return false;
+  }
+
+  // IPC from subframes must never inherit the main renderer's privileged bridge.
+  if (event?.senderFrame?.isMainFrame !== true) {
+    return false;
+  }
+
+  return isAllowedMainFrameNavigation(getSenderUrl(event), options);
+}
+
+/** 拒绝来自子 frame、外部页面或已销毁 renderer 的 IPC 请求。 */
+function assertTrustedRendererSender(event, options) {
+  if (!isTrustedRendererSender(event, options)) {
+    throw createIpcError('IPC_UNTRUSTED_SENDER', 'IPC request sender is not trusted');
+  }
+}
+
+/** 判断流标识是否满足长度与字符集约束。 */
+function isValidStreamId(streamId) {
+  return typeof streamId === 'string' && STREAM_ID_PATTERN.test(streamId);
+}
+
+/** 在流标识不合法时抛出稳定 IPC 错误。 */
+function assertValidStreamId(streamId) {
+  if (!isValidStreamId(streamId)) {
+    throw createIpcError('IPC_INVALID_STREAM_ID', 'Invalid IPC stream identifier');
+  }
+}
+
+/** 注册具备 sender 校验、参数校验和统一响应信封的敏感 IPC handler。 */
+function registerSecureIpcHandler(ipcMain, channel, handler, {
+  senderOptions,
+  validateArgs,
+  createSuccess = createSuccessResponse,
+  createError = createErrorResponse,
+} = {}) {
+  ipcMain.handle(channel, async (event, ...args) => {
+    try {
+      assertTrustedRendererSender(event, senderOptions);
+      if (typeof validateArgs === 'function') {
+        validateArgs(args, event);
+      }
+      return createSuccess(await handler(event, ...args));
+    } catch (error) {
+      return createError(error);
+    }
+  });
+}
+
+module.exports = {
+  assertTrustedRendererSender,
+  assertValidStreamId,
+  createIpcError,
+  isTrustedRendererSender,
+  isValidStreamId,
+  registerSecureIpcHandler,
+};

--- a/packages/desktop/config/ipc-security.test.js
+++ b/packages/desktop/config/ipc-security.test.js
@@ -1,0 +1,122 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  createIpcError,
+  isTrustedRendererSender,
+  isValidStreamId,
+  registerSecureIpcHandler,
+} = require('./ipc-security');
+
+const options = {
+  isDevelopment: false,
+  packagedRoot: 'C:/app/web-dist',
+  devServerUrl: 'http://localhost:18181',
+};
+
+function createEvent({
+  id = 1,
+  url = 'file:///C:/app/web-dist/index.html',
+  isMainFrame = true,
+} = {}) {
+  return {
+    sender: {
+      id,
+      getURL: () => url,
+      isDestroyed: () => false,
+    },
+    senderFrame: {
+      url,
+      isMainFrame,
+    },
+  };
+}
+
+function createIpcMain() {
+  const handlers = new Map();
+  return {
+    handlers,
+    handle(channel, handler) {
+      handlers.set(channel, handler);
+    },
+  };
+}
+
+test('IPC sender trust accepts only the app main frame', () => {
+  assert.equal(isTrustedRendererSender(createEvent(), options), true);
+  assert.equal(isTrustedRendererSender(createEvent({ isMainFrame: false }), options), false);
+  assert.equal(
+    isTrustedRendererSender(createEvent({ url: 'file:///C:/Windows/System32/notepad.exe' }), options),
+    false,
+  );
+  assert.equal(
+    isTrustedRendererSender(createEvent({ url: 'https://attacker.example' }), options),
+    false,
+  );
+});
+
+test('IPC sender trust accepts only the configured development origin', () => {
+  const developmentOptions = { ...options, isDevelopment: true };
+
+  assert.equal(
+    isTrustedRendererSender(createEvent({ url: 'http://localhost:18181/workspace' }), developmentOptions),
+    true,
+  );
+  assert.equal(
+    isTrustedRendererSender(createEvent({ url: 'http://localhost:5173/workspace' }), developmentOptions),
+    false,
+  );
+});
+
+test('stream identifiers are bounded and use a restricted alphabet', () => {
+  assert.equal(isValidStreamId('stream_abc-123'), true);
+  assert.equal(isValidStreamId('stream with spaces'), false);
+  assert.equal(isValidStreamId('../stream'), false);
+  assert.equal(isValidStreamId('a'.repeat(97)), false);
+});
+
+test('secure IPC handler rejects untrusted senders with the shared error envelope', async () => {
+  const ipcMain = createIpcMain();
+  let called = false;
+
+  registerSecureIpcHandler(ipcMain, 'sensitive-action', async () => {
+    called = true;
+    return 'unreachable';
+  }, { senderOptions: options });
+
+  const result = await ipcMain.handlers.get('sensitive-action')(
+    createEvent({ url: 'https://attacker.example' }),
+  );
+
+  assert.equal(called, false);
+  assert.deepEqual(result, {
+    success: false,
+    error: {
+      code: 'IPC_UNTRUSTED_SENDER',
+      message: 'IPC request sender is not trusted',
+    },
+  });
+});
+
+test('secure IPC handler validates arguments and normalizes successful results', async () => {
+  const ipcMain = createIpcMain();
+
+  registerSecureIpcHandler(ipcMain, 'validated-action', async (_event, value) => value.toUpperCase(), {
+    senderOptions: options,
+    validateArgs: ([value]) => {
+      if (typeof value !== 'string') {
+        throw createIpcError('IPC_INVALID_ARGUMENT', 'Invalid IPC request arguments');
+      }
+    },
+  });
+
+  const handler = ipcMain.handlers.get('validated-action');
+  assert.deepEqual(await handler(createEvent(), 'ok'), { success: true, data: 'OK' });
+  assert.deepEqual(await handler(createEvent(), 42), {
+    success: false,
+    error: {
+      code: 'IPC_INVALID_ARGUMENT',
+      message: 'Invalid IPC request arguments',
+    },
+  });
+});

--- a/packages/desktop/config/ipc-security.test.js
+++ b/packages/desktop/config/ipc-security.test.js
@@ -55,6 +55,21 @@ test('IPC sender trust accepts only the app main frame', () => {
   );
 });
 
+test('IPC sender trust tolerates missing senderFrame metadata on packaged file URLs', () => {
+  const eventWithoutFrame = {
+    sender: {
+      id: 7,
+      getURL: () => 'file:///C:/app/web-dist/index.html',
+      isDestroyed: () => false,
+    },
+  };
+  assert.equal(isTrustedRendererSender(eventWithoutFrame, options), true);
+
+  const eventWithUnknownMainFrame = createEvent();
+  delete eventWithUnknownMainFrame.senderFrame.isMainFrame;
+  assert.equal(isTrustedRendererSender(eventWithUnknownMainFrame, options), true);
+});
+
 test('IPC sender trust accepts only the configured development origin', () => {
   const developmentOptions = { ...options, isDevelopment: true };
 

--- a/packages/desktop/config/ipc/channel-manifest.js
+++ b/packages/desktop/config/ipc/channel-manifest.js
@@ -1,0 +1,330 @@
+/**
+ * Desktop IPC channel 轻量清单 + 协议元数据。
+ * 契约测试与装配完整性检查使用；默认不在 runtime 强制校验（避免破坏兼容）。
+ *
+ * 维护约定：
+ * 1. 新增 preload invoke channel 时同步更新本文件；
+ * 2. 领域 module 拆分后，对应 channel 应能在 handlers 中找到；
+ * 3. 流式事件名不在 invoke 清单内（由 stream 契约测试单独覆盖）；
+ * 4. 需要运行时校验时调用 assertKnownInvokeChannel / getChannelMeta。
+ */
+
+const { IPC_EVENTS } = require('../constants');
+
+/** 协议版本：破坏性 channel/信封变更时递增。 */
+const IPC_PROTOCOL_VERSION = '1.1.0';
+
+/** 统一响应信封形状（文档化，供测试与未来校验使用）。 */
+const RESPONSE_ENVELOPE = Object.freeze({
+  success: { type: 'boolean', required: true },
+  data: { type: 'any', required: false },
+  error: { type: 'string|object', required: false },
+});
+
+/** 文本模型管理 channel。 */
+const MODEL_CHANNELS = Object.freeze([
+  'model-getModels',
+  'model-addModel',
+  'model-updateModel',
+  'model-deleteModel',
+  'model-ensureInitialized',
+  'model-isInitialized',
+  'model-getAllModels',
+  'model-getEnabledModels',
+  'model-exportData',
+  'model-importData',
+  'model-getDataType',
+  'model-validateData',
+]);
+
+/** 图像模型与图像生成 channel。 */
+const IMAGE_CHANNELS = Object.freeze([
+  'image-model-ensureInitialized',
+  'image-model-isInitialized',
+  'image-model-getAllConfigs',
+  'image-model-getConfig',
+  'image-model-addConfig',
+  'image-model-updateConfig',
+  'image-model-deleteConfig',
+  'image-model-getEnabledConfigs',
+  'image-model-exportData',
+  'image-model-importData',
+  'image-model-getDataType',
+  'image-model-validateData',
+  'image-generate',
+  'image-generateText2Image',
+  'image-generateImage2Image',
+  'image-generateMultiImage',
+  'image-validateRequest',
+  'image-validateText2ImageRequest',
+  'image-validateImage2ImageRequest',
+  'image-validateMultiImageRequest',
+  'image-testConnection',
+  'image-getDynamicModels',
+]);
+
+/** 模板管理 channel。 */
+const TEMPLATE_CHANNELS = Object.freeze([
+  'template-getTemplates',
+  'template-getTemplate',
+  'template-createTemplate',
+  'template-updateTemplate',
+  'template-deleteTemplate',
+  'template-listTemplatesByType',
+  'template-exportTemplate',
+  'template-importTemplate',
+  'template-exportData',
+  'template-importData',
+  'template-getDataType',
+  'template-validateData',
+  'template-changeBuiltinTemplateLanguage',
+  'template-getCurrentBuiltinTemplateLanguage',
+  'template-getSupportedBuiltinTemplateLanguages',
+  'template-getSupportedLanguages',
+]);
+
+/** 历史记录 channel。 */
+const HISTORY_CHANNELS = Object.freeze([
+  'history-getHistory',
+  'history-addRecord',
+  'history-deleteRecord',
+  'history-clearHistory',
+  'history-getIterationChain',
+  'history-getAllChains',
+  'history-getChain',
+  'history-createNewChain',
+  'history-addIteration',
+  'history-deleteChain',
+  'history-exportData',
+  'history-importData',
+  'history-getDataType',
+  'history-validateData',
+]);
+
+/** 会话上下文 channel。 */
+const CONTEXT_CHANNELS = Object.freeze([
+  'context-list',
+  'context-getCurrentId',
+  'context-setCurrentId',
+  'context-get',
+  'context-create',
+  'context-duplicate',
+  'context-rename',
+  'context-save',
+  'context-update',
+  'context-remove',
+  'context-exportAll',
+  'context-importAll',
+  'context-exportData',
+  'context-importData',
+  'context-getDataType',
+  'context-validateData',
+]);
+
+/** 收藏管理 channel。 */
+const FAVORITE_CHANNELS = Object.freeze([
+  'favorite-addFavorite',
+  'favorite-getFavorites',
+  'favorite-getFavorite',
+  'favorite-updateFavorite',
+  'favorite-setFavoritePromptAssetCurrentVersion',
+  'favorite-deleteFavoritePromptAssetVersion',
+  'favorite-deleteFavorite',
+  'favorite-deleteFavorites',
+  'favorite-incrementUseCount',
+  'favorite-getCategories',
+  'favorite-addCategory',
+  'favorite-updateCategory',
+  'favorite-deleteCategory',
+  'favorite-getStats',
+  'favorite-searchFavorites',
+  'favorite-exportFavorites',
+  'favorite-importFavorites',
+  'favorite-getAllTags',
+  'favorite-addTag',
+  'favorite-renameTag',
+  'favorite-mergeTags',
+  'favorite-deleteTag',
+  'favorite-reorderCategories',
+  'favorite-getCategoryUsage',
+  'favorite-ensureDefaultCategories',
+]);
+
+/** 数据管理 channel。 */
+const DATA_CHANNELS = Object.freeze([
+  'data-exportAllData',
+  'data-importAllData',
+  'data-getStorageInfo',
+  'data-openStorageDirectory',
+]);
+
+/** 偏好设置 channel。 */
+const PREFERENCE_CHANNELS = Object.freeze([
+  'preference-get',
+  'preference-set',
+  'preference-delete',
+  'preference-keys',
+  'preference-clear',
+  'preference-getAll',
+  'preference-exportData',
+  'preference-importData',
+  'preference-getDataType',
+  'preference-validateData',
+]);
+
+/** Prompt 同步与流式 channel。 */
+const PROMPT_CHANNELS = Object.freeze([
+  'prompt-optimizePrompt',
+  'prompt-optimizeMessage',
+  'prompt-iteratePrompt',
+  'prompt-testPrompt',
+  'prompt-getHistory',
+  'prompt-getIterationChain',
+  'prompt-optimizePromptStream',
+  'prompt-optimizeMessageStream',
+  'prompt-iteratePromptStream',
+  'prompt-testPromptStream',
+  'prompt-testCustomConversationStream',
+]);
+
+/** LLM 与流取消 channel。 */
+const LLM_CHANNELS = Object.freeze([
+  'llm-testConnection',
+  'llm-sendMessage',
+  'llm-sendMessageStructured',
+  'llm-fetchModelList',
+  'llm-sendMessageStream',
+  'llm-sendMessageStreamWithTools',
+  'stream-cancel',
+]);
+
+/** 系统横切 channel。 */
+const SYSTEM_CHANNELS = Object.freeze([
+  'config-getEnvironmentVariables',
+  'shell-openExternal',
+  'app-get-version',
+  'app-set-locale',
+  'logs-get-paths',
+  'logs-open-directory',
+]);
+
+/** 自动更新 invoke channel（字符串值，非 IPC_EVENTS 键名）。 */
+const UPDATE_CHANNELS = Object.freeze([
+  IPC_EVENTS.UPDATE_CHECK,
+  IPC_EVENTS.UPDATE_CHECK_ALL_VERSIONS,
+  IPC_EVENTS.UPDATE_START_DOWNLOAD,
+  IPC_EVENTS.UPDATE_INSTALL,
+  IPC_EVENTS.UPDATE_IGNORE_VERSION,
+  IPC_EVENTS.UPDATE_UNIGNORE_VERSION,
+  IPC_EVENTS.UPDATE_GET_IGNORED_VERSIONS,
+  IPC_EVENTS.UPDATE_DOWNLOAD_SPECIFIC_VERSION,
+]);
+
+/** 自动更新事件 channel（main → renderer）。 */
+const UPDATE_EVENT_CHANNELS = Object.freeze([
+  IPC_EVENTS.UPDATE_AVAILABLE_INFO,
+  IPC_EVENTS.UPDATE_NOT_AVAILABLE,
+  IPC_EVENTS.UPDATE_DOWNLOAD_PROGRESS,
+  IPC_EVENTS.UPDATE_DOWNLOADED,
+  IPC_EVENTS.UPDATE_ERROR,
+  IPC_EVENTS.UPDATE_DOWNLOAD_STARTED,
+]);
+
+/** 领域 invoke channel 合集（不含 update 事件）。 */
+const ALL_DOMAIN_CHANNELS = Object.freeze([
+  ...LLM_CHANNELS,
+  ...PROMPT_CHANNELS,
+  ...MODEL_CHANNELS,
+  ...IMAGE_CHANNELS,
+  ...TEMPLATE_CHANNELS,
+  ...HISTORY_CHANNELS,
+  ...CONTEXT_CHANNELS,
+  ...FAVORITE_CHANNELS,
+  ...DATA_CHANNELS,
+  ...PREFERENCE_CHANNELS,
+  ...SYSTEM_CHANNELS,
+  ...UPDATE_CHANNELS,
+]);
+
+/**
+ * 轻量 channel 元数据：领域 + 是否流式 + 响应信封约定。
+ * 不描述完整 JSON Schema，仅保证契约测试可断言关键字段。
+ */
+const CHANNEL_META = Object.freeze(
+  Object.fromEntries(
+    ALL_DOMAIN_CHANNELS.map((channel) => {
+      const isStream = /Stream$/.test(channel) || channel === 'stream-cancel';
+      let domain = 'misc';
+      if (channel.startsWith('llm-') || channel === 'stream-cancel') domain = 'llm';
+      else if (channel.startsWith('prompt-')) domain = 'prompt';
+      else if (channel.startsWith('model-')) domain = 'model';
+      else if (channel.startsWith('image-')) domain = 'image';
+      else if (channel.startsWith('template-')) domain = 'template';
+      else if (channel.startsWith('history-')) domain = 'history';
+      else if (channel.startsWith('context-')) domain = 'context';
+      else if (channel.startsWith('favorite-')) domain = 'favorite';
+      else if (channel.startsWith('data-')) domain = 'data';
+      else if (channel.startsWith('preference-')) domain = 'preference';
+      else if (channel.startsWith('updater-') || channel.startsWith('update-')) domain = 'update';
+      else if (
+        channel.startsWith('config-')
+        || channel.startsWith('shell-')
+        || channel.startsWith('app-')
+        || channel.startsWith('logs-')
+      ) domain = 'system';
+
+      return [channel, Object.freeze({
+        channel,
+        domain,
+        kind: isStream ? 'stream' : 'invoke',
+        envelope: RESPONSE_ENVELOPE,
+      })];
+    }),
+  ),
+);
+
+/** 判断是否为已登记的 invoke channel。 */
+function isKnownInvokeChannel(channel) {
+  return Object.prototype.hasOwnProperty.call(CHANNEL_META, channel);
+}
+
+/**
+ * 可选运行时校验：未知 channel 抛错；默认仅供测试/调试使用。
+ * @param {string} channel
+ */
+function assertKnownInvokeChannel(channel) {
+  if (!isKnownInvokeChannel(channel)) {
+    const error = new Error(`Unknown IPC invoke channel: ${channel}`);
+    error.code = 'IPC_UNKNOWN_CHANNEL';
+    throw error;
+  }
+  return CHANNEL_META[channel];
+}
+
+/** 读取 channel 元数据；未知时返回 null。 */
+function getChannelMeta(channel) {
+  return CHANNEL_META[channel] || null;
+}
+
+module.exports = {
+  IPC_PROTOCOL_VERSION,
+  RESPONSE_ENVELOPE,
+  MODEL_CHANNELS,
+  IMAGE_CHANNELS,
+  TEMPLATE_CHANNELS,
+  HISTORY_CHANNELS,
+  CONTEXT_CHANNELS,
+  FAVORITE_CHANNELS,
+  DATA_CHANNELS,
+  PREFERENCE_CHANNELS,
+  PROMPT_CHANNELS,
+  LLM_CHANNELS,
+  SYSTEM_CHANNELS,
+  UPDATE_CHANNELS,
+  UPDATE_EVENT_CHANNELS,
+  ALL_DOMAIN_CHANNELS,
+  CHANNEL_META,
+  isKnownInvokeChannel,
+  assertKnownInvokeChannel,
+  getChannelMeta,
+};

--- a/packages/desktop/config/ipc/context-handlers.js
+++ b/packages/desktop/config/ipc/context-handlers.js
@@ -1,0 +1,168 @@
+/**
+ * 注册会话上下文相关的 Desktop IPC interface。
+ * 保持现有 channel、位置参数和响应信封不变。
+ *
+ * @param {object} dependencies 上下文领域注册依赖。
+ */
+function registerContextIpcHandlers({
+  ipcMain,
+  contextRepo,
+  safeSerialize,
+  createSuccessResponse,
+  createErrorResponse,
+}) {
+  ipcMain.handle('context-list', async () => {
+    try {
+      const result = await contextRepo.list();
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('context-getCurrentId', async () => {
+    try {
+      const result = await contextRepo.getCurrentId();
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('context-setCurrentId', async (_event, id) => {
+    try {
+      await contextRepo.setCurrentId(id);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('context-get', async (_event, id) => {
+    try {
+      const result = await contextRepo.get(id);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('context-create', async (_event, meta) => {
+    try {
+      const safeMeta = meta ? safeSerialize(meta) : undefined;
+      const result = await contextRepo.create(safeMeta);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('context-duplicate', async (_event, id, options) => {
+    try {
+      const safeOptions = options ? safeSerialize(options) : undefined;
+      const result = await contextRepo.duplicate(id, safeOptions);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('context-rename', async (_event, id, title) => {
+    try {
+      await contextRepo.rename(id, title);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('context-save', async (_event, ctx) => {
+    try {
+      const safeCtx = safeSerialize(ctx);
+      await contextRepo.save(safeCtx);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('context-update', async (_event, id, patch) => {
+    try {
+      const safePatch = safeSerialize(patch);
+      await contextRepo.update(id, safePatch);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('context-remove', async (_event, id) => {
+    try {
+      await contextRepo.remove(id);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('context-exportAll', async () => {
+    try {
+      const result = await contextRepo.exportAll();
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('context-importAll', async (_event, bundle, mode) => {
+    try {
+      const safeBundle = safeSerialize(bundle);
+      const result = await contextRepo.importAll(safeBundle, mode);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('context-exportData', async () => {
+    try {
+      const result = await contextRepo.exportData();
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('context-importData', async (_event, data) => {
+    try {
+      const safeData = safeSerialize(data);
+      await contextRepo.importData(safeData);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('context-getDataType', async () => {
+    try {
+      const result = contextRepo.getDataType();
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('context-validateData', async (_event, data) => {
+    try {
+      const safeData = safeSerialize(data);
+      const result = await contextRepo.validateData(safeData);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+}
+
+module.exports = {
+  registerContextIpcHandlers,
+};

--- a/packages/desktop/config/ipc/data-handlers.js
+++ b/packages/desktop/config/ipc/data-handlers.js
@@ -1,0 +1,82 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * 注册数据导入导出与本地存储信息相关的 Desktop IPC interface。
+ * 保持现有 channel、位置参数和响应信封不变。
+ *
+ * @param {object} dependencies 数据领域注册依赖。
+ */
+function registerDataIpcHandlers({
+  ipcMain,
+  dataManager,
+  app,
+  shell,
+  createSuccessResponse,
+  createErrorResponse,
+}) {
+  ipcMain.handle('data-exportAllData', async () => {
+    try {
+      const result = await dataManager.exportAllData();
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('data-importAllData', async (_event, dataString) => {
+    try {
+      await dataManager.importAllData(dataString);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  // Desktop: storage helpers for Data Manager UI
+  ipcMain.handle('data-getStorageInfo', async () => {
+    try {
+      const userDataPath = app.getPath('userData');
+      const mainFilePath = path.join(userDataPath, 'prompt-optimizer-data.json');
+      const backupFilePath = path.join(userDataPath, 'prompt-optimizer-data.json.backup');
+
+      /** 安全读取文件体积，缺失时返回 0。 */
+      const statSafe = async (targetPath) => {
+        try {
+          const stats = await fs.promises.stat(targetPath);
+          return typeof stats?.size === 'number' ? stats.size : 0;
+        } catch {
+          return 0;
+        }
+      };
+
+      const mainSizeBytes = await statSafe(mainFilePath);
+      const backupSizeBytes = await statSafe(backupFilePath);
+
+      return createSuccessResponse({
+        userDataPath,
+        mainFilePath,
+        mainSizeBytes,
+        backupFilePath,
+        backupSizeBytes,
+        totalBytes: mainSizeBytes + backupSizeBytes,
+      });
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('data-openStorageDirectory', async () => {
+    try {
+      const userDataPath = app.getPath('userData');
+      await shell.openPath(userDataPath);
+      return createSuccessResponse(true);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+}
+
+module.exports = {
+  registerDataIpcHandlers,
+};

--- a/packages/desktop/config/ipc/favorite-handlers.js
+++ b/packages/desktop/config/ipc/favorite-handlers.js
@@ -1,0 +1,298 @@
+/**
+ * 将收藏领域错误整理为可序列化的结构化错误载荷。
+ * 保留 code/details/cause，方便 renderer 做领域错误展示。
+ */
+function formatFavoriteError(error) {
+  if (!error || typeof error !== 'object') {
+    return { message: String(error || 'Unknown error'), code: 'UNKNOWN_ERROR' };
+  }
+
+  const formatted = {
+    message: error.message || 'Unknown error',
+    code: error.code || 'UNKNOWN_ERROR',
+    name: error.name || 'Error',
+  };
+
+  if (error.details) {
+    formatted.details = error.details;
+  }
+
+  if (error.cause) {
+    formatted.cause = {
+      message: error.cause.message || String(error.cause),
+      code: error.cause.code,
+      name: error.cause.name,
+    };
+  }
+
+  return formatted;
+}
+
+/**
+ * 输出收藏 IPC 失败日志，并返回与历史实现一致的错误信封。
+ */
+function createFavoriteErrorResponse(error) {
+  console.error('[Favorite IPC Error]', error);
+  return { success: false, error: formatFavoriteError(error) };
+}
+
+/**
+ * 注册收藏管理相关的 Desktop IPC interface。
+ * 保持现有 channel、位置参数和响应信封不变，仅从 main.js 拆出领域实现。
+ *
+ * @param {object} dependencies 收藏领域注册依赖。
+ * @param {Electron.IpcMain} dependencies.ipcMain Electron IPC 主进程对象。
+ * @param {object} dependencies.favoriteManager Core 收藏管理器。
+ * @param {Function} dependencies.safeSerialize 清理 Vue 响应式对象，避免 IPC 序列化失败。
+ * @param {Function} dependencies.createSuccessResponse 统一成功响应信封。
+ */
+function registerFavoriteIpcHandlers({
+  ipcMain,
+  favoriteManager,
+  safeSerialize,
+  createSuccessResponse,
+}) {
+  ipcMain.handle('favorite-addFavorite', async (_event, favorite) => {
+    try {
+      const safeFavorite = safeSerialize(favorite);
+      const result = await favoriteManager.addFavorite(safeFavorite);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createFavoriteErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('favorite-getFavorites', async (_event, options) => {
+    try {
+      const safeOptions = safeSerialize(options);
+      const result = await favoriteManager.getFavorites(safeOptions || undefined);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createFavoriteErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('favorite-getFavorite', async (_event, id) => {
+    try {
+      const result = await favoriteManager.getFavorite(id);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createFavoriteErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('favorite-updateFavorite', async (_event, id, updates) => {
+    try {
+      const safeUpdates = safeSerialize(updates);
+      await favoriteManager.updateFavorite(id, safeUpdates);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createFavoriteErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('favorite-setFavoritePromptAssetCurrentVersion', async (_event, id, versionId) => {
+    try {
+      await favoriteManager.setFavoritePromptAssetCurrentVersion(id, versionId);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createFavoriteErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('favorite-deleteFavoritePromptAssetVersion', async (_event, id, versionId) => {
+    try {
+      await favoriteManager.deleteFavoritePromptAssetVersion(id, versionId);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createFavoriteErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('favorite-deleteFavorite', async (_event, id) => {
+    try {
+      await favoriteManager.deleteFavorite(id);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createFavoriteErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('favorite-deleteFavorites', async (_event, ids) => {
+    try {
+      const safeIds = safeSerialize(ids);
+      await favoriteManager.deleteFavorites(safeIds);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createFavoriteErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('favorite-incrementUseCount', async (_event, id) => {
+    try {
+      await favoriteManager.incrementUseCount(id);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createFavoriteErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('favorite-getCategories', async () => {
+    try {
+      const result = await favoriteManager.getCategories();
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createFavoriteErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('favorite-addCategory', async (_event, category) => {
+    try {
+      const safeCategory = safeSerialize(category);
+      const result = await favoriteManager.addCategory(safeCategory);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createFavoriteErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('favorite-updateCategory', async (_event, id, updates) => {
+    try {
+      const safeUpdates = safeSerialize(updates);
+      await favoriteManager.updateCategory(id, safeUpdates);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createFavoriteErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('favorite-deleteCategory', async (_event, id) => {
+    try {
+      const result = await favoriteManager.deleteCategory(id);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createFavoriteErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('favorite-getStats', async () => {
+    try {
+      const result = await favoriteManager.getStats();
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createFavoriteErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('favorite-searchFavorites', async (_event, keyword, options) => {
+    try {
+      const safeOptions = safeSerialize(options);
+      const result = await favoriteManager.searchFavorites(keyword, safeOptions || undefined);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createFavoriteErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('favorite-exportFavorites', async (_event, ids) => {
+    try {
+      const safeIds = safeSerialize(ids);
+      const result = await favoriteManager.exportFavorites(safeIds || undefined);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createFavoriteErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('favorite-importFavorites', async (_event, data, options) => {
+    try {
+      const safeData = typeof data === 'string' ? data : safeSerialize(data);
+      const safeOptions = safeSerialize(options);
+      const result = await favoriteManager.importFavorites(safeData, safeOptions || undefined);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createFavoriteErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('favorite-getAllTags', async () => {
+    try {
+      const result = await favoriteManager.getAllTags();
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createFavoriteErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('favorite-addTag', async (_event, tag) => {
+    try {
+      await favoriteManager.addTag(tag);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createFavoriteErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('favorite-renameTag', async (_event, oldTag, newTag) => {
+    try {
+      const result = await favoriteManager.renameTag(oldTag, newTag);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createFavoriteErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('favorite-mergeTags', async (_event, sourceTags, targetTag) => {
+    try {
+      const safeSourceTags = safeSerialize(sourceTags);
+      const result = await favoriteManager.mergeTags(safeSourceTags, targetTag);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createFavoriteErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('favorite-deleteTag', async (_event, tag) => {
+    try {
+      const result = await favoriteManager.deleteTag(tag);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createFavoriteErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('favorite-reorderCategories', async (_event, categoryIds) => {
+    try {
+      const safeCategoryIds = safeSerialize(categoryIds);
+      await favoriteManager.reorderCategories(safeCategoryIds);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createFavoriteErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('favorite-getCategoryUsage', async (_event, categoryId) => {
+    try {
+      const result = await favoriteManager.getCategoryUsage(categoryId);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createFavoriteErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('favorite-ensureDefaultCategories', async (_event, defaultCategories) => {
+    try {
+      const safeCategories = safeSerialize(defaultCategories);
+      await favoriteManager.ensureDefaultCategories(safeCategories);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createFavoriteErrorResponse(error);
+    }
+  });
+}
+
+module.exports = {
+  registerFavoriteIpcHandlers,
+  formatFavoriteError,
+  createFavoriteErrorResponse,
+};

--- a/packages/desktop/config/ipc/history-handlers.js
+++ b/packages/desktop/config/ipc/history-handlers.js
@@ -1,0 +1,160 @@
+/**
+ * 注册历史记录相关的 Desktop IPC interface。
+ * 保持现有 channel、位置参数和响应信封不变，仅从 main.js 拆出领域实现。
+ *
+ * @param {object} dependencies 历史领域注册依赖。
+ * @param {Electron.IpcMain} dependencies.ipcMain Electron IPC 主进程对象。
+ * @param {object} dependencies.historyManager Core 历史记录管理器。
+ * @param {Function} dependencies.safeSerialize 清理 Vue 响应式对象，避免 IPC 序列化失败。
+ * @param {Function} dependencies.createSuccessResponse 统一成功响应信封。
+ * @param {Function} dependencies.createErrorResponse 统一失败响应信封。
+ */
+function registerHistoryIpcHandlers({
+  ipcMain,
+  historyManager,
+  safeSerialize,
+  createSuccessResponse,
+  createErrorResponse,
+}) {
+  ipcMain.handle('history-getHistory', async () => {
+    try {
+      const result = await historyManager.getRecords();
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('history-addRecord', async (_event, record) => {
+    try {
+      // 清理Vue响应式对象，防止IPC序列化错误
+      const safeRecord = safeSerialize(record);
+      const result = await historyManager.addRecord(safeRecord);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('history-deleteRecord', async (_event, id) => {
+    try {
+      await historyManager.deleteRecord(id);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('history-clearHistory', async () => {
+    try {
+      await historyManager.clearHistory();
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  // 历史记录链相关接口
+  ipcMain.handle('history-getIterationChain', async (_event, recordId) => {
+    try {
+      const result = await historyManager.getIterationChain(recordId);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('history-getAllChains', async () => {
+    try {
+      const result = await historyManager.getAllChains();
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('history-getChain', async (_event, chainId) => {
+    try {
+      const result = await historyManager.getChain(chainId);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('history-createNewChain', async (_event, record) => {
+    try {
+      // 清理Vue响应式对象，防止IPC序列化错误
+      const safeRecord = safeSerialize(record);
+      const result = await historyManager.createNewChain(safeRecord);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('history-addIteration', async (_event, params) => {
+    try {
+      // 清理Vue响应式对象，防止IPC序列化错误
+      const safeParams = safeSerialize(params);
+      const result = await historyManager.addIteration(safeParams);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('history-deleteChain', async (_event, chainId) => {
+    try {
+      await historyManager.deleteChain(chainId);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  // History Import/Export Data handlers (for bulk operations)
+  ipcMain.handle('history-exportData', async () => {
+    try {
+      const result = await historyManager.exportData();
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('history-importData', async (_event, data) => {
+    try {
+      // 清理Vue响应式对象，防止IPC序列化错误
+      const safeData = safeSerialize(data);
+      await historyManager.importData(safeData);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('history-getDataType', async () => {
+    try {
+      const result = historyManager.getDataType();
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('history-validateData', async (_event, data) => {
+    try {
+      // 清理Vue响应式对象，防止IPC序列化错误
+      const safeData = safeSerialize(data);
+      const result = await historyManager.validateData(safeData);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+}
+
+module.exports = {
+  registerHistoryIpcHandlers,
+};

--- a/packages/desktop/config/ipc/image-handlers.js
+++ b/packages/desktop/config/ipc/image-handlers.js
@@ -1,0 +1,248 @@
+/**
+ * 注册图像模型配置与图像生成相关的 Desktop IPC interface。
+ * 保持现有 channel、位置参数和响应信封不变，仅从 main.js 拆出领域实现。
+ *
+ * @param {object} dependencies 图像领域注册依赖。
+ * @param {Electron.IpcMain} dependencies.ipcMain Electron IPC 主进程对象。
+ * @param {object} dependencies.imageModelManager 图像模型配置管理器。
+ * @param {object} dependencies.imageService 图像生成领域服务。
+ * @param {object} dependencies.imageAdapterRegistry 图像 provider 动态模型注册表。
+ * @param {Function} dependencies.safeSerialize 清理 Vue 响应式对象，避免 IPC 序列化失败。
+ * @param {Function} dependencies.createSuccessResponse 统一成功响应信封。
+ * @param {Function} dependencies.createErrorResponse 统一失败响应信封。
+ * @param {Function} dependencies.createStructuredErrorResponse 图像生成失败时的结构化错误信封。
+ */
+function registerImageIpcHandlers({
+  ipcMain,
+  imageModelManager,
+  imageService,
+  imageAdapterRegistry,
+  safeSerialize,
+  createSuccessResponse,
+  createErrorResponse,
+  createStructuredErrorResponse,
+}) {
+  // ===== Image Model handlers (Config-centric) =====
+  ipcMain.handle('image-model-ensureInitialized', async () => {
+    try {
+      await imageModelManager.ensureInitialized();
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('image-model-isInitialized', async () => {
+    try {
+      const result = await imageModelManager.isInitialized();
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('image-model-getAllConfigs', async () => {
+    try {
+      const result = await imageModelManager.getAllConfigs();
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('image-model-getConfig', async (_event, id) => {
+    try {
+      const result = await imageModelManager.getConfig(id);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('image-model-addConfig', async (_event, config) => {
+    try {
+      const safeCfg = safeSerialize(config);
+      await imageModelManager.addConfig(safeCfg);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('image-model-updateConfig', async (_event, id, updates) => {
+    try {
+      const safe = safeSerialize(updates);
+      await imageModelManager.updateConfig(id, safe);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('image-model-deleteConfig', async (_event, id) => {
+    try {
+      await imageModelManager.deleteConfig(id);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('image-model-getEnabledConfigs', async () => {
+    try {
+      const result = await imageModelManager.getEnabledConfigs();
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('image-model-exportData', async () => {
+    try {
+      const result = await imageModelManager.exportData();
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('image-model-importData', async (_event, data) => {
+    try {
+      const safe = safeSerialize(data);
+      await imageModelManager.importData(safe);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('image-model-getDataType', async () => {
+    try {
+      const result = await imageModelManager.getDataType();
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('image-model-validateData', async (_event, data) => {
+    try {
+      const safe = safeSerialize(data);
+      const result = await imageModelManager.validateData(safe);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  // ===== Image Service handlers =====
+  ipcMain.handle('image-generate', async (_event, request) => {
+    try {
+      const safeReq = safeSerialize(request);
+      const res = await imageService.generate(safeReq);
+      return createSuccessResponse(res);
+    } catch (error) {
+      return createStructuredErrorResponse(error);
+    }
+  });
+
+  // 显式模式：避免根据 inputImage 是否存在隐式推断
+  ipcMain.handle('image-generateText2Image', async (_event, request) => {
+    try {
+      const safeReq = safeSerialize(request);
+      const res = await imageService.generateText2Image(safeReq);
+      return createSuccessResponse(res);
+    } catch (error) {
+      return createStructuredErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('image-generateImage2Image', async (_event, request) => {
+    try {
+      const safeReq = safeSerialize(request);
+      const res = await imageService.generateImage2Image(safeReq);
+      return createSuccessResponse(res);
+    } catch (error) {
+      return createStructuredErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('image-generateMultiImage', async (_event, request) => {
+    try {
+      const safeReq = safeSerialize(request);
+      const res = await imageService.generateMultiImage(safeReq);
+      return createSuccessResponse(res);
+    } catch (error) {
+      return createStructuredErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('image-validateRequest', async (_event, request) => {
+    try {
+      const safeReq = safeSerialize(request);
+      const res = await imageService.validateRequest(safeReq);
+      return createSuccessResponse(res);
+    } catch (error) {
+      return createStructuredErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('image-validateText2ImageRequest', async (_event, request) => {
+    try {
+      const safeReq = safeSerialize(request);
+      const res = await imageService.validateText2ImageRequest(safeReq);
+      return createSuccessResponse(res);
+    } catch (error) {
+      return createStructuredErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('image-validateImage2ImageRequest', async (_event, request) => {
+    try {
+      const safeReq = safeSerialize(request);
+      const res = await imageService.validateImage2ImageRequest(safeReq);
+      return createSuccessResponse(res);
+    } catch (error) {
+      return createStructuredErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('image-validateMultiImageRequest', async (_event, request) => {
+    try {
+      const safeReq = safeSerialize(request);
+      const res = await imageService.validateMultiImageRequest(safeReq);
+      return createSuccessResponse(res);
+    } catch (error) {
+      return createStructuredErrorResponse(error);
+    }
+  });
+
+  // 连接测试在主进程执行，避免渲染端直接发起网络请求
+  ipcMain.handle('image-testConnection', async (_event, config) => {
+    try {
+      const safeCfg = safeSerialize(config);
+      // Reuse ImageService.testConnection to keep behavior consistent with Web:
+      // - merges param overrides
+      // - enforces base64-only input for image2image tests
+      const result = await imageService.testConnection(safeCfg);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createStructuredErrorResponse(error);
+    }
+  });
+
+  // 动态模型拉取在主进程执行
+  ipcMain.handle('image-getDynamicModels', async (_event, providerId, connectionConfig) => {
+    try {
+      const safeConn = safeSerialize(connectionConfig);
+      const models = await imageAdapterRegistry.getDynamicModels(providerId, safeConn);
+      return createSuccessResponse(models);
+    } catch (error) {
+      return createStructuredErrorResponse(error);
+    }
+  });
+}
+
+module.exports = {
+  registerImageIpcHandlers,
+};

--- a/packages/desktop/config/ipc/llm-handlers.js
+++ b/packages/desktop/config/ipc/llm-handlers.js
@@ -1,0 +1,122 @@
+const {
+  assertValidStreamId,
+  createIpcError,
+} = require('../ipc-security');
+
+const LLM_STREAM_CHANNELS = Object.freeze({
+  token: 'stream-content',
+  reasoning: 'stream-thinking',
+  finish: 'stream-finish',
+  error: 'stream-error',
+});
+
+const LLM_TOOL_STREAM_CHANNELS = Object.freeze({
+  ...LLM_STREAM_CHANNELS,
+  toolCall: 'stream-tool-call',
+});
+
+/** 校验模型配置标识，阻止空值或异常超长字符串进入 Core。 */
+function assertProvider(provider) {
+  if (typeof provider !== 'string' || provider.trim().length === 0 || provider.length > 256) {
+    throw createIpcError('IPC_INVALID_ARGUMENT', 'Invalid IPC request arguments');
+  }
+}
+
+/** 校验消息集合的最小 IPC 结构，详细领域校验继续由 Core 负责。 */
+function assertMessages(messages) {
+  if (!Array.isArray(messages)) {
+    throw createIpcError('IPC_INVALID_ARGUMENT', 'Invalid IPC request arguments');
+  }
+}
+
+/** 校验工具定义集合的最小 IPC 结构。 */
+function assertTools(tools) {
+  if (!Array.isArray(tools)) {
+    throw createIpcError('IPC_INVALID_ARGUMENT', 'Invalid IPC request arguments');
+  }
+}
+
+/**
+ * 注册 Desktop 后端的 LLM IPC interface，保持现有 channel 与响应语义不变。
+ *
+ * @param {object} dependencies LLM 后端注册依赖。
+ * @param {Function} dependencies.registerSensitiveIpc 统一执行 sender 校验和错误封装的注册函数。
+ * @param {object} dependencies.llmService Core LLM 领域服务。
+ * @param {object} dependencies.streamRegistry 管理流所有权和取消状态的注册表。
+ * @param {Function} dependencies.runOwnedStream 执行 sender 绑定流任务的函数。
+ */
+function registerLlmIpcHandlers({
+  registerSensitiveIpc,
+  llmService,
+  streamRegistry,
+  runOwnedStream,
+}) {
+  registerSensitiveIpc('llm-testConnection', async (_event, provider) => {
+    await llmService.testConnection(provider);
+    return null;
+  }, ([provider]) => assertProvider(provider));
+
+  registerSensitiveIpc('llm-sendMessage', async (_event, messages, provider) => {
+    return llmService.sendMessage(messages, provider);
+  }, ([messages, provider]) => {
+    assertMessages(messages);
+    assertProvider(provider);
+  });
+
+  registerSensitiveIpc('llm-sendMessageStructured', async (_event, messages, provider) => {
+    return llmService.sendMessageStructured(messages, provider);
+  }, ([messages, provider]) => {
+    assertMessages(messages);
+    assertProvider(provider);
+  });
+
+  registerSensitiveIpc('llm-fetchModelList', async (_event, provider, customConfig) => {
+    return llmService.fetchModelList(provider, customConfig);
+  }, ([provider]) => assertProvider(provider));
+
+  registerSensitiveIpc('llm-sendMessageStream', async (event, messages, provider, streamId) => {
+    return runOwnedStream(
+      event,
+      streamId,
+      LLM_STREAM_CHANNELS,
+      (callbacks, signal) => llmService.sendMessageStream(
+        messages,
+        provider,
+        callbacks,
+        { signal },
+      ),
+    );
+  }, ([messages, provider, streamId]) => {
+    assertMessages(messages);
+    assertProvider(provider);
+    assertValidStreamId(streamId);
+  });
+
+  registerSensitiveIpc('llm-sendMessageStreamWithTools', async (event, messages, provider, tools, streamId) => {
+    return runOwnedStream(
+      event,
+      streamId,
+      LLM_TOOL_STREAM_CHANNELS,
+      (callbacks, signal) => llmService.sendMessageStreamWithTools(
+        messages,
+        provider,
+        tools,
+        callbacks,
+        { signal },
+      ),
+    );
+  }, ([messages, provider, tools, streamId]) => {
+    assertMessages(messages);
+    assertProvider(provider);
+    assertTools(tools);
+    assertValidStreamId(streamId);
+  });
+
+  registerSensitiveIpc('stream-cancel', async (event, streamId) => ({
+    cancelled: streamRegistry.cancel(event.sender, streamId),
+  }), ([streamId]) => assertValidStreamId(streamId));
+}
+
+module.exports = {
+  registerLlmIpcHandlers,
+};

--- a/packages/desktop/config/ipc/model-handlers.js
+++ b/packages/desktop/config/ipc/model-handlers.js
@@ -1,0 +1,141 @@
+/**
+ * 注册文本模型管理相关的 Desktop IPC interface。
+ * 保持现有 channel、位置参数和响应信封不变，仅从 main.js 拆出领域实现。
+ *
+ * @param {object} dependencies 模型领域注册依赖。
+ * @param {Electron.IpcMain} dependencies.ipcMain Electron IPC 主进程对象。
+ * @param {object} dependencies.modelManager Core 文本模型管理器。
+ * @param {Function} dependencies.safeSerialize 清理 Vue 响应式对象，避免 IPC 序列化失败。
+ * @param {Function} dependencies.createSuccessResponse 统一成功响应信封。
+ * @param {Function} dependencies.createErrorResponse 统一失败响应信封。
+ */
+function registerModelIpcHandlers({
+  ipcMain,
+  modelManager,
+  safeSerialize,
+  createSuccessResponse,
+  createErrorResponse,
+}) {
+  ipcMain.handle('model-getModels', async () => {
+    try {
+      const result = await modelManager.getAllModels();
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('model-addModel', async (_event, model) => {
+    try {
+      // 清理Vue响应式对象，防止IPC序列化错误
+      const safeModel = safeSerialize(model);
+      // model应该包含key和config，需要分离
+      const { key, ...config } = safeModel;
+      await modelManager.addModel(key, config);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('model-updateModel', async (_event, id, updates) => {
+    try {
+      // 清理Vue响应式对象，防止IPC序列化错误
+      const safeUpdates = safeSerialize(updates);
+      await modelManager.updateModel(id, safeUpdates);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('model-deleteModel', async (_event, id) => {
+    try {
+      await modelManager.deleteModel(id);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('model-ensureInitialized', async () => {
+    try {
+      await modelManager.ensureInitialized();
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('model-isInitialized', async () => {
+    try {
+      const result = await modelManager.isInitialized();
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('model-getAllModels', async () => {
+    try {
+      const result = await modelManager.getAllModels();
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('model-getEnabledModels', async () => {
+    try {
+      const result = await modelManager.getEnabledModels();
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  // Model Import/Export Data handlers (for bulk operations)
+  ipcMain.handle('model-exportData', async () => {
+    try {
+      const result = await modelManager.exportData();
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('model-importData', async (_event, data) => {
+    try {
+      // 清理Vue响应式对象，防止IPC序列化错误
+      const safeData = safeSerialize(data);
+      await modelManager.importData(safeData);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('model-getDataType', async () => {
+    try {
+      const result = modelManager.getDataType();
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('model-validateData', async (_event, data) => {
+    try {
+      // 清理Vue响应式对象，防止IPC序列化错误
+      const safeData = safeSerialize(data);
+      const result = await modelManager.validateData(safeData);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+}
+
+module.exports = {
+  registerModelIpcHandlers,
+};

--- a/packages/desktop/config/ipc/owned-stream-runner.js
+++ b/packages/desktop/config/ipc/owned-stream-runner.js
@@ -1,0 +1,51 @@
+const { createOwnedStreamHandlers } = require('../stream-registry');
+
+/**
+ * 创建绑定 renderer 所有权的流任务执行器，集中处理事件转发、错误通知和注册表清理。
+ *
+ * @param {object} dependencies 运行流任务所需的后端依赖。
+ * @param {ReturnType<import('../stream-registry').createStreamRegistry>} dependencies.streamRegistry
+ *   维护 sender 与 streamId 所有权的注册表。
+ * @returns {Function} 供各领域 IPC module 复用的流任务执行函数。
+ */
+function createOwnedStreamRunner({ streamRegistry }) {
+  if (!streamRegistry || typeof streamRegistry.register !== 'function') {
+    throw new TypeError('Owned stream runner requires a stream registry');
+  }
+
+  /**
+   * 执行单个流任务，并确保结束、异常或取消后都释放该任务的所有权记录。
+   */
+  return async function runOwnedStream(
+    event,
+    streamId,
+    channels,
+    operation,
+    notifyError = false,
+  ) {
+    const stream = streamRegistry.register(event.sender, streamId);
+    const handlers = createOwnedStreamHandlers({
+      registry: streamRegistry,
+      sender: event.sender,
+      streamId,
+      channels,
+    });
+
+    try {
+      // 将同一 AbortSignal 交给领域 service；取消后既停止 IPC 转发，也中止 provider 请求。
+      await operation(handlers, stream.signal);
+      return null;
+    } catch (error) {
+      if (notifyError) {
+        handlers.onError(error);
+      }
+      throw error;
+    } finally {
+      streamRegistry.complete(event.sender, streamId);
+    }
+  };
+}
+
+module.exports = {
+  createOwnedStreamRunner,
+};

--- a/packages/desktop/config/ipc/preference-handlers.js
+++ b/packages/desktop/config/ipc/preference-handlers.js
@@ -1,0 +1,112 @@
+/**
+ * 注册偏好设置相关的 Desktop IPC interface。
+ * 保持现有 channel、位置参数和响应信封不变。
+ *
+ * @param {object} dependencies 偏好设置注册依赖。
+ */
+function registerPreferenceIpcHandlers({
+  ipcMain,
+  preferenceService,
+  safeSerialize,
+  createSuccessResponse,
+  createErrorResponse,
+}) {
+  ipcMain.handle('preference-get', async (_event, key, defaultValue) => {
+    try {
+      const value = await preferenceService.get(key, defaultValue);
+      return createSuccessResponse(value);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('preference-set', async (_event, key, value) => {
+    try {
+      await preferenceService.set(key, value);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('preference-delete', async (_event, key) => {
+    try {
+      await preferenceService.delete(key);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('preference-keys', async () => {
+    try {
+      const result = await preferenceService.keys();
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('preference-clear', async () => {
+    try {
+      await preferenceService.clear();
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('preference-getAll', async () => {
+    try {
+      const result = await preferenceService.getAll();
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  // Preference Import/Export Data handlers (for bulk operations)
+  ipcMain.handle('preference-exportData', async () => {
+    try {
+      const result = await preferenceService.exportData();
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('preference-importData', async (_event, data) => {
+    try {
+      // 清理Vue响应式对象，防止IPC序列化错误
+      const safeData = safeSerialize(data);
+      await preferenceService.importData(safeData);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('preference-getDataType', async () => {
+    try {
+      const result = preferenceService.getDataType();
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('preference-validateData', async (_event, data) => {
+    try {
+      // 清理Vue响应式对象，防止IPC序列化错误
+      const safeData = safeSerialize(data);
+      const result = await preferenceService.validateData(safeData);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+}
+
+module.exports = {
+  registerPreferenceIpcHandlers,
+};

--- a/packages/desktop/config/ipc/prompt-stream-handlers.js
+++ b/packages/desktop/config/ipc/prompt-stream-handlers.js
@@ -1,0 +1,105 @@
+const { assertValidStreamId } = require('../ipc-security');
+
+const PROMPT_STREAM_CHANNELS = Object.freeze({
+  token: 'stream-token',
+  reasoning: 'stream-reasoning-token',
+  toolCall: 'stream-tool-call',
+  finish: 'stream-finish',
+  error: 'stream-error',
+});
+
+/**
+ * 为位置参数式 IPC interface 创建 streamId 校验函数，避免注册处重复索引逻辑。
+ */
+function createStreamIdValidator(index) {
+  /** 校验指定参数位置上的流标识。 */
+  return function validateStreamId(args) {
+    assertValidStreamId(args[index]);
+  };
+}
+
+/**
+ * 注册 Prompt 领域的流式后端 IPC interface，所有事件只回传给发起请求的 renderer。
+ *
+ * @param {object} dependencies Prompt 流式注册依赖。
+ * @param {Function} dependencies.registerSensitiveIpc 统一执行 sender 校验和错误封装的注册函数。
+ * @param {object} dependencies.promptService Core Prompt 领域服务。
+ * @param {Function} dependencies.runOwnedStream 执行 sender 绑定流任务的函数。
+ */
+function registerPromptStreamIpcHandlers({
+  registerSensitiveIpc,
+  promptService,
+  runOwnedStream,
+}) {
+  /** 执行 Prompt 流任务，并将服务异常同步为 stream error 事件。 */
+  function runPromptStream(event, streamId, operation) {
+    return runOwnedStream(event, streamId, PROMPT_STREAM_CHANNELS, operation, true);
+  }
+
+  registerSensitiveIpc('prompt-optimizePromptStream', async (event, request, streamId) => {
+    return runPromptStream(event, streamId, (streamHandlers, signal) => (
+      promptService.optimizePromptStream(request, streamHandlers, { signal })
+    ));
+  }, createStreamIdValidator(1));
+
+  registerSensitiveIpc('prompt-optimizeMessageStream', async (event, request, streamId) => {
+    return runPromptStream(event, streamId, (streamHandlers, signal) => (
+      promptService.optimizeMessageStream(request, streamHandlers, { signal })
+    ));
+  }, createStreamIdValidator(1));
+
+  registerSensitiveIpc('prompt-iteratePromptStream', async (
+    event,
+    originalPrompt,
+    lastOptimizedPrompt,
+    iterateInput,
+    modelKey,
+    templateId,
+    streamId,
+    contextData,
+  ) => {
+    return runPromptStream(event, streamId, (streamHandlers, signal) => (
+      promptService.iteratePromptStream(
+        originalPrompt,
+        lastOptimizedPrompt,
+        iterateInput,
+        modelKey,
+        streamHandlers,
+        templateId,
+        contextData,
+        { signal },
+      )
+    ));
+  }, createStreamIdValidator(5));
+
+  // IPC order: system, user, model, streamId, inputImages (preserves #196 contract)
+  registerSensitiveIpc('prompt-testPromptStream', async (
+    event,
+    systemPrompt,
+    userPrompt,
+    modelKey,
+    streamId,
+    inputImages,
+  ) => {
+    return runPromptStream(event, streamId, (streamHandlers, signal) => (
+      promptService.testPromptStream(
+        systemPrompt,
+        userPrompt,
+        modelKey,
+        streamHandlers,
+        inputImages,
+        { signal },
+      )
+    ));
+  }, createStreamIdValidator(3));
+
+  registerSensitiveIpc('prompt-testCustomConversationStream', async (event, request, streamId) => {
+    return runPromptStream(event, streamId, (streamHandlers, signal) => (
+      promptService.testCustomConversationStream(request, streamHandlers, { signal })
+    ));
+  }, createStreamIdValidator(1));
+}
+
+module.exports = {
+  registerPromptStreamIpcHandlers,
+};

--- a/packages/desktop/config/ipc/prompt-sync-handlers.js
+++ b/packages/desktop/config/ipc/prompt-sync-handlers.js
@@ -1,0 +1,87 @@
+/**
+ * 注册 Prompt 同步（非流式）IPC interface。
+ * 流式 Prompt 通道仍由 prompt-stream-handlers 负责；本模块只覆盖位置参数同步调用。
+ *
+ * @param {object} dependencies Prompt 同步注册依赖。
+ */
+function registerPromptSyncIpcHandlers({
+  ipcMain,
+  promptService,
+  historyManager,
+  createSuccessResponse,
+  createErrorResponse,
+}) {
+  ipcMain.handle('prompt-optimizePrompt', async (_event, request) => {
+    try {
+      const result = await promptService.optimizePrompt(request);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('prompt-optimizeMessage', async (_event, request) => {
+    try {
+      const result = await promptService.optimizeMessage(request);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('prompt-iteratePrompt', async (
+    _event,
+    originalPrompt,
+    lastOptimizedPrompt,
+    iterateInput,
+    modelKey,
+    templateId,
+    contextData,
+  ) => {
+    try {
+      const result = await promptService.iteratePrompt(
+        originalPrompt,
+        lastOptimizedPrompt,
+        iterateInput,
+        modelKey,
+        templateId,
+        contextData,
+      );
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('prompt-testPrompt', async (_event, systemPrompt, userPrompt, modelKey, inputImages) => {
+    try {
+      const result = await promptService.testPrompt(systemPrompt, userPrompt, modelKey, inputImages);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  // 历史兼容：部分 renderer 仍通过 prompt 前缀读取历史数据。
+  ipcMain.handle('prompt-getHistory', async () => {
+    try {
+      const result = await historyManager.getHistory();
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('prompt-getIterationChain', async (_event, recordId) => {
+    try {
+      const result = await historyManager.getIterationChain(recordId);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+}
+
+module.exports = {
+  registerPromptSyncIpcHandlers,
+};

--- a/packages/desktop/config/ipc/system-handlers.js
+++ b/packages/desktop/config/ipc/system-handlers.js
@@ -1,0 +1,88 @@
+const path = require('path');
+
+/**
+ * 注册应用信息、运行时配置、外链和日志相关 IPC。
+ * 这些 handler 横切多个领域，但接口边界清晰，适合从 composition root 拆出。
+ *
+ * @param {object} dependencies 系统级 IPC 注册依赖。
+ */
+function registerSystemIpcHandlers({
+  ipcMain,
+  shell,
+  consoleLogger,
+  registerSensitiveIpc,
+  getPublicRuntimeConfig,
+  isSafeExternalUrl,
+  createIpcError,
+  createSuccessResponse,
+  createErrorResponse,
+  setUiLocale,
+  normalizeUiLocale,
+  packageJsonPath = path.join(__dirname, '../../package.json'),
+}) {
+  // 环境配置同步 - 主进程作为唯一配置源
+  registerSensitiveIpc('config-getEnvironmentVariables', async () => {
+    const publicEnv = getPublicRuntimeConfig(process.env);
+    console.log('[Main Process] Public runtime configuration requested by UI process');
+    console.log(`[Main Process] Returning ${Object.keys(publicEnv).length / 2} public VITE_* variables (with no-prefix duplicates)`);
+    return publicEnv;
+  });
+
+  // 外部链接处理器
+  registerSensitiveIpc('shell-openExternal', async (_event, url) => {
+    await shell.openExternal(url);
+    return true;
+  }, ([url]) => {
+    if (typeof url !== 'string' || !isSafeExternalUrl(url)) {
+      throw createIpcError('IPC_INVALID_ARGUMENT', 'Invalid IPC request arguments');
+    }
+  });
+
+  // 应用信息处理器
+  ipcMain.handle('app-get-version', () => {
+    try {
+      // package.json 由 Desktop 包自身提供，路径相对本 module 固定
+      // eslint-disable-next-line import/no-dynamic-require, global-require
+      const packageJson = require(packageJsonPath);
+      return createSuccessResponse(packageJson.version);
+    } catch (error) {
+      console.error('[Main Process] Failed to get app version:', error);
+      return createErrorResponse(error);
+    }
+  });
+
+  // UI locale sync (renderer -> main)
+  // Used to localize Electron-only UI like context menus.
+  ipcMain.handle('app-set-locale', (_event, locale) => {
+    try {
+      setUiLocale(normalizeUiLocale(locale) || 'en-US');
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  // 日志相关处理器
+  ipcMain.handle('logs-get-paths', () => {
+    try {
+      const paths = consoleLogger.getLogPaths();
+      return createSuccessResponse(paths);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('logs-open-directory', async () => {
+    try {
+      const { logDir } = consoleLogger.getLogPaths();
+      await shell.openPath(logDir);
+      return createSuccessResponse(true);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+}
+
+module.exports = {
+  registerSystemIpcHandlers,
+};

--- a/packages/desktop/config/ipc/template-handlers.js
+++ b/packages/desktop/config/ipc/template-handlers.js
@@ -1,0 +1,180 @@
+/**
+ * 注册模板管理相关的 Desktop IPC interface。
+ * 保持现有 channel、位置参数和响应信封不变，仅从 main.js 拆出领域实现。
+ *
+ * @param {object} dependencies 模板领域注册依赖。
+ * @param {Electron.IpcMain} dependencies.ipcMain Electron IPC 主进程对象。
+ * @param {object} dependencies.templateManager Core 模板管理器。
+ * @param {Function} dependencies.safeSerialize 清理 Vue 响应式对象，避免 IPC 序列化失败。
+ * @param {Function} dependencies.createSuccessResponse 统一成功响应信封。
+ * @param {Function} dependencies.createErrorResponse 统一失败响应信封。
+ */
+function registerTemplateIpcHandlers({
+  ipcMain,
+  templateManager,
+  safeSerialize,
+  createSuccessResponse,
+  createErrorResponse,
+}) {
+  ipcMain.handle('template-getTemplates', async () => {
+    try {
+      const result = await templateManager.listTemplates();
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('template-getTemplate', async (_event, id) => {
+    try {
+      const result = await templateManager.getTemplate(id);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('template-createTemplate', async (_event, template) => {
+    try {
+      // 清理Vue响应式对象，防止IPC序列化错误
+      const safeTemplate = safeSerialize(template);
+      await templateManager.saveTemplate(safeTemplate);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('template-updateTemplate', async (_event, id, updates) => {
+    try {
+      // Get existing template and merge with updates
+      const existingTemplate = await templateManager.getTemplate(id);
+      // 清理Vue响应式对象，防止IPC序列化错误
+      const safeUpdates = safeSerialize(updates);
+      const updatedTemplate = { ...existingTemplate, ...safeUpdates, id };
+      await templateManager.saveTemplate(updatedTemplate);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('template-deleteTemplate', async (_event, id) => {
+    try {
+      await templateManager.deleteTemplate(id);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('template-listTemplatesByType', async (_event, type) => {
+    try {
+      const result = await templateManager.listTemplatesByType(type);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  // Template Import/Export handlers
+  ipcMain.handle('template-exportTemplate', async (_event, id) => {
+    try {
+      const result = await templateManager.exportTemplate(id);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('template-importTemplate', async (_event, jsonString) => {
+    try {
+      await templateManager.importTemplate(jsonString);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  // Template Import/Export Data handlers (for bulk operations)
+  ipcMain.handle('template-exportData', async () => {
+    try {
+      const result = await templateManager.exportData();
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('template-importData', async (_event, data) => {
+    try {
+      // 清理Vue响应式对象，防止IPC序列化错误
+      const safeData = safeSerialize(data);
+      await templateManager.importData(safeData);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('template-getDataType', async () => {
+    try {
+      const result = templateManager.getDataType();
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('template-validateData', async (_event, data) => {
+    try {
+      // 清理Vue响应式对象，防止IPC序列化错误
+      const safeData = safeSerialize(data);
+      const result = templateManager.validateData(safeData);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  // Template language handlers
+  ipcMain.handle('template-changeBuiltinTemplateLanguage', async (_event, language) => {
+    try {
+      await templateManager.changeBuiltinTemplateLanguage(language);
+      return createSuccessResponse(null);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('template-getCurrentBuiltinTemplateLanguage', async () => {
+    try {
+      const result = await templateManager.getCurrentBuiltinTemplateLanguage();
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('template-getSupportedBuiltinTemplateLanguages', async () => {
+    try {
+      const result = await templateManager.getSupportedBuiltinTemplateLanguages();
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
+  ipcMain.handle('template-getSupportedLanguages', async (_event, template) => {
+    try {
+      const result = templateManager.getSupportedLanguages(template);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+}
+
+module.exports = {
+  registerTemplateIpcHandlers,
+};

--- a/packages/desktop/config/ipc/update-handlers.js
+++ b/packages/desktop/config/ipc/update-handlers.js
@@ -1,0 +1,907 @@
+/**
+ * 自动更新 IPC（对齐 upstream develop manual-release 策略）
+ * ctx 注入 ctx.preferenceService / ctx.mainWindow / ctx.isUpdaterQuitting
+ */
+const {
+  createManualUpdateRequiredError,
+  getUpdateDeliveryPolicy,
+  isManualReleaseDelivery,
+} = require('../update-delivery-policy');
+
+function createUpdateHandlers(ctx) {
+  const {
+    ipcMain,
+    autoUpdater,
+    app,
+    path,
+    createSuccessResponse,
+    createErrorResponse,
+    createDetailedErrorResponse,
+    DEFAULT_CONFIG,
+    IPC_EVENTS,
+    PREFERENCE_KEYS,
+    validateVersion,
+    buildReleaseUrl,
+    getRepositoryInfo,
+  } = ctx;
+
+  const getIgnoredVersions = async () => {
+    try {
+      const ignoredVersions = await ctx.preferenceService.get(PREFERENCE_KEYS.IGNORED_VERSIONS, null);
+      if (ignoredVersions && typeof ignoredVersions === 'object') {
+        return ignoredVersions;
+      }
+      return { stable: null, prerelease: null };
+    } catch (error) {
+      console.warn('[Updater] Failed to read ignored versions, using defaults:', error);
+      return { stable: null, prerelease: null };
+    }
+  };
+
+  const isVersionIgnored = async (version) => {
+    const ignoredVersions = await getIgnoredVersions();
+    const versionType = version.includes('-') ? 'prerelease' : 'stable';
+
+    // 检查对应类型的忽略版本
+    if (versionType === 'stable' && ignoredVersions.stable === version) {
+      return true;
+    }
+    if (versionType === 'prerelease' && ignoredVersions.prerelease === version) {
+      return true;
+    }
+
+    return false;
+  };
+
+  // 自动更新处理器设置
+  async function setupUpdateHandlers() {
+    console.log('[Main Process] Setting up auto-update handlers...');
+
+
+
+    // 更新操作状态锁，防止并发调用
+    let isCheckingForUpdate = false;
+    let isDownloadingUpdate = false;
+    let isInstallingUpdate = false;
+
+    // 配置更新器基本设置
+    autoUpdater.autoDownload = DEFAULT_CONFIG.autoDownload;
+    autoUpdater.allowPrerelease = DEFAULT_CONFIG.allowPrerelease;
+    autoUpdater.allowDowngrade = false; // 默认不允许降级，只在渠道切换时临时启用
+
+    // Resolve the repository once so the feed, delivery policy, and Release URLs
+    // cannot diverge when development repository overrides are enabled.
+    const {
+      packagedRepositoryInfo,
+      repositoryInfo: resolvedRepositoryInfo,
+      packagedRepositorySlug: defaultRepo,
+      repositorySlug: currentRepo,
+      shouldOverrideFeed,
+    } = resolveUpdateRepositoryConfig();
+    let repositoryInfo = resolvedRepositoryInfo;
+
+    // 如果环境变量中的仓库与默认仓库不同，使用setFeedURL动态配置
+    if (shouldOverrideFeed) {
+      try {
+        const { owner, repo } = repositoryInfo;
+
+        const feedConfig = {
+          provider: 'github',
+          owner,
+          repo,
+          private: false // 只支持公开仓库
+        };
+
+        console.log('[Updater] Using custom repository configuration:', {
+          owner,
+          repo,
+          private: false,
+          source: 'environment variables'
+        });
+
+        autoUpdater.setFeedURL(feedConfig);
+      } catch (configError) {
+        console.error('[Updater] Failed to configure custom repository:', configError);
+        console.log('[Updater] Falling back to default configuration');
+        repositoryInfo = packagedRepositoryInfo;
+      }
+    } else {
+      console.log('[Updater] Using default repository configuration:', defaultRepo || 'unknown');
+    }
+
+    // Main-process source of truth for how this effective repository can deliver updates.
+    // macOS remains check-only until release artifacts are Developer ID signed.
+    const updateDelivery = getUpdateDeliveryPolicy({ repositoryInfo });
+
+    // 开发模式下的更新检查配置
+    if (process.env.NODE_ENV === 'development' || !app.isPackaged) {
+      console.log('[Updater] Development mode detected');
+    
+      // 设置开发环境专用的日志器（官方推荐）
+      const log = require('electron-log');
+      autoUpdater.logger = log;
+      autoUpdater.logger.transports.file.level = 'debug';
+      autoUpdater.logger.transports.console.level = 'debug';
+    
+      // 为更新器创建专门的日志文件
+      const userDataPath = app.getPath('userData');
+      autoUpdater.logger.transports.file.resolvePathFn = () => 
+        path.join(userDataPath, 'logs', 'auto-updater.log');
+    
+      // 强制启用开发模式更新检查
+      autoUpdater.forceDevUpdateConfig = true;
+    
+      console.log('[Updater] Development mode configuration:');
+      console.log('[Updater] - forceDevUpdateConfig: true');
+      console.log('[Updater] - Looking for dev-app-update.yml in:', path.join(__dirname, '..', '..', 'dev-app-update.yml'));
+      console.log('[Updater] - dev-app-update.yml exists:', require('fs').existsSync(path.join(__dirname, '..', '..', 'dev-app-update.yml')));
+    
+      console.log('[Updater] Development mode update testing enabled');
+      console.log('[Updater] Auto-updater logs will be saved to:', path.join(userDataPath, 'logs', 'auto-updater.log'));
+    }
+
+    // 设置更新事件处理 - 仅在应用启动时设置一次
+    autoUpdater.on('update-available', async (info) => {
+      console.log('[Updater] Update available:', info);
+
+      try {
+        // 验证版本号格式
+        if (!validateVersion(info.version)) {
+          console.error('[Updater] Invalid version format:', info.version);
+          return;
+        }
+
+        // 检查版本是否被忽略
+        try {
+          const isIgnored = await isVersionIgnored(info.version);
+          if (isIgnored) {
+            console.log('[Updater] Ignoring version:', info.version);
+            return;
+          }
+        } catch (prefError) {
+          console.warn('[Updater] Failed to check ignored versions, continuing with update check:', prefError);
+          // 继续执行，不阻断更新流程
+        }
+
+        // 构建安全的GitHub Release页面链接
+        let releaseUrl;
+        try {
+          releaseUrl = buildReleaseUrl(info.version, repositoryInfo);
+        } catch (urlError) {
+          console.error('[Updater] Failed to build release URL:', urlError);
+          // 使用fallback URL或跳过URL
+          releaseUrl = null;
+        }
+
+        // 发送更新可用通知到UI
+        if (ctx.mainWindow && !ctx.mainWindow.isDestroyed()) {
+          ctx.mainWindow.webContents.send(IPC_EVENTS.UPDATE_AVAILABLE_INFO, {
+            version: info.version,
+            releaseDate: info.releaseDate,
+            releaseNotes: info.releaseNotes,
+            releaseUrl: releaseUrl
+          });
+        }
+      } catch (error) {
+        console.error('[Updater] Critical error in update-available handler:', error);
+        // 即使出错也要通知用户有更新可用，但不包含详细信息
+        if (ctx.mainWindow && !ctx.mainWindow.isDestroyed()) {
+          ctx.mainWindow.webContents.send(IPC_EVENTS.UPDATE_AVAILABLE_INFO, {
+            version: info.version || 'Unknown',
+            releaseDate: info.releaseDate || null,
+            releaseNotes: null,
+            releaseUrl: null,
+            error: 'Failed to process update information'
+          });
+        }
+      }
+    });
+
+    autoUpdater.on('update-not-available', (info) => {
+      console.log('[Updater] No update available:', info);
+      // 注意：现在这个事件监听器主要用于日志记录
+      // 实际的UI更新逻辑已经移到前端的请求-响应模式中
+      // 这样避免了竞争条件和全局状态的问题
+    });
+
+    autoUpdater.on('error', (error) => {
+      console.error('[Updater] Update error:', error);
+
+      // 如果是 403 错误，提供基本的调试信息
+      if (error.code === 'HTTP_ERROR_403' || (error.message && error.message.includes('403'))) {
+        console.log('[Updater Debug] ===== 403 ERROR DEBUGGING =====');
+        console.log('[Updater Debug] This is a 403 Forbidden error, likely repository access issue');
+
+        console.log('[Updater Debug] Common 403 causes:');
+        console.log('[Updater Debug] 1. Repository is private (not supported)');
+        console.log('[Updater Debug] 2. Repository does not exist');
+        console.log('[Updater Debug] 3. Network/firewall blocking GitHub API');
+        console.log('[Updater Debug] 4. GitHub API rate limiting');
+
+        console.log('[Updater Debug] Error details:', {
+          code: error.code,
+          message: error.message,
+          stack: error.stack
+        });
+        console.log('[Updater Debug] =====================================');
+      }
+
+      // Operation handlers and download callbacks own their respective locks.
+      // A global updater error must not unlock an unrelated in-flight operation.
+
+      // 创建详细的错误信息
+      const detailedErrorResponse = createDetailedErrorResponse(error);
+
+      // 发送详细错误事件到UI
+      if (ctx.mainWindow && !ctx.mainWindow.isDestroyed()) {
+        ctx.mainWindow.webContents.send(IPC_EVENTS.UPDATE_ERROR, {
+          message: detailedErrorResponse.error,
+          code: error.code || 'UNKNOWN_ERROR',
+          timestamp: new Date().toISOString()
+        });
+      }
+    });
+
+    autoUpdater.on('download-progress', (progress) => {
+      console.log('[Updater] Download progress:', progress);
+      if (ctx.mainWindow && !ctx.mainWindow.isDestroyed()) {
+        ctx.mainWindow.webContents.send(IPC_EVENTS.UPDATE_DOWNLOAD_PROGRESS, progress);
+      }
+    });
+
+    autoUpdater.on('update-downloaded', (info) => {
+      console.log('[Updater] Update downloaded:', info);
+      console.log('[Updater] ===== UPDATE READY FOR INSTALLATION =====');
+      console.log('[Updater] Downloaded version:', info.version);
+      console.log('[Updater] Release date:', info.releaseDate);
+      console.log('[Updater] Next step: User needs to click "Install and Restart" to complete the update');
+      console.log('[Updater] The application will automatically restart after installation');
+      console.log('[Updater] =============================================');
+    
+      // 下载完成，重置下载状态
+      isDownloadingUpdate = false;
+    
+      if (ctx.mainWindow && !ctx.mainWindow.isDestroyed()) {
+        // 发送更详细的信息给前端，包含安装提示
+        ctx.mainWindow.webContents.send(IPC_EVENTS.UPDATE_DOWNLOADED, {
+          ...info,
+          message: 'Update downloaded successfully. Click "Install and Restart" to complete the installation.',
+          needsRestart: true,
+          canInstallNow: true,
+          installAction: 'Click the install button to restart and apply the update'
+        });
+      }
+    });
+
+    // 检查更新 - 直接返回完整结果，避免全局状态
+    ipcMain.handle(IPC_EVENTS.UPDATE_CHECK, async () => {
+      // 检查是否已有更新检查在进行中
+      if (isCheckingForUpdate) {
+        console.log('[Updater] Update check already in progress, ignoring request');
+        return createSuccessResponse({
+          message: 'Update check already in progress',
+          inProgress: true
+        });
+      }
+
+      // 设置检查状态锁
+      isCheckingForUpdate = true;
+
+      try {
+        // 读取用户偏好设置，使用错误边界处理和明确的备用方案
+        let allowPrerelease = DEFAULT_CONFIG.allowPrerelease;
+        try {
+          allowPrerelease = await ctx.preferenceService.get(PREFERENCE_KEYS.ALLOW_PRERELEASE, DEFAULT_CONFIG.allowPrerelease);
+          console.log('[Updater] Successfully read prerelease preference:', allowPrerelease);
+        } catch (prefError) {
+          console.warn('[Updater] PreferenceService unavailable, using safe default (stable releases only):', prefError);
+          allowPrerelease = false; // 明确的安全默认值
+
+          // 可选：通知用户偏好设置不可用
+          if (ctx.mainWindow && !ctx.mainWindow.isDestroyed()) {
+            ctx.mainWindow.webContents.send('preference-service-warning', {
+              message: 'Settings temporarily unavailable, using default configuration',
+              timestamp: new Date().toISOString()
+            });
+          }
+        }
+
+        console.log('[Updater] Checking for updates with settings:', { allowPrerelease });
+
+        // 配置更新器
+        autoUpdater.allowPrerelease = allowPrerelease;
+
+        // 执行更新检查
+        console.log('[Updater] Starting update check...');
+      
+        // 在实际调用 checkForUpdates 前检查配置
+        console.log('[Updater Debug] ===== PRE-CHECK CONFIGURATION =====');
+        console.log('[Updater Debug] autoUpdater.allowPrerelease:', autoUpdater.allowPrerelease);
+        console.log('[Updater Debug] autoUpdater.autoDownload:', autoUpdater.autoDownload);
+        console.log('[Updater Debug] ===============================================');
+      
+        const result = await autoUpdater.checkForUpdates();
+
+        console.log('[DEBUG] ===== BACKEND UPDATE CHECK RESULT =====');
+        console.log('[DEBUG] autoUpdater.checkForUpdates() returned:', result);
+        console.log('[DEBUG] Result type:', typeof result);
+        console.log('[DEBUG] Result is null:', result === null);
+        console.log('[DEBUG] Result is undefined:', result === undefined);
+        if (result) {
+          console.log('[DEBUG] Result.updateInfo:', result.updateInfo);
+          console.log('[DEBUG] Result.updateInfo type:', typeof result.updateInfo);
+        }
+        console.log('[DEBUG] ==========================================');
+
+        // 构建完整的响应数据，包含所有必要信息
+        const currentVersion = require('../../package.json').version;
+        let responseData = {
+          checkResult: result,
+          currentVersion: currentVersion,
+          hasUpdate: false,
+          remoteVersion: null,
+          remoteReleaseUrl: null,
+          message: 'Update check completed'
+        };
+
+        if (result && result.updateInfo) {
+          const updateInfo = result.updateInfo;
+          responseData.remoteVersion = updateInfo.version;
+          responseData.hasUpdate = updateInfo.version !== currentVersion;
+
+          // 构建发布页面URL
+          try {
+            responseData.remoteReleaseUrl = buildReleaseUrl(updateInfo.version, repositoryInfo);
+          } catch (urlError) {
+            console.warn('[Updater] Failed to build release URL:', urlError);
+          }
+
+          if (responseData.hasUpdate) {
+            responseData.message = `New version ${updateInfo.version} is available`;
+          } else {
+            responseData.message = `You are already using the latest version (${updateInfo.version})`;
+          }
+
+          console.log('[Updater] Successfully retrieved update info:', {
+            remoteVersion: updateInfo.version,
+            hasUpdate: responseData.hasUpdate,
+            releaseUrl: responseData.remoteReleaseUrl
+          });
+        } else {
+          // 没有获取到远程版本信息，这可能是配置或网络问题
+          console.log('[Updater] No update info received - checking possible causes...');
+
+          // 生产环境或配置了开发环境但仍然没有获取到信息
+          console.warn('[Updater] No update info received - this may indicate a configuration or network issue');
+          console.warn('[Updater] Possible causes:');
+          console.warn('  - app-update.yml missing or misconfigured');
+          console.warn('  - Network connectivity issues');
+          console.warn('  - GitHub repository access issues');
+          console.warn('  - Invalid repository configuration');
+
+          responseData.message = 'Unable to check for updates - configuration or network issue';
+          responseData.checkResult = null;
+        }
+
+        return createSuccessResponse(responseData);
+      } catch (error) {
+        console.error('[Updater] Check update failed:', error);
+        const detailedResponse = createDetailedErrorResponse(error);
+        console.error('[DEBUG] Detailed error response being sent:', detailedResponse);
+        return detailedResponse;
+      } finally {
+        // 无论成功还是失败，都要释放锁
+        isCheckingForUpdate = false;
+        console.log('[Updater] Update check completed, lock released');
+      }
+    });
+
+    // 统一检查所有版本（解决并发冲突问题）
+    ipcMain.handle(IPC_EVENTS.UPDATE_CHECK_ALL_VERSIONS, async () => {
+      console.log('[Updater] Starting unified version check for all versions');
+      const currentVersion = require('../../package.json').version;
+    
+      // 检查是否已有更新检查在进行中
+      if (isCheckingForUpdate) {
+        console.log('[Updater] Update check already in progress, ignoring request');
+        return createSuccessResponse({
+          currentVersion,
+          updateDelivery,
+          stable: null,
+          prerelease: null,
+          message: 'Update check already in progress',
+          inProgress: true
+        });
+      }
+
+      // 设置检查状态锁
+      isCheckingForUpdate = true;
+
+      try {
+        const results = {
+          currentVersion,
+          updateDelivery,
+          stable: null,
+          prerelease: null
+        };
+
+        // 辅助函数：处理单个版本检查结果
+        const processResult = (result, versionType) => {
+          if (!result || !result.updateInfo) {
+            console.log(`[Updater] No ${versionType} update available`);
+            return {
+              hasUpdate: false,
+              remoteVersion: null,
+              remoteReleaseUrl: null,
+              message: `No ${versionType} update available`,
+              versionType,
+              noVersionFound: true
+            };
+          }
+
+          const updateInfo = result.updateInfo;
+          const remoteVersion = updateInfo.version;
+
+          // 预览版检查时，过滤掉正式版
+          if (versionType === 'prerelease') {
+            const isPrerelease = remoteVersion.includes('-');
+            if (!isPrerelease) {
+              return {
+                hasUpdate: false,
+                remoteVersion: null,
+                remoteReleaseUrl: null,
+                message: 'No newer prerelease available (latest release is stable)',
+                versionType,
+                noVersionFound: true,
+                latestStableVersion: remoteVersion
+              };
+            }
+          }
+
+          // 简单但有效的版本比较：让前端处理复杂的语义化版本比较
+          // 这里只需要确保返回远程版本信息，前端会进行准确的版本比较
+          const hasUpdate = remoteVersion !== currentVersion;
+
+          console.log(`[Updater] Version check for ${versionType}:`, {
+            currentVersion,
+            remoteVersion,
+            hasUpdate: hasUpdate ? 'possible (will be verified by frontend)' : 'no'
+          });
+          let remoteReleaseUrl = null;
+
+          // 构建发布页面URL
+          try {
+            remoteReleaseUrl = buildReleaseUrl(updateInfo.version, repositoryInfo);
+          } catch (urlError) {
+            console.warn(`[Updater] Failed to build ${versionType} release URL:`, urlError);
+          }
+
+          console.log(`[Updater] ${versionType} version check result:`, {
+            remoteVersion,
+            hasUpdate,
+            releaseUrl: remoteReleaseUrl
+          });
+
+          return {
+            hasUpdate,
+            remoteVersion,
+            remoteReleaseUrl,
+            message: hasUpdate ?
+              `New ${versionType} version ${remoteVersion} is available` :
+              `You are already using the latest ${versionType} version`,
+            versionType,
+            releaseDate: updateInfo.releaseDate,
+            releaseNotes: updateInfo.releaseNotes
+          };
+        };
+
+        // 1. 检查正式版
+        console.log('[Updater] Checking stable version...');
+        autoUpdater.allowPrerelease = false;
+      
+        try {
+          const stableResult = await autoUpdater.checkForUpdates();
+          results.stable = processResult(stableResult, 'stable');
+        } catch (error) {
+          console.error('[Updater] Stable version check failed:', error);
+          results.stable = {
+            hasUpdate: false,
+            remoteVersion: null,
+            remoteReleaseUrl: null,
+            message: `Stable version check failed: ${error.message}`,
+            versionType: 'stable',
+            error: error.message
+          };
+        }
+
+        // 2. 延迟后检查预览版（避免状态冲突）
+        console.log('[Updater] Waiting before checking prerelease version...');
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        console.log('[Updater] Checking prerelease version...');
+        autoUpdater.allowPrerelease = true;
+      
+        try {
+          const prereleaseResult = await autoUpdater.checkForUpdates();
+          results.prerelease = processResult(prereleaseResult, 'prerelease');
+        } catch (error) {
+          console.error('[Updater] Prerelease version check failed:', error);
+          results.prerelease = {
+            hasUpdate: false,
+            remoteVersion: null,
+            remoteReleaseUrl: null,
+            message: `Prerelease version check failed: ${error.message}`,
+            versionType: 'prerelease',
+            error: error.message
+          };
+        }
+
+        // 3. 恢复用户偏好设置
+        try {
+          const userPreference = await ctx.preferenceService.get(PREFERENCE_KEYS.ALLOW_PRERELEASE, DEFAULT_CONFIG.allowPrerelease);
+          autoUpdater.allowPrerelease = userPreference;
+          autoUpdater.allowDowngrade = false; // 总是恢复为 false
+          console.log('[Updater] Restored user preference:', { allowPrerelease: userPreference, allowDowngrade: false });
+        } catch (prefError) {
+          console.warn('[Updater] Failed to restore user preference, using default:', prefError);
+          autoUpdater.allowPrerelease = DEFAULT_CONFIG.allowPrerelease;
+          autoUpdater.allowDowngrade = false; // 确保在错误情况下也恢复
+        }
+
+        console.log('[Updater] Unified version check completed:', {
+          stable: results.stable?.hasUpdate ? results.stable.remoteVersion : 'no update',
+          prerelease: results.prerelease?.hasUpdate ? results.prerelease.remoteVersion : 'no update'
+        });
+
+        return createSuccessResponse(results);
+      } catch (error) {
+        console.error('[Updater] Unified version check failed:', error);
+        return createDetailedErrorResponse(error);
+      } finally {
+        // 无论成功还是失败，都要释放锁
+        isCheckingForUpdate = false;
+        console.log('[Updater] Unified version check completed, lock released');
+      }
+    });
+
+    // Open only a main-process constructed URL for an updater release page.
+    ipcMain.handle(IPC_EVENTS.UPDATE_OPEN_RELEASE_PAGE, async (event, version) => {
+      try {
+        const releaseUrl = version
+          ? buildReleaseUrl(version, repositoryInfo)
+          : updateDelivery.fallbackReleaseUrl;
+
+        if (!releaseUrl) {
+          const error = new Error('Release page URL is unavailable');
+          error.code = 'UPDATER_RELEASE_URL_UNAVAILABLE';
+          throw error;
+        }
+
+        await shell.openExternal(releaseUrl);
+        return createSuccessResponse({ url: releaseUrl });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    });
+
+    // 开始下载更新
+    ipcMain.handle(IPC_EVENTS.UPDATE_START_DOWNLOAD, async () => {
+      if (isManualReleaseDelivery(updateDelivery)) {
+        return createErrorResponse(
+          createManualUpdateRequiredError('start-download', updateDelivery)
+        );
+      }
+
+      // 检查是否已有下载在进行中
+      if (isDownloadingUpdate) {
+        console.log('[Updater] Download already in progress, ignoring request');
+        return createSuccessResponse({
+          message: 'Download already in progress',
+          inProgress: true
+        });
+      }
+
+      // 设置下载状态锁
+      isDownloadingUpdate = true;
+
+      try {
+        console.log('[Updater] Starting update download...');
+        await autoUpdater.downloadUpdate();
+        return createSuccessResponse(null);
+      } catch (error) {
+        console.error('[Updater] Download failed:', error);
+        isDownloadingUpdate = false; // 失败时重置状态
+        return createDetailedErrorResponse(error);
+      }
+    });
+
+    // 安装更新
+    ipcMain.handle(IPC_EVENTS.UPDATE_INSTALL, async () => {
+      if (isManualReleaseDelivery(updateDelivery)) {
+        return createErrorResponse(
+          createManualUpdateRequiredError('install', updateDelivery)
+        );
+      }
+
+      // 检查是否已有安装在进行中
+      if (isInstallingUpdate) {
+        console.log('[Updater] Install already in progress, ignoring request');
+        return createSuccessResponse({
+          message: 'Install already in progress',
+          inProgress: true
+        });
+      }
+
+      // 设置安装状态锁
+      isInstallingUpdate = true;
+
+      try {
+        console.log('[Updater] ===== STARTING UPDATE INSTALLATION =====');
+        console.log('[Updater] User clicked "Install and Restart"');
+        console.log('[Updater] The application will now close and restart with the new version');
+        console.log('[Updater] If the application does not restart automatically, please launch it manually');
+        console.log('[Updater] ==========================================');
+      
+        // 设置更新安装退出标志，跳过数据保存逻辑
+        ctx.isUpdaterQuitting = true;
+        console.log('[Updater] Set updater quit flag to skip data save');
+      
+        // 注意：quitAndInstall会立即退出应用，所以不会执行到finally
+        // 这个方法会：
+        // 1. 关闭当前应用
+        // 2. 安装新版本
+        // 3. 启动新版本的应用
+        autoUpdater.quitAndInstall();
+      
+        // 这行代码通常不会执行到，因为 quitAndInstall() 会立即退出应用
+        return createSuccessResponse({
+          message: 'Installation started, application will restart'
+        });
+      } catch (error) {
+        console.error('[Updater] Install failed:', error);
+        console.error('[Updater] ===== INSTALLATION ERROR =====');
+        console.error('[Updater] Error details:', error.message);
+        console.error('[Updater] This may indicate:');
+        console.error('[Updater] 1. Update file was corrupted during download');
+        console.error('[Updater] 2. Insufficient permissions to install');
+        console.error('[Updater] 3. Antivirus software blocked the installation');
+        console.error('[Updater] 4. The update file was not properly downloaded');
+        console.error('[Updater] Please try downloading the update again');
+        console.error('[Updater] ===============================');
+      
+        return createDetailedErrorResponse(error);
+      } finally {
+        // 确保锁总是被释放（虽然quitAndInstall成功时不会执行到这里）
+        isInstallingUpdate = false;
+      }
+    });
+
+    // 获取忽略版本状态
+    ipcMain.handle(IPC_EVENTS.UPDATE_GET_IGNORED_VERSIONS, async () => {
+      try {
+        const ignoredVersions = await getIgnoredVersions();
+        console.log('[Updater] Retrieved ignored versions:', ignoredVersions);
+        return createSuccessResponse(ignoredVersions);
+      } catch (error) {
+        console.error('[Updater] Failed to get ignored versions:', error);
+        return createDetailedErrorResponse(error);
+      }
+    });
+
+    // 忽略版本
+    ipcMain.handle(IPC_EVENTS.UPDATE_IGNORE_VERSION, async (event, version, versionType) => {
+      try {
+        // 验证版本号格式
+        if (!validateVersion(version)) {
+          throw new Error(`Invalid version format: ${version}`);
+        }
+
+        // 如果没有指定类型，根据版本号自动判断
+        if (!versionType) {
+          versionType = version.includes('-') ? 'prerelease' : 'stable';
+        }
+
+        console.log('[Updater] Ignoring version:', version, 'type:', versionType);
+
+        // 获取当前忽略版本数据
+        const ignoredVersions = await getIgnoredVersions();
+
+        // 更新对应类型的忽略版本
+        ignoredVersions[versionType] = version;
+
+        // 保存更新后的数据
+        await ctx.preferenceService.set(PREFERENCE_KEYS.IGNORED_VERSIONS, ignoredVersions);
+
+        return createSuccessResponse(null);
+      } catch (error) {
+        console.error('[Updater] Failed to ignore version:', error);
+        return createDetailedErrorResponse(error);
+      }
+    });
+
+    // 取消忽略版本
+    ipcMain.handle(IPC_EVENTS.UPDATE_UNIGNORE_VERSION, async (event, versionType) => {
+      try {
+        // 验证版本类型
+        if (!['stable', 'prerelease'].includes(versionType)) {
+          throw new Error(`Invalid version type: ${versionType}`);
+        }
+
+        console.log('[Updater] Unignoring version type:', versionType);
+
+        // 获取当前忽略版本数据
+        const ignoredVersions = await getIgnoredVersions();
+
+        // 清除对应类型的忽略版本
+        ignoredVersions[versionType] = null;
+
+        // 保存更新后的数据
+        await ctx.preferenceService.set(PREFERENCE_KEYS.IGNORED_VERSIONS, ignoredVersions);
+
+        return createSuccessResponse(null);
+      } catch (error) {
+        console.error('[Updater] Failed to unignore version:', error);
+        return createDetailedErrorResponse(error);
+      }
+    });
+
+    // 下载特定版本（原子操作）
+    ipcMain.handle(IPC_EVENTS.UPDATE_DOWNLOAD_SPECIFIC_VERSION, async (event, versionType) => {
+      if (isManualReleaseDelivery(updateDelivery)) {
+        return createErrorResponse(
+          createManualUpdateRequiredError('download-specific-version', updateDelivery, {
+            versionType,
+          })
+        );
+      }
+
+      try {
+        console.log('[Updater] Starting atomic download for version type:', versionType);
+
+        // 验证版本类型
+        if (!['stable', 'prerelease'].includes(versionType)) {
+          throw new Error(`Invalid version type: ${versionType}`);
+        }
+
+        // 防止并发下载 - 立即设置状态锁
+        if (isDownloadingUpdate) {
+          console.log('[Updater] Download already in progress');
+          return createErrorResponse('Download already in progress');
+        }
+
+        // 立即设置下载状态，防止竞态条件
+        isDownloadingUpdate = true;
+
+        // 1. 保存当前配置（包括偏好设置和autoUpdater实例配置）
+        const originalPreference = await ctx.preferenceService.get(PREFERENCE_KEYS.ALLOW_PRERELEASE, false);
+        const originalAutoUpdaterConfig = {
+          allowPrerelease: autoUpdater.allowPrerelease,
+          allowDowngrade: autoUpdater.allowDowngrade
+        };
+        console.log('[Updater] Original preference:', originalPreference);
+        console.log('[Updater] Original autoUpdater config:', originalAutoUpdaterConfig);
+
+        try {
+          // 2. 设置目标通道（同时修改偏好设置和autoUpdater实例）
+          const targetPreference = versionType === 'prerelease';
+          await ctx.preferenceService.set(PREFERENCE_KEYS.ALLOW_PRERELEASE, targetPreference);
+
+          // 直接配置autoUpdater实例，确保本次操作使用正确配置
+          autoUpdater.allowPrerelease = targetPreference;
+          autoUpdater.allowDowngrade = true; // 允许降级，支持从预览版切换到正式版
+
+          console.log('[Updater] Set preference to:', targetPreference);
+          console.log('[Updater] Set autoUpdater config:', {
+            allowPrerelease: autoUpdater.allowPrerelease,
+            allowDowngrade: autoUpdater.allowDowngrade
+          });
+
+          // 3. 检查更新
+          console.log('[Updater] Checking for updates...');
+          const checkResult = await autoUpdater.checkForUpdates();
+
+          if (!checkResult || !checkResult.updateInfo) {
+            console.log('[Updater] No update available for', versionType);
+            isDownloadingUpdate = false; // 重置状态
+            return createSuccessResponse({
+              hasUpdate: false,
+              message: `No ${versionType} update available`,
+              versionType,
+              version: null,
+              reason: 'no-update'
+            });
+          }
+
+          // 检查版本是否被忽略
+          const isIgnored = await isVersionIgnored(checkResult.updateInfo.version);
+          if (isIgnored) {
+            console.log('[Updater] Version is ignored:', checkResult.updateInfo.version);
+            isDownloadingUpdate = false; // 重置状态
+            return createSuccessResponse({
+              hasUpdate: false,
+              message: `Version ${checkResult.updateInfo.version} is ignored`,
+              versionType,
+              version: checkResult.updateInfo.version,
+              reason: 'ignored'
+            });
+          }
+
+          // 4. 立即开始下载
+          console.log('[Updater] Starting download for version:', checkResult.updateInfo.version);
+          // 注意：isDownloadingUpdate 已在函数开始时设置
+
+          // 由于 autoDownload = false，必须手动调用 downloadUpdate()
+          // 注意：不要 await downloadUpdate()，因为它会等到下载完成
+          // 我们只需要启动下载，然后立即返回，避免超时问题
+          try {
+            // 启动下载（不等待完成）
+            autoUpdater.downloadUpdate().catch(downloadError => {
+              console.error('[Updater] Download failed:', downloadError);
+              isDownloadingUpdate = false;
+              // 发送错误事件到前端
+              if (ctx.mainWindow && !ctx.mainWindow.isDestroyed()) {
+                ctx.mainWindow.webContents.send(IPC_EVENTS.UPDATE_ERROR, {
+                  message: downloadError.message || 'Download failed',
+                  error: downloadError,
+                  timestamp: new Date().toISOString()
+                });
+              }
+            });
+            console.log('[Updater] Download started successfully');
+
+            // 立即发送下载开始事件到前端，确保UI状态同步
+            if (ctx.mainWindow && !ctx.mainWindow.isDestroyed()) {
+              ctx.mainWindow.webContents.send(IPC_EVENTS.UPDATE_DOWNLOAD_STARTED, {
+                versionType,
+                version: checkResult.updateInfo.version,
+                timestamp: new Date().toISOString()
+              });
+            }
+          } catch (downloadError) {
+            console.error('[Updater] Failed to start download:', downloadError);
+            isDownloadingUpdate = false;
+            throw downloadError;
+          }
+
+          return createSuccessResponse({
+            hasUpdate: true,
+            updateInfo: checkResult.updateInfo,
+            versionType,
+            message: `Started downloading ${versionType} version ${checkResult.updateInfo.version}`
+          });
+
+        } finally {
+          // 5. 确保恢复原始配置（偏好设置和autoUpdater实例）
+          try {
+            // 恢复偏好设置
+            await ctx.preferenceService.set(PREFERENCE_KEYS.ALLOW_PRERELEASE, originalPreference);
+            console.log('[Updater] Restored preference to:', originalPreference);
+
+            // 恢复autoUpdater实例配置
+            autoUpdater.allowPrerelease = originalAutoUpdaterConfig.allowPrerelease;
+            autoUpdater.allowDowngrade = originalAutoUpdaterConfig.allowDowngrade;
+            console.log('[Updater] Restored autoUpdater config to:', originalAutoUpdaterConfig);
+          } catch (restoreError) {
+            console.error('[Updater] Failed to restore configuration:', restoreError);
+          }
+        }
+
+      } catch (error) {
+        console.error('[Updater] Atomic download failed:', error);
+        // 确保下载状态被重置
+        if (isDownloadingUpdate) {
+          isDownloadingUpdate = false;
+        }
+        return createDetailedErrorResponse(error);
+      }
+    });
+
+    console.log('[Main Process] Auto-update handlers ready.');
+  }
+
+  return { setupUpdateHandlers };
+}
+
+module.exports = {
+  createUpdateHandlers,
+};

--- a/packages/desktop/config/preload-stream-cancellation.test.js
+++ b/packages/desktop/config/preload-stream-cancellation.test.js
@@ -1,0 +1,125 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+const path = require('node:path');
+const { EventEmitter } = require('node:events');
+
+/**
+ * 使用可控的 Electron IPC 替身加载 preload，并返回暴露给前端的桥接接口。
+ */
+function loadPreloadWithElectronMock(ipcRenderer) {
+  const preloadPath = path.resolve(__dirname, '../preload.js');
+  const originalLoad = Module._load;
+  let api;
+
+  Module._load = function load(request, parent, isMain) {
+    if (request === 'electron') {
+      return {
+        contextBridge: {
+          exposeInMainWorld: (_name, exposedApi) => {
+            api = exposedApi;
+          },
+        },
+        ipcRenderer,
+      };
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  try {
+    delete require.cache[preloadPath];
+    require(preloadPath);
+    return api;
+  } finally {
+    Module._load = originalLoad;
+    delete require.cache[preloadPath];
+  }
+}
+
+test('preload AbortSignal cancels an active stream and resolves the caller promptly', async () => {
+  const calls = [];
+  const listeners = new Map();
+  const ipcRenderer = {
+    on(channel, listener) {
+      listeners.set(`${channel}:${listener.name || listeners.size}`, listener);
+    },
+    removeListener(channel, listener) {
+      listeners.delete(`${channel}:${listener.name || 0}`);
+    },
+    invoke(channel, ...args) {
+      calls.push([channel, ...args]);
+      if (channel === 'stream-cancel') {
+        return Promise.resolve({ success: true, data: { cancelled: true } });
+      }
+      return new Promise(() => {});
+    },
+  };
+  const api = loadPreloadWithElectronMock(ipcRenderer);
+  const controller = new AbortController();
+
+  const pending = api.llm.sendMessageStream([], 'provider', {}, controller.signal);
+  controller.abort();
+
+  await assert.rejects(
+    pending,
+    (error) => error && error.code === 'IPC_STREAM_CANCELLED',
+  );
+  assert.equal(calls[0][0], 'llm-sendMessageStream');
+  assert.equal(calls[1][0], 'stream-cancel');
+  assert.match(calls[1][1], /^stream_[A-Za-z0-9_]+$/);
+  assert.equal(listeners.size, 0);
+});
+
+test('preload forwards Prompt AbortSignal to the main-process cancellation channel', async () => {
+  const calls = [];
+  const ipcRenderer = new EventEmitter();
+  ipcRenderer.invoke = (channel, ...args) => {
+    calls.push([channel, ...args]);
+    if (channel === 'stream-cancel') {
+      return Promise.resolve({ success: true, data: { cancelled: true } });
+    }
+    return new Promise(() => {});
+  };
+  const api = loadPreloadWithElectronMock(ipcRenderer);
+  const controller = new AbortController();
+
+  const pending = api.prompt.optimizePromptStream({}, {}, controller.signal);
+  controller.abort();
+
+  await assert.rejects(
+    Promise.race([
+      pending,
+      new Promise((_, reject) => setTimeout(() => reject(new Error('Prompt cancellation timed out')), 100)),
+    ]),
+    (error) => error && error.code === 'IPC_STREAM_CANCELLED',
+  );
+  assert.equal(calls[0][0], 'prompt-optimizePromptStream');
+  assert.equal(calls[1][0], 'stream-cancel');
+  assert.equal(ipcRenderer.listenerCount('stream-token-' + calls[1][1]), 0);
+});
+
+test('preload on/off and disposer remove the exact wrapped listener', () => {
+  const ipcRenderer = new EventEmitter();
+  ipcRenderer.invoke = async () => ({ success: true, data: null });
+  const api = loadPreloadWithElectronMock(ipcRenderer);
+  let callCount = 0;
+
+  /** 记录前端实际收到的更新事件次数。 */
+  const callback = () => {
+    callCount += 1;
+  };
+
+  const dispose = api.on('update-error', callback);
+  assert.equal(typeof dispose, 'function');
+  ipcRenderer.emit('update-error', {}, 'first');
+  assert.equal(callCount, 1);
+
+  api.off('update-error', callback);
+  ipcRenderer.emit('update-error', {}, 'second');
+  assert.equal(callCount, 1);
+  assert.equal(ipcRenderer.listenerCount('update-error'), 0);
+
+  const disposeAgain = api.on('update-error', callback);
+  disposeAgain();
+  assert.equal(ipcRenderer.listenerCount('update-error'), 0);
+});

--- a/packages/desktop/config/remote-storage.test.js
+++ b/packages/desktop/config/remote-storage.test.js
@@ -1,0 +1,68 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { handleRemoteStorageOperation } = require('../remote-storage');
+
+const webDavRequest = (path, directory = 'prompt-optimizer-backups') => ({
+  operation: 'head',
+  path,
+  provider: {
+    kind: 'webdav',
+    endpoint: 'https://storage.example.test',
+    directory,
+  },
+});
+
+test('remote storage rejects traversal paths before creating a client', async () => {
+  const unsafePaths = [
+    '../outside.json',
+    'nested/../../outside.json',
+    'nested\\..\\outside.json',
+    '%2e%2e/outside.json',
+    'nested/%2foutside.json',
+  ];
+
+  for (const path of unsafePaths) {
+    let clientCreated = false;
+    await assert.rejects(
+      handleRemoteStorageOperation(webDavRequest(path), {
+        createWebDavClient: async () => {
+          clientCreated = true;
+          return {};
+        },
+      }),
+      /Remote storage path/,
+    );
+    assert.equal(clientCreated, false, `client should not be created for ${path}`);
+  }
+});
+
+test('remote storage rejects a traversal base directory', async () => {
+  let clientCreated = false;
+  await assert.rejects(
+    handleRemoteStorageOperation(webDavRequest('backup.json', '../outside'), {
+      createWebDavClient: async () => {
+        clientCreated = true;
+        return {};
+      },
+    }),
+    /Remote storage path/,
+  );
+  assert.equal(clientCreated, false);
+});
+
+test('remote storage keeps valid nested WebDAV paths compatible', async () => {
+  let requestedPath = null;
+  const result = await handleRemoteStorageOperation(webDavRequest('daily/backup.json'), {
+    createWebDavClient: async () => ({
+      stat: async (path) => {
+        requestedPath = path;
+        return { size: 42 };
+      },
+    }),
+  });
+
+  assert.equal(requestedPath, '/prompt-optimizer-backups/daily/backup.json');
+  assert.equal(result.path, 'daily/backup.json');
+  assert.equal(result.sizeBytes, 42);
+});

--- a/packages/desktop/config/runtime-security.js
+++ b/packages/desktop/config/runtime-security.js
@@ -1,3 +1,7 @@
+/** Runtime config exposed to renderer must be explicitly public.
+ * Supplier API keys (VITE_*_API_KEY) stay main-process-only and are never
+ * returned by getPublicRuntimeConfig / config-getEnvironmentVariables.
+ */
 const PUBLIC_RUNTIME_CONFIG_PATTERN = /^VITE_(?:APP|PUBLIC)_[A-Z0-9_]+$/;
 const SENSITIVE_RUNTIME_CONFIG_SEGMENT = /(?:^|_)(?:API_KEY|KEY|TOKEN|SECRET|PASSWORD|PASS|AUTHORIZATION|HEADERS|CREDENTIALS?|COOKIE|PRIVATE)(?:_|$)/i;
 

--- a/packages/desktop/config/runtime-security.js
+++ b/packages/desktop/config/runtime-security.js
@@ -1,0 +1,30 @@
+const PUBLIC_RUNTIME_CONFIG_PATTERN = /^VITE_(?:APP|PUBLIC)_[A-Z0-9_]+$/;
+const SENSITIVE_RUNTIME_CONFIG_SEGMENT = /(?:^|_)(?:API_KEY|KEY|TOKEN|SECRET|PASSWORD|PASS|AUTHORIZATION|HEADERS|CREDENTIALS?|COOKIE|PRIVATE)(?:_|$)/i;
+
+/** 判断环境变量是否明确允许暴露给 renderer，且名称不包含敏感字段。 */
+function isPublicRuntimeConfigKey(key) {
+  return PUBLIC_RUNTIME_CONFIG_PATTERN.test(key)
+    && !SENSITIVE_RUNTIME_CONFIG_SEGMENT.test(key);
+}
+
+/** 从主进程环境中提取 renderer 可见的公共配置及其无前缀兼容键。 */
+function getPublicRuntimeConfig(environment) {
+  const config = {};
+
+  for (const [key, value] of Object.entries(environment)) {
+    if (!isPublicRuntimeConfigKey(key) || value === undefined || value === null || String(value).length === 0) {
+      continue;
+    }
+
+    const stringValue = String(value);
+    config[key] = stringValue;
+    config[key.replace(/^VITE_/, '')] = stringValue;
+  }
+
+  return config;
+}
+
+module.exports = {
+  getPublicRuntimeConfig,
+  isPublicRuntimeConfigKey,
+};

--- a/packages/desktop/config/runtime-security.test.js
+++ b/packages/desktop/config/runtime-security.test.js
@@ -1,0 +1,38 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { getPublicRuntimeConfig } = require('./runtime-security');
+
+test('renderer runtime config exposes only explicitly public VITE variables', () => {
+  const config = getPublicRuntimeConfig({
+    VITE_PUBLIC_RELEASE_CHANNEL: 'stable',
+    VITE_APP_BUILD_LABEL: 'desktop',
+    VITE_OPENAI_API_KEY: 'secret-openai-key',
+    VITE_CUSTOM_API_HEADERS: '{"Authorization":"Bearer secret"}',
+    VITE_CUSTOM_API_BASE_URL: 'https://provider.example',
+    INTERNAL_FEATURE_FLAG: 'hidden',
+  });
+
+  assert.deepEqual(config, {
+    VITE_PUBLIC_RELEASE_CHANNEL: 'stable',
+    PUBLIC_RELEASE_CHANNEL: 'stable',
+    VITE_APP_BUILD_LABEL: 'desktop',
+    APP_BUILD_LABEL: 'desktop',
+  });
+  assert.equal(JSON.stringify(config).includes('secret-openai-key'), false);
+  assert.equal(JSON.stringify(config).includes('Bearer secret'), false);
+  assert.equal(JSON.stringify(config).includes('provider.example'), false);
+});
+
+test('renderer runtime config rejects public-looking names that contain sensitive segments', () => {
+  const config = getPublicRuntimeConfig({
+    VITE_PUBLIC_API_TOKEN_HINT: 'still-secret',
+    VITE_APP_PASSWORD_STATUS: 'still-secret',
+    VITE_PUBLIC_FEATURE_FLAG: 'enabled',
+  });
+
+  assert.deepEqual(config, {
+    VITE_PUBLIC_FEATURE_FLAG: 'enabled',
+    PUBLIC_FEATURE_FLAG: 'enabled',
+  });
+});

--- a/packages/desktop/config/stream-registry.js
+++ b/packages/desktop/config/stream-registry.js
@@ -1,0 +1,184 @@
+const { createIpcError } = require('./ipc-security');
+
+/** 获取 renderer sender 的稳定标识，并拒绝无效 sender。 */
+function getSenderId(sender) {
+  if (!sender || typeof sender.id !== 'number') {
+    throw createIpcError('IPC_UNTRUSTED_SENDER', 'IPC request sender is not trusted');
+  }
+  return sender.id;
+}
+
+/** 创建限制并发数、校验所有权并支持取消的流任务注册表。 */
+function createStreamRegistry({ maxStreamsPerSender = 4 } = {}) {
+  const streams = new Map();
+  const observedSenders = new WeakSet();
+
+  /** 注册新流任务并返回供领域执行器使用的取消信号。 */
+  function register(sender, streamId) {
+    const senderId = getSenderId(sender);
+    if (streams.has(streamId)) {
+      throw createIpcError('IPC_STREAM_ALREADY_EXISTS', 'IPC stream identifier is already active');
+    }
+
+    const activeForSender = [...streams.values()]
+      .filter((stream) => stream.senderId === senderId)
+      .length;
+    if (activeForSender >= maxStreamsPerSender) {
+      throw createIpcError('IPC_STREAM_LIMIT_REACHED', 'Too many active IPC streams');
+    }
+
+    const controller = new AbortController();
+    const stream = { sender, senderId, controller, signal: controller.signal };
+    streams.set(streamId, stream);
+
+    observeSender(sender);
+
+    return stream;
+  }
+
+  /** 判断流标识是否仍在注册表中。 */
+  function has(streamId) {
+    return streams.has(streamId);
+  }
+
+  /** 判断流是否属于指定 sender 且仍可向 renderer 转发事件。 */
+  function isOwned(sender, streamId) {
+    const stream = streams.get(streamId);
+    return Boolean(stream)
+      && stream.senderId === getSenderId(sender);
+  }
+
+  /** 流仍归该 sender 且未取消时，才转发 token/tool 事件。 */
+  function isActive(sender, streamId) {
+    const stream = streams.get(streamId);
+    return isOwned(sender, streamId) && !stream.signal.aborted;
+  }
+
+  /** 由流所有者取消任务并触发对应 AbortSignal。 */
+  function cancel(sender, streamId) {
+    const stream = streams.get(streamId);
+    if (!stream) {
+      throw createIpcError('IPC_STREAM_NOT_FOUND', 'IPC stream was not found');
+    }
+    if (stream.senderId !== getSenderId(sender)) {
+      throw createIpcError('IPC_STREAM_NOT_OWNER', 'IPC stream is not owned by this renderer');
+    }
+
+    stream.controller.abort();
+    streams.delete(streamId);
+    return true;
+  }
+
+  /** 在任务正常完成或异常结束后释放所有权记录。 */
+  function complete(sender, streamId) {
+    const stream = streams.get(streamId);
+    if (!stream) {
+      return false;
+    }
+    if (stream.senderId !== getSenderId(sender)) {
+      throw createIpcError('IPC_STREAM_NOT_OWNER', 'IPC stream is not owned by this renderer');
+    }
+
+    streams.delete(streamId);
+    return true;
+  }
+
+  /** sender 销毁时取消其全部活动流，避免后台任务继续占用资源。 */
+  function cancelAllForSender(sender) {
+    const senderId = getSenderId(sender);
+    for (const [streamId, stream] of streams) {
+      if (stream.senderId !== senderId) {
+        continue;
+      }
+      stream.controller.abort();
+      streams.delete(streamId);
+    }
+  }
+
+  /** 每个 sender 只绑定一次销毁监听，避免频繁流调用累积 EventEmitter listener。 */
+  function observeSender(sender) {
+    if (typeof sender.once !== 'function' || observedSenders.has(sender)) {
+      return;
+    }
+
+    observedSenders.add(sender);
+    sender.once('destroyed', () => {
+      try {
+        cancelAllForSender(sender);
+      } finally {
+        observedSenders.delete(sender);
+      }
+    });
+  }
+
+  return {
+    cancel,
+    cancelAllForSender,
+    complete,
+    has,
+    isActive,
+    isOwned,
+    register,
+  };
+}
+
+/** 创建只向流所有者发送 token、工具、完成和错误事件的回调集合。 */
+function createOwnedStreamHandlers({ registry, sender, streamId, channels }) {
+  /** 在流仍活动时发送单个 renderer 事件。 */
+  const send = function send(channel, payload) {
+    if (!channel || !registry.isActive(sender, streamId)) {
+      return false;
+    }
+    if (typeof sender.isDestroyed === 'function' && sender.isDestroyed()) {
+      registry.complete(sender, streamId);
+      return false;
+    }
+
+    const eventName = `${channel}-${streamId}`;
+    if (arguments.length === 1) {
+      sender.send(eventName);
+    } else {
+      sender.send(eventName, payload);
+    }
+    return true;
+  };
+
+  const sendOwned = function sendOwned(channel, payload) {
+    if (!channel || !registry.isOwned(sender, streamId)) {
+      return false;
+    }
+    if (typeof sender.isDestroyed === 'function' && sender.isDestroyed()) {
+      registry.complete(sender, streamId);
+      return false;
+    }
+    const eventName = `${channel}-${streamId}`;
+    if (arguments.length === 1) {
+      sender.send(eventName);
+    } else {
+      sender.send(eventName, payload);
+    }
+    return true;
+  };
+
+  return {
+    onToken: (token) => send(channels.token, token),
+    onReasoningToken: (token) => send(channels.reasoning, token),
+    onToolCall: (toolCall) => send(channels.toolCall, toolCall),
+    onComplete: () => {
+      if (sendOwned(channels.finish)) {
+        registry.complete(sender, streamId);
+      }
+    },
+    onError: (error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      if (sendOwned(channels.error, message)) {
+        registry.complete(sender, streamId);
+      }
+    },
+  };
+}
+
+module.exports = {
+  createOwnedStreamHandlers,
+  createStreamRegistry,
+};

--- a/packages/desktop/config/stream-registry.test.js
+++ b/packages/desktop/config/stream-registry.test.js
@@ -1,0 +1,94 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+
+const {
+  createOwnedStreamHandlers,
+  createStreamRegistry,
+} = require('./stream-registry');
+
+/** 创建具备 Electron WebContents 最小事件接口的 renderer sender 替身。 */
+function createSender(id) {
+  const sent = [];
+  const sender = new EventEmitter();
+  sender.id = id;
+  sender.sent = sent;
+  sender.isDestroyed = () => false;
+  sender.send = (...args) => sent.push(args);
+  return sender;
+}
+
+test('stream cancellation aborts the owner controller and stops further renderer events', () => {
+  const registry = createStreamRegistry();
+  const sender = createSender(1);
+  const stream = registry.register(sender, 'stream_owner');
+  const handlers = createOwnedStreamHandlers({
+    registry,
+    sender,
+    streamId: 'stream_owner',
+    channels: { token: 'stream-token', finish: 'stream-finish', error: 'stream-error' },
+  });
+
+  handlers.onToken('before-cancel');
+  assert.deepEqual(sender.sent, [['stream-token-stream_owner', 'before-cancel']]);
+
+  assert.equal(registry.cancel(sender, 'stream_owner'), true);
+  assert.equal(stream.signal.aborted, true);
+
+  handlers.onToken('after-cancel');
+  handlers.onComplete();
+  assert.deepEqual(sender.sent, [['stream-token-stream_owner', 'before-cancel']]);
+  assert.equal(registry.has('stream_owner'), false);
+});
+
+test('a non-owner cannot cancel an active stream', () => {
+  const registry = createStreamRegistry();
+  const owner = createSender(1);
+  const otherSender = createSender(2);
+  registry.register(owner, 'stream_owner');
+
+  assert.throws(
+    () => registry.cancel(otherSender, 'stream_owner'),
+    (error) => error && error.code === 'IPC_STREAM_NOT_OWNER',
+  );
+  assert.equal(registry.has('stream_owner'), true);
+});
+
+test('stream completion sends only to the registered sender and clears ownership', () => {
+  const registry = createStreamRegistry();
+  const owner = createSender(1);
+  const unrelatedWindow = createSender(2);
+  registry.register(owner, 'stream_complete');
+  const handlers = createOwnedStreamHandlers({
+    registry,
+    sender: owner,
+    streamId: 'stream_complete',
+    channels: { finish: 'stream-finish', error: 'stream-error' },
+  });
+
+  handlers.onComplete();
+
+  assert.deepEqual(owner.sent, [['stream-finish-stream_complete']]);
+  assert.deepEqual(unrelatedWindow.sent, []);
+  assert.equal(registry.has('stream_complete'), false);
+});
+
+test('stream registry binds one destroyed listener per sender and cancels active work on teardown', () => {
+  const registry = createStreamRegistry();
+  const sender = createSender(1);
+
+  for (let index = 0; index < 12; index += 1) {
+    const streamId = `stream_completed_${index}`;
+    registry.register(sender, streamId);
+    registry.complete(sender, streamId);
+  }
+
+  const activeStream = registry.register(sender, 'stream_active');
+  assert.equal(sender.listenerCount('destroyed'), 1);
+
+  sender.emit('destroyed');
+
+  assert.equal(activeStream.signal.aborted, true);
+  assert.equal(registry.has('stream_active'), false);
+  assert.equal(sender.listenerCount('destroyed'), 0);
+});

--- a/packages/desktop/config/window-security.js
+++ b/packages/desktop/config/window-security.js
@@ -1,0 +1,70 @@
+const path = require('path');
+const { fileURLToPath } = require('url');
+
+/** 仅允许具备主机名的 HTTP/HTTPS 地址交给系统浏览器。 */
+function isSafeExternalUrl(value) {
+  try {
+    const url = new URL(value);
+    return ['http:', 'https:'].includes(url.protocol) && Boolean(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+/** 判断候选文件路径是否位于指定应用根目录内。 */
+function isPathWithin(candidatePath, rootPath) {
+  const candidate = path.resolve(candidatePath);
+  const root = path.resolve(rootPath);
+  return candidate === root || candidate.startsWith(`${root}${path.sep}`);
+}
+
+/** 校验主 frame 导航是否属于当前开发源或打包应用目录。 */
+function isAllowedMainFrameNavigation(targetUrl, options) {
+  try {
+    const url = new URL(targetUrl);
+    if (options.isDevelopment) {
+      return url.origin === new URL(options.devServerUrl).origin;
+    }
+
+    return url.protocol === 'file:'
+      && isPathWithin(fileURLToPath(url), options.packagedRoot);
+  } catch {
+    return false;
+  }
+}
+
+/** 安装顶层导航、新窗口和 webview 的统一 Electron 安全门禁。 */
+function installMainFrameNavigationGuard(webContents, options) {
+  /** 将通过协议校验的外部地址交给系统浏览器，并隔离打开失败。 */
+  const openExternal = (url) => {
+    if (!isSafeExternalUrl(url)) {
+      return;
+    }
+
+    void Promise.resolve(options.openExternal(url)).catch(() => {});
+  };
+
+  webContents.on('will-navigate', (event, targetUrl) => {
+    if (isAllowedMainFrameNavigation(targetUrl, options)) {
+      return;
+    }
+
+    event.preventDefault();
+    openExternal(targetUrl);
+  });
+
+  webContents.setWindowOpenHandler(({ url }) => {
+    openExternal(url);
+    return { action: 'deny' };
+  });
+
+  webContents.on('will-attach-webview', (event) => {
+    event.preventDefault();
+  });
+}
+
+module.exports = {
+  installMainFrameNavigationGuard,
+  isAllowedMainFrameNavigation,
+  isSafeExternalUrl,
+};

--- a/packages/desktop/config/window-security.js
+++ b/packages/desktop/config/window-security.js
@@ -15,7 +15,11 @@ function isSafeExternalUrl(value) {
 function isPathWithin(candidatePath, rootPath) {
   const candidate = path.resolve(candidatePath);
   const root = path.resolve(rootPath);
-  return candidate === root || candidate.startsWith(`${root}${path.sep}`);
+  // Windows paths are case-insensitive; normalize to avoid false untrusted senders.
+  const norm = (value) => process.platform === 'win32' ? value.toLowerCase() : value;
+  const c = norm(candidate);
+  const r = norm(root);
+  return c === r || c.startsWith(`${r}${path.sep}`);
 }
 
 /** 校验主 frame 导航是否属于当前开发源或打包应用目录。 */

--- a/packages/desktop/config/window-security.test.js
+++ b/packages/desktop/config/window-security.test.js
@@ -1,0 +1,63 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+
+const {
+  installMainFrameNavigationGuard,
+  isAllowedMainFrameNavigation,
+} = require('./window-security');
+
+function createWebContents() {
+  const webContents = new EventEmitter();
+  webContents.setWindowOpenHandler = (handler) => {
+    webContents.windowOpenHandler = handler;
+  };
+  return webContents;
+}
+
+test('production navigation allows only packaged files under the application root', () => {
+  const options = {
+    isDevelopment: false,
+    packagedRoot: 'C:/app/web-dist',
+    devServerUrl: 'http://localhost:18181',
+  };
+
+  assert.equal(isAllowedMainFrameNavigation('file:///C:/app/web-dist/index.html', options), true);
+  assert.equal(isAllowedMainFrameNavigation('file:///C:/app/web-dist/assets/app.js', options), true);
+  assert.equal(isAllowedMainFrameNavigation('file:///C:/Windows/System32/notepad.exe', options), false);
+  assert.equal(isAllowedMainFrameNavigation('https://attacker.example', options), false);
+});
+
+test('development navigation allows only the configured development server origin', () => {
+  const options = {
+    isDevelopment: true,
+    packagedRoot: 'C:/app/web-dist',
+    devServerUrl: 'http://localhost:18181',
+  };
+
+  assert.equal(isAllowedMainFrameNavigation('http://localhost:18181/workspace', options), true);
+  assert.equal(isAllowedMainFrameNavigation('http://localhost:5173/workspace', options), false);
+  assert.equal(isAllowedMainFrameNavigation('https://attacker.example', options), false);
+});
+
+test('navigation guard prevents untrusted top-level navigation and opens only safe external links', async () => {
+  const webContents = createWebContents();
+  const openedUrls = [];
+  installMainFrameNavigationGuard(webContents, {
+    isDevelopment: false,
+    packagedRoot: 'C:/app/web-dist',
+    devServerUrl: 'http://localhost:18181',
+    openExternal: async (url) => openedUrls.push(url),
+  });
+
+  let prevented = false;
+  webContents.emit('will-navigate', { preventDefault: () => { prevented = true; } }, 'https://docs.example');
+  await new Promise(resolve => setImmediate(resolve));
+
+  assert.equal(prevented, true);
+  assert.deepEqual(openedUrls, ['https://docs.example']);
+  assert.deepEqual(webContents.windowOpenHandler({ url: 'javascript:alert(1)' }), { action: 'deny' });
+  assert.deepEqual(webContents.windowOpenHandler({ url: 'https://docs.example/new' }), { action: 'deny' });
+  await new Promise(resolve => setImmediate(resolve));
+  assert.deepEqual(openedUrls, ['https://docs.example', 'https://docs.example/new']);
+});

--- a/packages/desktop/config/window-security.test.js
+++ b/packages/desktop/config/window-security.test.js
@@ -61,3 +61,20 @@ test('navigation guard prevents untrusted top-level navigation and opens only sa
   await new Promise(resolve => setImmediate(resolve));
   assert.deepEqual(openedUrls, ['https://docs.example', 'https://docs.example/new']);
 });
+
+test('production file URL allowlist accepts mixed-case packaged paths', () => {
+  const options = {
+    isDevelopment: false,
+    packagedRoot: 'C:/app/web-dist',
+    devServerUrl: 'http://localhost:18181',
+  };
+  // Windows webContents may surface different drive-letter casing than packagedRoot.
+  assert.equal(
+    isAllowedMainFrameNavigation('file:///c:/APP/web-dist/index.html', options),
+    true,
+  );
+  assert.equal(
+    isAllowedMainFrameNavigation('file:///C:/app/web-dist/index.html', options),
+    true,
+  );
+});

--- a/packages/desktop/main.js
+++ b/packages/desktop/main.js
@@ -49,6 +49,13 @@ const {
   getPageZoomActionFromDirection,
 } = require('./config/page-zoom');
 const { setupRemoteStorageHandlers } = require('./remote-storage');
+const { getPublicRuntimeConfig } = require('./config/runtime-security');
+const { installMainFrameNavigationGuard, isSafeExternalUrl } = require('./config/window-security');
+const {
+  createIpcError,
+  registerSecureIpcHandler,
+} = require('./config/ipc-security');
+
 const path = require('path');
 
 // 确定正确的配置文件路径
@@ -67,6 +74,16 @@ const envPath = path.join(__dirname, '.env');
 // 加载环境变量
 require('dotenv').config({ path: envLocalPath });
 require('dotenv').config({ path: envPath });
+
+function getIpcSenderOptions() {
+  return {
+    isDevelopment: process.env.NODE_ENV === 'development',
+    packagedRoot: path.join(__dirname, 'web-dist'),
+    devServerUrl: 'http://localhost:18181',
+  };
+}
+
+
 
 
 const {
@@ -424,24 +441,15 @@ function setupPreferenceHandlers() {
 // 构建注入到渲染进程的运行时配置脚本（双份键：带前缀与不带前缀）
 function buildRuntimeConfigScriptFromEnv() {
   try {
-    const entries = Object.entries(process.env)
-      .filter(([k, v]) => k.startsWith('VITE_') && v !== undefined && v !== null && String(v).length > 0);
+    const publicConfig = getPublicRuntimeConfig(process.env);
+    const publicCount = Object.keys(publicConfig).filter((key) => key.startsWith('VITE_')).length;
 
-    const props = [];
-    for (const [k, v] of entries) {
-      const val = String(v).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-      const noPrefix = k.replace(/^VITE_/, '');
-      props.push([noPrefix, val]);
-      props.push([k, val]);
-    }
-
-    const body = props.map(([key, val]) => `  ${key}: "${val}"`).join(',\n');
-
-    return `// Injected by Electron main process\n`
-      + `window.runtime_config = Object.assign({}, (window.runtime_config || {}), {\n`
-      + `${body}\n`
-      + `});\n`
-      + `console.log('[Main Process] runtime_config injected with ${entries.length} VITE_* vars (dual keys)');\n`;
+    return `// Injected by Electron main process
+`
+      + `window.runtime_config = Object.assign({}, (window.runtime_config || {}), ${JSON.stringify(publicConfig)});
+`
+      + `console.log('[Main Process] runtime_config injected with ${publicCount} public VITE_* vars (dual keys)');
+`;
   } catch (e) {
     return `console.warn('[Main Process] Failed to build runtime_config:', ${JSON.stringify(String(e))});`;
   }
@@ -495,6 +503,12 @@ function createWindow() {
       })
     )
   );
+
+  installMainFrameNavigationGuard(mainWindow.webContents, {
+    ...getIpcSenderOptions(),
+    openExternal: (url) => shell.openExternal(url),
+  });
+
   mainWindow.webContents.setZoomLevel(DEFAULT_PAGE_ZOOM_LEVEL);
   void mainWindow.webContents
     .setVisualZoomLevelLimits(VISUAL_ZOOM_LIMITS.minimum, VISUAL_ZOOM_LIMITS.maximum)
@@ -2226,23 +2240,12 @@ function setupIPC() {
   // 环境配置同步 - 主进程作为唯一配置源
   ipcMain.handle('config-getEnvironmentVariables', async (event) => {
     try {
-      // 自动透传所有 VITE_* 变量并附加无前缀副本
-      const viteEnv = Object.fromEntries(
-        Object.entries(process.env)
-          .filter(([k, v]) => k.startsWith('VITE_') && v !== undefined)
-          .map(([k, v]) => [k, String(v)])
-      );
+      // Only expose explicitly public runtime config to the renderer.
+      const publicConfig = getPublicRuntimeConfig(process.env);
+      const publicCount = Object.keys(publicConfig).filter((key) => key.startsWith('VITE_')).length;
 
-      const noPrefixEnv = Object.fromEntries(
-        Object.entries(viteEnv).map(([k, v]) => [k.replace(/^VITE_/, ''), v])
-      );
-
-      const allEnvVars = { ...viteEnv, ...noPrefixEnv };
-
-      console.log('[Main Process] Environment variables requested by UI process');
-      console.log(`[Main Process] Returning ${Object.keys(viteEnv).length} VITE_* variables (with no-prefix duplicates)`);
-
-      return createSuccessResponse(allEnvVars);
+      console.log(`[Main Process] Returning ${publicCount} public VITE_* variables (with no-prefix duplicates)`);
+      return createSuccessResponse(publicConfig);
     } catch (error) {
       return createErrorResponse(error);
     }
@@ -2256,6 +2259,9 @@ function setupIPC() {
       const urlObj = new URL(url);
       if (!['http:', 'https:'].includes(urlObj.protocol)) {
         throw new Error(`Unsupported protocol: ${urlObj.protocol}`);
+      }
+      if (!isSafeExternalUrl(url)) {
+        throw createIpcError('IPC_UNSAFE_EXTERNAL_URL', 'Refusing to open unsafe external URL');
       }
       await shell.openExternal(url);
       return createSuccessResponse(true);

--- a/packages/desktop/main.js
+++ b/packages/desktop/main.js
@@ -55,6 +55,7 @@ const {
   createIpcError,
   registerSecureIpcHandler,
 } = require('./config/ipc-security');
+const { createStreamRegistry } = require('./config/stream-registry');
 
 const path = require('path');
 
@@ -82,6 +83,9 @@ function getIpcSenderOptions() {
     devServerUrl: 'http://localhost:18181',
   };
 }
+
+const streamRegistry = createStreamRegistry();
+
 
 
 
@@ -987,8 +991,19 @@ function setupIPC() {
   });
 
   // Streaming handler - more complex due to callbacks
+  
+  ipcMain.handle('stream-cancel', async (event, streamId) => {
+    try {
+      streamRegistry.cancel(event.sender, streamId);
+      return createSuccessResponse(true);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  });
+
   ipcMain.handle('llm-sendMessageStream', async (event, messages, provider, streamId) => {
     try {
+      const stream = streamRegistry.register(event.sender, streamId);
       // 使用符合 StreamHandlers 接口的回调名称
       const callbacks = {
         onToken: (token) => {
@@ -1013,16 +1028,19 @@ function setupIPC() {
         }
       };
 
-      await llmService.sendMessageStream(messages, provider, callbacks);
+      await llmService.sendMessageStream(messages, provider, callbacks, { signal: stream.signal });
       return createSuccessResponse(null);
     } catch (error) {
       return createErrorResponse(error);
+    } finally {
+      streamRegistry.complete(event.sender, streamId);
     }
   });
 
   // Streaming handler with tools - supports tool-call events
   ipcMain.handle('llm-sendMessageStreamWithTools', async (event, messages, provider, tools, streamId) => {
     try {
+      const stream = streamRegistry.register(event.sender, streamId);
       const callbacks = {
         onToken: (token) => {
           if (mainWindow && !mainWindow.isDestroyed()) {
@@ -1051,10 +1069,12 @@ function setupIPC() {
         }
       };
 
-      await llmService.sendMessageStreamWithTools(messages, provider, tools, callbacks);
+      await llmService.sendMessageStreamWithTools(messages, provider, tools, callbacks, { signal: stream.signal });
       return createSuccessResponse(null);
     } catch (error) {
       return createErrorResponse(error);
+    } finally {
+      streamRegistry.complete(event.sender, streamId);
     }
   });
 
@@ -1146,44 +1166,72 @@ function setupIPC() {
   ipcMain.handle('prompt-optimizePromptStream', async (event, request, streamId) => {
     const streamHandlers = createIpcStreamHandlers(mainWindow, streamId);
     try {
-      await promptService.optimizePromptStream(request, streamHandlers);
+      const stream = streamRegistry.register(event.sender, streamId);
+      await promptService.optimizePromptStream(request, streamHandlers, { signal: stream.signal });
       return createSuccessResponse(null);
     } catch (error) {
       streamHandlers.onError(error);
       return createErrorResponse(error);
+    } finally {
+      streamRegistry.complete(event.sender, streamId);
     }
   });
 
   ipcMain.handle('prompt-optimizeMessageStream', async (event, request, streamId) => {
     const streamHandlers = createIpcStreamHandlers(mainWindow, streamId);
     try {
-      await promptService.optimizeMessageStream(request, streamHandlers);
+      const stream = streamRegistry.register(event.sender, streamId);
+      await promptService.optimizeMessageStream(request, streamHandlers, { signal: stream.signal });
       return createSuccessResponse(null);
     } catch (error) {
       streamHandlers.onError(error);
       return createErrorResponse(error);
+    } finally {
+      streamRegistry.complete(event.sender, streamId);
     }
   });
 
   ipcMain.handle('prompt-iteratePromptStream', async (event, originalPrompt, lastOptimizedPrompt, iterateInput, modelKey, templateId, streamId, contextData) => {
     const streamHandlers = createIpcStreamHandlers(mainWindow, streamId);
     try {
-      await promptService.iteratePromptStream(originalPrompt, lastOptimizedPrompt, iterateInput, modelKey, streamHandlers, templateId, contextData);
+      const stream = streamRegistry.register(event.sender, streamId);
+      await promptService.iteratePromptStream(
+        originalPrompt,
+        lastOptimizedPrompt,
+        iterateInput,
+        modelKey,
+        streamHandlers,
+        templateId,
+        contextData,
+        { signal: stream.signal },
+      );
       return createSuccessResponse(null);
     } catch (error) {
       streamHandlers.onError(error);
       return createErrorResponse(error);
+    } finally {
+      streamRegistry.complete(event.sender, streamId);
     }
   });
 
   ipcMain.handle('prompt-testPromptStream', async (event, systemPrompt, userPrompt, modelKey, streamId, inputImages) => {
     const streamHandlers = createIpcStreamHandlers(mainWindow, streamId);
     try {
-      await promptService.testPromptStream(systemPrompt, userPrompt, modelKey, streamHandlers, inputImages);
+      const stream = streamRegistry.register(event.sender, streamId);
+      await promptService.testPromptStream(
+        systemPrompt,
+        userPrompt,
+        modelKey,
+        streamHandlers,
+        inputImages,
+        { signal: stream.signal },
+      );
       return createSuccessResponse(null);
     } catch (error) {
       streamHandlers.onError(error);
       return createErrorResponse(error);
+    } finally {
+      streamRegistry.complete(event.sender, streamId);
     }
   });
 
@@ -1210,11 +1258,18 @@ function setupIPC() {
   ipcMain.handle('prompt-testCustomConversationStream', async (event, request, streamId) => {
     const streamHandlers = createIpcStreamHandlers(mainWindow, streamId);
     try {
-      await promptService.testCustomConversationStream(request, streamHandlers);
+      const stream = streamRegistry.register(event.sender, streamId);
+      await promptService.testCustomConversationStream(
+        request,
+        streamHandlers,
+        { signal: stream.signal },
+      );
       return createSuccessResponse(null);
     } catch (error) {
       streamHandlers.onError(error);
       return createErrorResponse(error);
+    } finally {
+      streamRegistry.complete(event.sender, streamId);
     }
   });
 

--- a/packages/desktop/main.js
+++ b/packages/desktop/main.js
@@ -924,6 +924,16 @@ function createFavoriteErrorResponse(error) {
 // --- High-Level IPC Service Handlers ---
 function setupIPC() {
   console.log('[Main Process] Setting up high-level service IPC handlers...');
+  /** Trusted-sender IPC registration for high-sensitivity channels. */
+  const registerSensitiveIpc = (channel, handler, validateArgs) => {
+    registerSecureIpcHandler(ipcMain, channel, handler, {
+      senderOptions: getIpcSenderOptions(),
+      validateArgs,
+      createSuccess: createSuccessResponse,
+      createError: createErrorResponse,
+    });
+  };
+
   setupPreferenceHandlers();
   setupRemoteStorageHandlers(ipcMain, {
     createSuccessResponse,
@@ -2238,36 +2248,25 @@ function setupIPC() {
 
 
   // 环境配置同步 - 主进程作为唯一配置源
-  ipcMain.handle('config-getEnvironmentVariables', async (event) => {
-    try {
-      // Only expose explicitly public runtime config to the renderer.
-      const publicConfig = getPublicRuntimeConfig(process.env);
-      const publicCount = Object.keys(publicConfig).filter((key) => key.startsWith('VITE_')).length;
-
-      console.log(`[Main Process] Returning ${publicCount} public VITE_* variables (with no-prefix duplicates)`);
-      return createSuccessResponse(publicConfig);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
+  // Secrets stay main-process-only; renderer receives explicit public keys only.
+  registerSensitiveIpc('config-getEnvironmentVariables', async () => {
+    const publicConfig = getPublicRuntimeConfig(process.env);
+    const publicCount = Object.keys(publicConfig).filter((key) => key.startsWith('VITE_')).length;
+    console.log(`[Main Process] Returning ${publicCount} public VITE_* variables (with no-prefix duplicates)`);
+    return publicConfig;
   });
 
   // 外部链接处理器
-  ipcMain.handle('shell-openExternal', async (event, url) => {
-    try {
-      console.log('[Main Process] Opening external URL:', url);
-      // 安全性检查：仅允许 http/https 协议
-      const urlObj = new URL(url);
-      if (!['http:', 'https:'].includes(urlObj.protocol)) {
-        throw new Error(`Unsupported protocol: ${urlObj.protocol}`);
-      }
-      if (!isSafeExternalUrl(url)) {
-        throw createIpcError('IPC_UNSAFE_EXTERNAL_URL', 'Refusing to open unsafe external URL');
-      }
-      await shell.openExternal(url);
-      return createSuccessResponse(true);
-    } catch (error) {
-      console.error('[Main Process] Failed to open external URL:', error);
-      return createErrorResponse(error);
+  registerSensitiveIpc('shell-openExternal', async (_event, url) => {
+    console.log('[Main Process] Opening external URL:', url);
+    if (!isSafeExternalUrl(url)) {
+      throw createIpcError('IPC_UNSAFE_EXTERNAL_URL', 'Refusing to open unsafe external URL');
+    }
+    await shell.openExternal(url);
+    return true;
+  }, ([url]) => {
+    if (typeof url !== 'string' || url.length === 0 || url.length > 2048) {
+      throw createIpcError('IPC_INVALID_ARGUMENT', 'Invalid external URL');
     }
   });
 

--- a/packages/desktop/main.js
+++ b/packages/desktop/main.js
@@ -26,17 +26,12 @@ const { app, BrowserWindow, ipcMain, shell, session, Menu, nativeImage } = requi
 const { autoUpdater } = require('electron-updater');
 const {
   buildReleaseUrl,
-  resolveUpdateRepositoryConfig,
   validateVersion,
+  getRepositoryInfo,
   IPC_EVENTS,
   PREFERENCE_KEYS,
   DEFAULT_CONFIG
 } = require('./config/update-config');
-const {
-  createManualUpdateRequiredError,
-  getUpdateDeliveryPolicy,
-  isManualReleaseDelivery,
-} = require('./config/update-delivery-policy');
 const { createGlobalDispatcherFromProxyDecision } = require('./config/proxy-dispatcher');
 const {
   buildAppMenuTemplate,
@@ -48,7 +43,6 @@ const {
   applyPageZoomAction,
   getPageZoomActionFromDirection,
 } = require('./config/page-zoom');
-const { setupRemoteStorageHandlers } = require('./remote-storage');
 const { getPublicRuntimeConfig } = require('./config/runtime-security');
 const { installMainFrameNavigationGuard, isSafeExternalUrl } = require('./config/window-security');
 const {
@@ -56,8 +50,32 @@ const {
   registerSecureIpcHandler,
 } = require('./config/ipc-security');
 const { createStreamRegistry } = require('./config/stream-registry');
-
+const { createOwnedStreamRunner } = require('./config/ipc/owned-stream-runner');
+const { registerLlmIpcHandlers } = require('./config/ipc/llm-handlers');
+const { registerPromptStreamIpcHandlers } = require('./config/ipc/prompt-stream-handlers');
+const { registerModelIpcHandlers } = require('./config/ipc/model-handlers');
+const { registerImageIpcHandlers } = require('./config/ipc/image-handlers');
+const { registerTemplateIpcHandlers } = require('./config/ipc/template-handlers');
+const { registerHistoryIpcHandlers } = require('./config/ipc/history-handlers');
+const { registerFavoriteIpcHandlers } = require('./config/ipc/favorite-handlers');
+const { registerContextIpcHandlers } = require('./config/ipc/context-handlers');
+const { registerDataIpcHandlers } = require('./config/ipc/data-handlers');
+const { registerPromptSyncIpcHandlers } = require('./config/ipc/prompt-sync-handlers');
+const { registerPreferenceIpcHandlers } = require('./config/ipc/preference-handlers');
+const { registerSystemIpcHandlers } = require('./config/ipc/system-handlers');
+const { createUpdateHandlers } = require('./config/ipc/update-handlers');
+const { setupRemoteStorageHandlers } = require('./remote-storage');
 const path = require('path');
+
+const streamRegistry = createStreamRegistry();
+
+function getIpcSenderOptions() {
+  return {
+    isDevelopment: process.env.NODE_ENV === 'development',
+    packagedRoot: path.join(__dirname, 'web-dist'),
+    devServerUrl: 'http://localhost:18181',
+  };
+}
 
 // 确定正确的配置文件路径
 // 在生产环境中，优先从exe所在目录查找.env.local文件
@@ -75,20 +93,6 @@ const envPath = path.join(__dirname, '.env');
 // 加载环境变量
 require('dotenv').config({ path: envLocalPath });
 require('dotenv').config({ path: envPath });
-
-function getIpcSenderOptions() {
-  return {
-    isDevelopment: process.env.NODE_ENV === 'development',
-    packagedRoot: path.join(__dirname, 'web-dist'),
-    devServerUrl: 'http://localhost:18181',
-  };
-}
-
-const streamRegistry = createStreamRegistry();
-
-
-
-
 
 const {
   PreferenceService,
@@ -346,114 +350,24 @@ async function initializePreferenceService(storageProvider) {
 }
 
 function setupPreferenceHandlers() {
-  ipcMain.handle('preference-get', async (event, key, defaultValue) => {
-    try {
-      const value = await preferenceService.get(key, defaultValue);
-      return createSuccessResponse(value);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('preference-set', async (event, key, value) => {
-    try {
-      await preferenceService.set(key, value);
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('preference-delete', async (event, key) => {
-    try {
-      await preferenceService.delete(key);
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('preference-keys', async () => {
-    try {
-      const result = await preferenceService.keys();
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('preference-clear', async () => {
-    try {
-      await preferenceService.clear();
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('preference-getAll', async (event) => {
-    try {
-      const result = await preferenceService.getAll();
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  // Preference Import/Export Data handlers (for bulk operations)
-  ipcMain.handle('preference-exportData', async (event) => {
-    try {
-      const result = await preferenceService.exportData();
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('preference-importData', async (event, data) => {
-    try {
-      // 清理Vue响应式对象，防止IPC序列化错误
-      const safeData = safeSerialize(data);
-      await preferenceService.importData(safeData);
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('preference-getDataType', async (event) => {
-    try {
-      const result = preferenceService.getDataType();
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('preference-validateData', async (event, data) => {
-    try {
-      // 清理Vue响应式对象，防止IPC序列化错误
-      const safeData = safeSerialize(data);
-      const result = await preferenceService.validateData(safeData);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
+  // 将偏好设置 IPC 委托给独立后端 module。
+  registerPreferenceIpcHandlers({
+    ipcMain,
+    preferenceService,
+    safeSerialize,
+    createSuccessResponse,
+    createErrorResponse,
   });
 }
 
-// 构建注入到渲染进程的运行时配置脚本（双份键：带前缀与不带前缀）
+// 构建注入到渲染进程的公共运行时配置脚本（双份键：带前缀与不带前缀）。
 function buildRuntimeConfigScriptFromEnv() {
   try {
     const publicConfig = getPublicRuntimeConfig(process.env);
-    const publicCount = Object.keys(publicConfig).filter((key) => key.startsWith('VITE_')).length;
 
-    return `// Injected by Electron main process
-`
-      + `window.runtime_config = Object.assign({}, (window.runtime_config || {}), ${JSON.stringify(publicConfig)});
-`
-      + `console.log('[Main Process] runtime_config injected with ${publicCount} public VITE_* vars (dual keys)');
-`;
+    return `// Injected by Electron main process\n`
+      + `window.runtime_config = Object.assign({}, (window.runtime_config || {}), ${JSON.stringify(publicConfig)});\n`
+      + `console.log('[Main Process] runtime_config injected with ${Object.keys(publicConfig).length / 2} public VITE_* vars (dual keys)');\n`;
   } catch (e) {
     return `console.warn('[Main Process] Failed to build runtime_config:', ${JSON.stringify(String(e))});`;
   }
@@ -495,6 +409,13 @@ function createWindow() {
     },
   });
 
+  installMainFrameNavigationGuard(mainWindow.webContents, {
+    isDevelopment: process.env.NODE_ENV === 'development',
+    packagedRoot: path.join(__dirname, 'web-dist'),
+    devServerUrl: 'http://localhost:18181',
+    openExternal: (url) => shell.openExternal(url),
+  });
+
   const handlePageZoomAction = (action, targetWebContents = mainWindow?.webContents) => {
     applyPageZoomAction(targetWebContents, action);
   };
@@ -507,12 +428,6 @@ function createWindow() {
       })
     )
   );
-
-  installMainFrameNavigationGuard(mainWindow.webContents, {
-    ...getIpcSenderOptions(),
-    openExternal: (url) => shell.openExternal(url),
-  });
-
   mainWindow.webContents.setZoomLevel(DEFAULT_PAGE_ZOOM_LEVEL);
   void mainWindow.webContents
     .setVisualZoomLevelLimits(VISUAL_ZOOM_LIMITS.minimum, VISUAL_ZOOM_LIMITS.maximum)
@@ -751,7 +666,6 @@ async function initializeServices() {
     console.log('[DESKTOP] Creating LLM service...');
     llmService = createLLMService(modelManager);
 
-    console.log('[DESKTOP] Creating image understanding service...');
     imageUnderstandingService = createImageUnderstandingService({
       imageInputConverter: convertImageInputWithElectronNativeImage,
     });
@@ -894,41 +808,37 @@ function createDetailedErrorResponse(error) {
   return { success: false, error: detailedMessage };
 }
 
-function formatFavoriteError(error) {
-  if (!error || typeof error !== 'object') {
-    return { message: String(error || 'Unknown error'), code: 'UNKNOWN_ERROR' };
-  }
-
-  const formatted = {
-    message: error.message || 'Unknown error',
-    code: error.code || 'UNKNOWN_ERROR',
-    name: error.name || 'Error'
-  };
-
-  if (error.details) {
-    formatted.details = error.details;
-  }
-
-  if (error.cause) {
-    formatted.cause = {
-      message: error.cause.message || String(error.cause),
-      code: error.cause.code,
-      name: error.cause.name
-    };
-  }
-
-  return formatted;
-}
-
-function createFavoriteErrorResponse(error) {
-  console.error('[Favorite IPC Error]', error);
-  return { success: false, error: formatFavoriteError(error) };
-}
-
 // --- High-Level IPC Service Handlers ---
+// 自动更新 handlers 依赖 main 可变状态，通过 getter/setter 注入。
+const { setupUpdateHandlers } = createUpdateHandlers({
+  get preferenceService() { return preferenceService; },
+  get mainWindow() { return mainWindow; },
+  get isUpdaterQuitting() { return isUpdaterQuitting; },
+  set isUpdaterQuitting(value) { isUpdaterQuitting = value; },
+  ipcMain,
+  autoUpdater,
+  app,
+  path,
+  createSuccessResponse,
+  createErrorResponse,
+  createDetailedErrorResponse,
+  DEFAULT_CONFIG,
+  IPC_EVENTS,
+  PREFERENCE_KEYS,
+  validateVersion,
+  buildReleaseUrl,
+  getRepositoryInfo,
+});
+
 function setupIPC() {
   console.log('[Main Process] Setting up high-level service IPC handlers...');
-  /** Trusted-sender IPC registration for high-sensitivity channels. */
+  setupPreferenceHandlers();
+  setupRemoteStorageHandlers(ipcMain, {
+    createSuccessResponse,
+    createErrorResponse,
+  });
+  
+  /** 注册需要可信 sender、参数校验和统一响应信封的 IPC handler。 */
   const registerSensitiveIpc = (channel, handler, validateArgs) => {
     registerSecureIpcHandler(ipcMain, channel, handler, {
       senderOptions: getIpcSenderOptions(),
@@ -938,302 +848,38 @@ function setupIPC() {
     });
   };
 
-  setupPreferenceHandlers();
-  setupRemoteStorageHandlers(ipcMain, {
+  // 集中执行 sender 绑定流任务，确保结束、异常和取消都会清理注册表。
+  const runOwnedStream = createOwnedStreamRunner({ streamRegistry });
+
+  // 将 LLM 与取消通道注册委托给独立后端 module，main.js 只负责依赖装配。
+  registerLlmIpcHandlers({
+    registerSensitiveIpc,
+    llmService,
+    streamRegistry,
+    runOwnedStream,
+  });
+
+  // 将 Prompt 流式通道注册委托给独立后端 module，保持现有 renderer interface 不变。
+  registerPromptStreamIpcHandlers({
+    registerSensitiveIpc,
+    promptService,
+    runOwnedStream,
+  });
+
+  // 将 Prompt 同步接口委托给独立后端 module；流式接口由 prompt-stream-handlers 负责。
+  registerPromptSyncIpcHandlers({
+    ipcMain,
+    promptService,
+    historyManager,
     createSuccessResponse,
     createErrorResponse,
   });
-  
-  // LLM Service handlers
-  ipcMain.handle('llm-testConnection', async (event, provider) => {
-    try {
-      await llmService.testConnection(provider);
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
+
+  // multimodal evaluation：图像理解走主进程，避免 renderer 直连供应商。
+  registerSensitiveIpc('image-understanding-understand', async (_event, request) => {
+    return imageUnderstandingService.understand(safeSerialize(request));
   });
 
-  ipcMain.handle('llm-sendMessage', async (event, messages, provider) => {
-    try {
-      const result = await llmService.sendMessage(messages, provider);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('llm-sendMessageStructured', async (event, messages, provider) => {
-    try {
-      const result = await llmService.sendMessageStructured(messages, provider);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('llm-fetchModelList', async (event, provider, customConfig) => {
-    try {
-      const result = await llmService.fetchModelList(provider, customConfig);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('image-understanding-understand', async (event, request) => {
-    try {
-      const result = await imageUnderstandingService.understand(safeSerialize(request));
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  // Streaming handler - more complex due to callbacks
-  
-  ipcMain.handle('stream-cancel', async (event, streamId) => {
-    try {
-      streamRegistry.cancel(event.sender, streamId);
-      return createSuccessResponse(true);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('llm-sendMessageStream', async (event, messages, provider, streamId) => {
-    try {
-      const stream = streamRegistry.register(event.sender, streamId);
-      // 使用符合 StreamHandlers 接口的回调名称
-      const callbacks = {
-        onToken: (token) => {
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            event.sender.send(`stream-content-${streamId}`, token);
-          }
-        },
-        onReasoningToken: (thinking) => {
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            event.sender.send(`stream-thinking-${streamId}`, thinking);
-          }
-        },
-        onComplete: () => {
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            event.sender.send(`stream-finish-${streamId}`);
-          }
-        },
-        onError: (error) => {
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            event.sender.send(`stream-error-${streamId}`, error.message);
-          }
-        }
-      };
-
-      await llmService.sendMessageStream(messages, provider, callbacks, { signal: stream.signal });
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createErrorResponse(error);
-    } finally {
-      streamRegistry.complete(event.sender, streamId);
-    }
-  });
-
-  // Streaming handler with tools - supports tool-call events
-  ipcMain.handle('llm-sendMessageStreamWithTools', async (event, messages, provider, tools, streamId) => {
-    try {
-      const stream = streamRegistry.register(event.sender, streamId);
-      const callbacks = {
-        onToken: (token) => {
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            event.sender.send(`stream-content-${streamId}`, token);
-          }
-        },
-        onReasoningToken: (thinking) => {
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            event.sender.send(`stream-thinking-${streamId}`, thinking);
-          }
-        },
-        onToolCall: (toolCall) => {
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            event.sender.send(`stream-tool-call-${streamId}`, toolCall);
-          }
-        },
-        onComplete: () => {
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            event.sender.send(`stream-finish-${streamId}`);
-          }
-        },
-        onError: (error) => {
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            event.sender.send(`stream-error-${streamId}`, error.message);
-          }
-        }
-      };
-
-      await llmService.sendMessageStreamWithTools(messages, provider, tools, callbacks, { signal: stream.signal });
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createErrorResponse(error);
-    } finally {
-      streamRegistry.complete(event.sender, streamId);
-    }
-  });
-
-  // Prompt Service handlers
-  ipcMain.handle('prompt-optimizePrompt', async (event, request) => {
-    try {
-      const result = await promptService.optimizePrompt(request);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('prompt-optimizeMessage', async (event, request) => {
-    try {
-      const result = await promptService.optimizeMessage(request);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('prompt-iteratePrompt', async (event, originalPrompt, lastOptimizedPrompt, iterateInput, modelKey, templateId, contextData) => {
-    try {
-      const result = await promptService.iteratePrompt(originalPrompt, lastOptimizedPrompt, iterateInput, modelKey, templateId, contextData);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('prompt-testPrompt', async (event, systemPrompt, userPrompt, modelKey, inputImages) => {
-    try {
-      const result = await promptService.testPrompt(systemPrompt, userPrompt, modelKey, inputImages);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('prompt-getHistory', async () => {
-    try {
-      const result = await historyManager.getHistory();
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('prompt-getIterationChain', async (event, recordId) => {
-    try {
-      const result = await historyManager.getIterationChain(recordId);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  // Helper for creating stream handlers that send data to the renderer process
-  const createIpcStreamHandlers = (window, streamId) => ({
-    onToken: (token) => {
-      if (window && !window.isDestroyed()) {
-        window.webContents.send(`stream-token-${streamId}`, token);
-      }
-    },
-    onReasoningToken: (token) => {
-      if (window && !window.isDestroyed()) {
-        window.webContents.send(`stream-reasoning-token-${streamId}`, token);
-      }
-    },
-    onToolCall: (toolCall) => {
-      // 工具调用事件单独通道
-      if (window && !window.isDestroyed()) {
-        window.webContents.send(`stream-tool-call-${streamId}`, toolCall);
-      }
-    },
-    onComplete: () => {
-      if (window && !window.isDestroyed()) {
-        window.webContents.send(`stream-finish-${streamId}`);
-      }
-    },
-    onError: (error) => {
-      if (window && !window.isDestroyed()) {
-        window.webContents.send(`stream-error-${streamId}`, error.message);
-      }
-    },
-  });
-
-  ipcMain.handle('prompt-optimizePromptStream', async (event, request, streamId) => {
-    const streamHandlers = createIpcStreamHandlers(mainWindow, streamId);
-    try {
-      const stream = streamRegistry.register(event.sender, streamId);
-      await promptService.optimizePromptStream(request, streamHandlers, { signal: stream.signal });
-      return createSuccessResponse(null);
-    } catch (error) {
-      streamHandlers.onError(error);
-      return createErrorResponse(error);
-    } finally {
-      streamRegistry.complete(event.sender, streamId);
-    }
-  });
-
-  ipcMain.handle('prompt-optimizeMessageStream', async (event, request, streamId) => {
-    const streamHandlers = createIpcStreamHandlers(mainWindow, streamId);
-    try {
-      const stream = streamRegistry.register(event.sender, streamId);
-      await promptService.optimizeMessageStream(request, streamHandlers, { signal: stream.signal });
-      return createSuccessResponse(null);
-    } catch (error) {
-      streamHandlers.onError(error);
-      return createErrorResponse(error);
-    } finally {
-      streamRegistry.complete(event.sender, streamId);
-    }
-  });
-
-  ipcMain.handle('prompt-iteratePromptStream', async (event, originalPrompt, lastOptimizedPrompt, iterateInput, modelKey, templateId, streamId, contextData) => {
-    const streamHandlers = createIpcStreamHandlers(mainWindow, streamId);
-    try {
-      const stream = streamRegistry.register(event.sender, streamId);
-      await promptService.iteratePromptStream(
-        originalPrompt,
-        lastOptimizedPrompt,
-        iterateInput,
-        modelKey,
-        streamHandlers,
-        templateId,
-        contextData,
-        { signal: stream.signal },
-      );
-      return createSuccessResponse(null);
-    } catch (error) {
-      streamHandlers.onError(error);
-      return createErrorResponse(error);
-    } finally {
-      streamRegistry.complete(event.sender, streamId);
-    }
-  });
-
-  ipcMain.handle('prompt-testPromptStream', async (event, systemPrompt, userPrompt, modelKey, streamId, inputImages) => {
-    const streamHandlers = createIpcStreamHandlers(mainWindow, streamId);
-    try {
-      const stream = streamRegistry.register(event.sender, streamId);
-      await promptService.testPromptStream(
-        systemPrompt,
-        userPrompt,
-        modelKey,
-        streamHandlers,
-        inputImages,
-        { signal: stream.signal },
-      );
-      return createSuccessResponse(null);
-    } catch (error) {
-      streamHandlers.onError(error);
-      return createErrorResponse(error);
-    } finally {
-      streamRegistry.complete(event.sender, streamId);
-    }
-  });
 
   // 在页面加载前拦截 /config.js 并注入运行时环境变量（双份键）
   try {
@@ -1254,1117 +900,87 @@ function setupIPC() {
     console.warn('[Main Process] Unable to register runtime config interceptor:', e);
   }
 
-  // 自定义会话测试（支持工具、变量、对话消息）
-  ipcMain.handle('prompt-testCustomConversationStream', async (event, request, streamId) => {
-    const streamHandlers = createIpcStreamHandlers(mainWindow, streamId);
-    try {
-      const stream = streamRegistry.register(event.sender, streamId);
-      await promptService.testCustomConversationStream(
-        request,
-        streamHandlers,
-        { signal: stream.signal },
-      );
-      return createSuccessResponse(null);
-    } catch (error) {
-      streamHandlers.onError(error);
-      return createErrorResponse(error);
-    } finally {
-      streamRegistry.complete(event.sender, streamId);
-    }
-  });
-
-  // Model Manager handlers
-  ipcMain.handle('model-getModels', async (event) => {
-    try {
-      const result = await modelManager.getAllModels();
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('model-addModel', async (event, model) => {
-    try {
-      // 清理Vue响应式对象，防止IPC序列化错误
-      const safeModel = safeSerialize(model);
-      // model应该包含key和config，需要分离
-      const { key, ...config } = safeModel;
-      await modelManager.addModel(key, config);
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('model-updateModel', async (event, id, updates) => {
-    try {
-      // 清理Vue响应式对象，防止IPC序列化错误
-      const safeUpdates = safeSerialize(updates);
-      await modelManager.updateModel(id, safeUpdates);
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('model-deleteModel', async (event, id) => {
-    try {
-      await modelManager.deleteModel(id);
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('model-ensureInitialized', async () => {
-    try {
-      await modelManager.ensureInitialized();
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('model-isInitialized', async () => {
-    try {
-      const result = await modelManager.isInitialized();
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('model-getAllModels', async () => {
-    try {
-      const result = await modelManager.getAllModels();
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('model-getEnabledModels', async (event) => {
-    try {
-      const result = await modelManager.getEnabledModels();
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  // Model Import/Export Data handlers (for bulk operations)
-  ipcMain.handle('model-exportData', async (event) => {
-    try {
-      const result = await modelManager.exportData();
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  // ===== Image Model handlers (Config-centric) =====
-  ipcMain.handle('image-model-ensureInitialized', async () => {
-    try { await imageModelManager.ensureInitialized(); return createSuccessResponse(null) }
-    catch (error) { return createErrorResponse(error) }
-  })
-  ipcMain.handle('image-model-isInitialized', async () => {
-    try { const r = await imageModelManager.isInitialized(); return createSuccessResponse(r) }
-    catch (error) { return createErrorResponse(error) }
-  })
-  ipcMain.handle('image-model-getAllConfigs', async () => {
-    try { const r = await imageModelManager.getAllConfigs(); return createSuccessResponse(r) }
-    catch (error) { return createErrorResponse(error) }
-  })
-  ipcMain.handle('image-model-getConfig', async (e, id) => {
-    try { const r = await imageModelManager.getConfig(id); return createSuccessResponse(r) }
-    catch (error) { return createErrorResponse(error) }
-  })
-  ipcMain.handle('image-model-addConfig', async (e, config) => {
-    try { const safeCfg = safeSerialize(config); await imageModelManager.addConfig(safeCfg); return createSuccessResponse(null) }
-    catch (error) { return createErrorResponse(error) }
-  })
-  ipcMain.handle('image-model-updateConfig', async (e, id, updates) => {
-    try { const safe = safeSerialize(updates); await imageModelManager.updateConfig(id, safe); return createSuccessResponse(null) }
-    catch (error) { return createErrorResponse(error) }
-  })
-  ipcMain.handle('image-model-deleteConfig', async (e, id) => {
-    try { await imageModelManager.deleteConfig(id); return createSuccessResponse(null) }
-    catch (error) { return createErrorResponse(error) }
-  })
-  ipcMain.handle('image-model-getEnabledConfigs', async () => {
-    try { const r = await imageModelManager.getEnabledConfigs(); return createSuccessResponse(r) }
-    catch (error) { return createErrorResponse(error) }
-  })
-  ipcMain.handle('image-model-exportData', async () => {
-    try { const r = await imageModelManager.exportData(); return createSuccessResponse(r) }
-    catch (error) { return createErrorResponse(error) }
-  })
-  ipcMain.handle('image-model-importData', async (e, data) => {
-    try { const safe = safeSerialize(data); await imageModelManager.importData(safe); return createSuccessResponse(null) }
-    catch (error) { return createErrorResponse(error) }
-  })
-  ipcMain.handle('image-model-getDataType', async () => {
-    try { const r = await imageModelManager.getDataType(); return createSuccessResponse(r) }
-    catch (error) { return createErrorResponse(error) }
-  })
-  ipcMain.handle('image-model-validateData', async (e, data) => {
-    try { const safe = safeSerialize(data); const r = await imageModelManager.validateData(safe); return createSuccessResponse(r) }
-    catch (error) { return createErrorResponse(error) }
-  })
-
-  // ===== Image Service handlers =====
-  ipcMain.handle('image-generate', async (e, request) => {
-    try {
-      const safeReq = safeSerialize(request)
-      const res = await imageService.generate(safeReq)
-      return createSuccessResponse(res)
-    } catch (error) {
-      return createStructuredErrorResponse(error)
-    }
-  })
-
-  // 显式模式：避免根据 inputImage 是否存在隐式推断
-  ipcMain.handle('image-generateText2Image', async (e, request) => {
-    try {
-      const safeReq = safeSerialize(request)
-      const res = await imageService.generateText2Image(safeReq)
-      return createSuccessResponse(res)
-    } catch (error) {
-      return createStructuredErrorResponse(error)
-    }
-  })
-
-  ipcMain.handle('image-generateImage2Image', async (e, request) => {
-    try {
-      const safeReq = safeSerialize(request)
-      const res = await imageService.generateImage2Image(safeReq)
-      return createSuccessResponse(res)
-    } catch (error) {
-      return createStructuredErrorResponse(error)
-    }
-  })
-
-  ipcMain.handle('image-generateMultiImage', async (e, request) => {
-    try {
-      const safeReq = safeSerialize(request)
-      const res = await imageService.generateMultiImage(safeReq)
-      return createSuccessResponse(res)
-    } catch (error) {
-      return createStructuredErrorResponse(error)
-    }
-  })
-
-  ipcMain.handle('image-validateRequest', async (e, request) => {
-    try {
-      const safeReq = safeSerialize(request)
-      const res = await imageService.validateRequest(safeReq)
-      return createSuccessResponse(res)
-    } catch (error) {
-      return createStructuredErrorResponse(error)
-    }
-  })
-
-  ipcMain.handle('image-validateText2ImageRequest', async (e, request) => {
-    try {
-      const safeReq = safeSerialize(request)
-      const res = await imageService.validateText2ImageRequest(safeReq)
-      return createSuccessResponse(res)
-    } catch (error) {
-      return createStructuredErrorResponse(error)
-    }
-  })
-
-  ipcMain.handle('image-validateImage2ImageRequest', async (e, request) => {
-    try {
-      const safeReq = safeSerialize(request)
-      const res = await imageService.validateImage2ImageRequest(safeReq)
-      return createSuccessResponse(res)
-    } catch (error) {
-      return createStructuredErrorResponse(error)
-    }
-  })
-
-  ipcMain.handle('image-validateMultiImageRequest', async (e, request) => {
-    try {
-      const safeReq = safeSerialize(request)
-      const res = await imageService.validateMultiImageRequest(safeReq)
-      return createSuccessResponse(res)
-    } catch (error) {
-      return createStructuredErrorResponse(error)
-    }
-  })
-
-  // 新增：连接测试（在主进程执行，避免渲染端网络请求）
-  ipcMain.handle('image-testConnection', async (e, config) => {
-    try {
-      const safeCfg = safeSerialize(config)
-      // Reuse ImageService.testConnection to keep behavior consistent with Web:
-      // - merges param overrides
-      // - enforces base64-only input for image2image tests
-      const result = await imageService.testConnection(safeCfg)
-      return createSuccessResponse(result)
-    } catch (error) {
-      return createStructuredErrorResponse(error)
-    }
-  })
-
-  // 新增：动态模型拉取（在主进程执行）
-  ipcMain.handle('image-getDynamicModels', async (e, providerId, connectionConfig) => {
-    try {
-      const safeConn = safeSerialize(connectionConfig)
-      const models = await imageAdapterRegistry.getDynamicModels(providerId, safeConn)
-      return createSuccessResponse(models)
-    } catch (error) {
-      return createStructuredErrorResponse(error)
-    }
-  })
-
-  ipcMain.handle('model-importData', async (event, data) => {
-    try {
-      // 清理Vue响应式对象，防止IPC序列化错误
-      const safeData = safeSerialize(data);
-      await modelManager.importData(safeData);
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('model-getDataType', async (event) => {
-    try {
-      const result = modelManager.getDataType();
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('model-validateData', async (event, data) => {
-    try {
-      // 清理Vue响应式对象，防止IPC序列化错误
-      const safeData = safeSerialize(data);
-      const result = await modelManager.validateData(safeData);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  // Template Manager handlers
-  ipcMain.handle('template-getTemplates', async (event) => {
-    try {
-      const result = await templateManager.listTemplates();
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('template-getTemplate', async (event, id) => {
-    try {
-      const result = await templateManager.getTemplate(id);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('template-createTemplate', async (event, template) => {
-    try {
-      // 清理Vue响应式对象，防止IPC序列化错误
-      const safeTemplate = safeSerialize(template);
-      await templateManager.saveTemplate(safeTemplate);
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('template-updateTemplate', async (event, id, updates) => {
-    try {
-      // Get existing template and merge with updates
-      const existingTemplate = await templateManager.getTemplate(id);
-      // 清理Vue响应式对象，防止IPC序列化错误
-      const safeUpdates = safeSerialize(updates);
-      const updatedTemplate = { ...existingTemplate, ...safeUpdates, id };
-      await templateManager.saveTemplate(updatedTemplate);
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('template-deleteTemplate', async (event, id) => {
-    try {
-      await templateManager.deleteTemplate(id);
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('template-listTemplatesByType', async (event, type) => {
-    try {
-      const result = await templateManager.listTemplatesByType(type);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  // Template Import/Export handlers
-  ipcMain.handle('template-exportTemplate', async (event, id) => {
-    try {
-      const result = await templateManager.exportTemplate(id);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('template-importTemplate', async (event, jsonString) => {
-    try {
-      await templateManager.importTemplate(jsonString);
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  // Template Import/Export Data handlers (for bulk operations)
-  ipcMain.handle('template-exportData', async (event) => {
-    try {
-      const result = await templateManager.exportData();
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('template-importData', async (event, data) => {
-    try {
-      // 清理Vue响应式对象，防止IPC序列化错误
-      const safeData = safeSerialize(data);
-      await templateManager.importData(safeData);
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('template-getDataType', async (event) => {
-    try {
-      const result = templateManager.getDataType();
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('template-validateData', async (event, data) => {
-    try {
-      // 清理Vue响应式对象，防止IPC序列化错误
-      const safeData = safeSerialize(data);
-      const result = templateManager.validateData(safeData);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  // Template language handlers
-  ipcMain.handle('template-changeBuiltinTemplateLanguage', async (event, language) => {
-    try {
-      await templateManager.changeBuiltinTemplateLanguage(language);
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('template-getCurrentBuiltinTemplateLanguage', async (event) => {
-    try {
-      const result = await templateManager.getCurrentBuiltinTemplateLanguage();
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('template-getSupportedBuiltinTemplateLanguages', async (event) => {
-    try {
-      const result = await templateManager.getSupportedBuiltinTemplateLanguages();
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('template-getSupportedLanguages', async (event, template) => {
-    try {
-      const result = templateManager.getSupportedLanguages(template);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  // History Manager handlers
-  ipcMain.handle('history-getHistory', async (event) => {
-    try {
-      const result = await historyManager.getRecords();
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('history-addRecord', async (event, record) => {
-    try {
-      // 清理Vue响应式对象，防止IPC序列化错误
-      const safeRecord = safeSerialize(record);
-      const result = await historyManager.addRecord(safeRecord);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('history-deleteRecord', async (event, id) => {
-    try {
-      await historyManager.deleteRecord(id);
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('history-clearHistory', async (event) => {
-    try {
-      await historyManager.clearHistory();
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  // 添加缺失的历史记录链功能
-  ipcMain.handle('history-getIterationChain', async (event, recordId) => {
-    try {
-      const result = await historyManager.getIterationChain(recordId);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('history-getAllChains', async (event) => {
-    try {
-      const result = await historyManager.getAllChains();
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('history-getChain', async (event, chainId) => {
-    try {
-      const result = await historyManager.getChain(chainId);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('history-createNewChain', async (event, record) => {
-    try {
-      // 清理Vue响应式对象，防止IPC序列化错误
-      const safeRecord = safeSerialize(record);
-      const result = await historyManager.createNewChain(safeRecord);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('history-addIteration', async (event, params) => {
-    try {
-      // 清理Vue响应式对象，防止IPC序列化错误
-      const safeParams = safeSerialize(params);
-      const result = await historyManager.addIteration(safeParams);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('history-deleteChain', async (event, chainId) => {
-    try {
-      await historyManager.deleteChain(chainId);
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  // History Import/Export Data handlers (for bulk operations)
-  ipcMain.handle('history-exportData', async (event) => {
-    try {
-      const result = await historyManager.exportData();
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('history-importData', async (event, data) => {
-    try {
-      // 清理Vue响应式对象，防止IPC序列化错误
-      const safeData = safeSerialize(data);
-      await historyManager.importData(safeData);
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('history-getDataType', async (event) => {
-    try {
-      const result = historyManager.getDataType();
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('history-validateData', async (event, data) => {
-    try {
-      // 清理Vue响应式对象，防止IPC序列化错误
-      const safeData = safeSerialize(data);
-      const result = await historyManager.validateData(safeData);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  // Context Repository handlers
-  ipcMain.handle('context-list', async (event) => {
-    try {
-      const result = await contextRepo.list();
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('context-getCurrentId', async (event) => {
-    try {
-      const result = await contextRepo.getCurrentId();
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('context-setCurrentId', async (event, id) => {
-    try {
-      await contextRepo.setCurrentId(id);
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('context-get', async (event, id) => {
-    try {
-      const result = await contextRepo.get(id);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('context-create', async (event, meta) => {
-    try {
-      const safeMeta = meta ? safeSerialize(meta) : undefined;
-      const result = await contextRepo.create(safeMeta);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('context-duplicate', async (event, id, options) => {
-    try {
-      const safeOptions = options ? safeSerialize(options) : undefined;
-      const result = await contextRepo.duplicate(id, safeOptions);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('context-rename', async (event, id, title) => {
-    try {
-      await contextRepo.rename(id, title);
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('context-save', async (event, ctx) => {
-    try {
-      const safeCtx = safeSerialize(ctx);
-      await contextRepo.save(safeCtx);
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('context-update', async (event, id, patch) => {
-    try {
-      const safePatch = safeSerialize(patch);
-      await contextRepo.update(id, safePatch);
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('context-remove', async (event, id) => {
-    try {
-      await contextRepo.remove(id);
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('context-exportAll', async (event) => {
-    try {
-      const result = await contextRepo.exportAll();
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('context-importAll', async (event, bundle, mode) => {
-    try {
-      const safeBundle = safeSerialize(bundle);
-      const result = await contextRepo.importAll(safeBundle, mode);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('context-exportData', async (event) => {
-    try {
-      const result = await contextRepo.exportData();
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('context-importData', async (event, data) => {
-    try {
-      const safeData = safeSerialize(data);
-      await contextRepo.importData(safeData);
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('context-getDataType', async (event) => {
-    try {
-      const result = contextRepo.getDataType();
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('context-validateData', async (event, data) => {
-    try {
-      const safeData = safeSerialize(data);
-      const result = await contextRepo.validateData(safeData);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  // Favorite Manager handlers
-  ipcMain.handle('favorite-addFavorite', async (event, favorite) => {
-    try {
-      const safeFavorite = safeSerialize(favorite);
-      const result = await favoriteManager.addFavorite(safeFavorite);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createFavoriteErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('favorite-getFavorites', async (event, options) => {
-    try {
-      const safeOptions = safeSerialize(options);
-      const result = await favoriteManager.getFavorites(safeOptions || undefined);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createFavoriteErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('favorite-getFavorite', async (event, id) => {
-    try {
-      const result = await favoriteManager.getFavorite(id);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createFavoriteErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('favorite-updateFavorite', async (event, id, updates) => {
-    try {
-      const safeUpdates = safeSerialize(updates);
-      await favoriteManager.updateFavorite(id, safeUpdates);
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createFavoriteErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('favorite-setFavoritePromptAssetCurrentVersion', async (event, id, versionId) => {
-    try {
-      await favoriteManager.setFavoritePromptAssetCurrentVersion(id, versionId);
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createFavoriteErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('favorite-deleteFavoritePromptAssetVersion', async (event, id, versionId) => {
-    try {
-      await favoriteManager.deleteFavoritePromptAssetVersion(id, versionId);
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createFavoriteErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('favorite-deleteFavorite', async (event, id) => {
-    try {
-      await favoriteManager.deleteFavorite(id);
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createFavoriteErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('favorite-deleteFavorites', async (event, ids) => {
-    try {
-      const safeIds = safeSerialize(ids);
-      await favoriteManager.deleteFavorites(safeIds);
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createFavoriteErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('favorite-incrementUseCount', async (event, id) => {
-    try {
-      await favoriteManager.incrementUseCount(id);
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createFavoriteErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('favorite-getCategories', async () => {
-    try {
-      const result = await favoriteManager.getCategories();
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createFavoriteErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('favorite-addCategory', async (event, category) => {
-    try {
-      const safeCategory = safeSerialize(category);
-      const result = await favoriteManager.addCategory(safeCategory);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createFavoriteErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('favorite-updateCategory', async (event, id, updates) => {
-    try {
-      const safeUpdates = safeSerialize(updates);
-      await favoriteManager.updateCategory(id, safeUpdates);
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createFavoriteErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('favorite-deleteCategory', async (event, id) => {
-    try {
-      const result = await favoriteManager.deleteCategory(id);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createFavoriteErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('favorite-getStats', async () => {
-    try {
-      const result = await favoriteManager.getStats();
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createFavoriteErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('favorite-searchFavorites', async (event, keyword, options) => {
-    try {
-      const safeOptions = safeSerialize(options);
-      const result = await favoriteManager.searchFavorites(keyword, safeOptions || undefined);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createFavoriteErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('favorite-exportFavorites', async (event, ids) => {
-    try {
-      const safeIds = safeSerialize(ids);
-      const result = await favoriteManager.exportFavorites(safeIds || undefined);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createFavoriteErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('favorite-importFavorites', async (event, data, options) => {
-    try {
-      const safeData = typeof data === 'string' ? data : safeSerialize(data);
-      const safeOptions = safeSerialize(options);
-      const result = await favoriteManager.importFavorites(safeData, safeOptions || undefined);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createFavoriteErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('favorite-getAllTags', async () => {
-    try {
-      const result = await favoriteManager.getAllTags();
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createFavoriteErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('favorite-addTag', async (event, tag) => {
-    try {
-      await favoriteManager.addTag(tag);
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createFavoriteErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('favorite-renameTag', async (event, oldTag, newTag) => {
-    try {
-      const result = await favoriteManager.renameTag(oldTag, newTag);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createFavoriteErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('favorite-mergeTags', async (event, sourceTags, targetTag) => {
-    try {
-      const safeSourceTags = safeSerialize(sourceTags);
-      const result = await favoriteManager.mergeTags(safeSourceTags, targetTag);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createFavoriteErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('favorite-deleteTag', async (event, tag) => {
-    try {
-      const result = await favoriteManager.deleteTag(tag);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createFavoriteErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('favorite-reorderCategories', async (event, categoryIds) => {
-    try {
-      const safeCategoryIds = safeSerialize(categoryIds);
-      await favoriteManager.reorderCategories(safeCategoryIds);
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createFavoriteErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('favorite-getCategoryUsage', async (event, categoryId) => {
-    try {
-      const result = await favoriteManager.getCategoryUsage(categoryId);
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createFavoriteErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('favorite-ensureDefaultCategories', async (event, defaultCategories) => {
-    try {
-      const safeCategories = safeSerialize(defaultCategories);
-      await favoriteManager.ensureDefaultCategories(safeCategories);
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createFavoriteErrorResponse(error);
-    }
-  });
-
-  // Data Manager handlers
-  ipcMain.handle('data-exportAllData', async (event) => {
-    try {
-      const result = await dataManager.exportAllData();
-      return createSuccessResponse(result);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('data-importAllData', async (event, dataString) => {
-    try {
-      await dataManager.importAllData(dataString);
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  // Desktop: storage helpers for Data Manager UI
-  ipcMain.handle('data-getStorageInfo', async () => {
-    try {
-      const userDataPath = app.getPath('userData');
-      const mainFilePath = path.join(userDataPath, 'prompt-optimizer-data.json');
-      const backupFilePath = path.join(userDataPath, 'prompt-optimizer-data.json.backup');
-
-      const statSafe = async (p) => {
-        try {
-          const s = await require('fs').promises.stat(p);
-          return typeof s?.size === 'number' ? s.size : 0;
-        } catch {
-          return 0;
-        }
-      };
-
-      const mainSizeBytes = await statSafe(mainFilePath);
-      const backupSizeBytes = await statSafe(backupFilePath);
-
-      return createSuccessResponse({
-        userDataPath,
-        mainFilePath,
-        mainSizeBytes,
-        backupFilePath,
-        backupSizeBytes,
-        totalBytes: mainSizeBytes + backupSizeBytes,
-      });
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('data-openStorageDirectory', async () => {
-    try {
-      const userDataPath = app.getPath('userData');
-      await shell.openPath(userDataPath);
-      return createSuccessResponse(true);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-
-
-  // 环境配置同步 - 主进程作为唯一配置源
-  // Secrets stay main-process-only; renderer receives explicit public keys only.
-  registerSensitiveIpc('config-getEnvironmentVariables', async () => {
-    const publicConfig = getPublicRuntimeConfig(process.env);
-    const publicCount = Object.keys(publicConfig).filter((key) => key.startsWith('VITE_')).length;
-    console.log(`[Main Process] Returning ${publicCount} public VITE_* variables (with no-prefix duplicates)`);
-    return publicConfig;
-  });
-
-  // 外部链接处理器
-  registerSensitiveIpc('shell-openExternal', async (_event, url) => {
-    console.log('[Main Process] Opening external URL:', url);
-    if (!isSafeExternalUrl(url)) {
-      throw createIpcError('IPC_UNSAFE_EXTERNAL_URL', 'Refusing to open unsafe external URL');
-    }
-    await shell.openExternal(url);
-    return true;
-  }, ([url]) => {
-    if (typeof url !== 'string' || url.length === 0 || url.length > 2048) {
-      throw createIpcError('IPC_INVALID_ARGUMENT', 'Invalid external URL');
-    }
-  });
-
-  // 应用信息处理器
-  ipcMain.handle('app-get-version', () => {
-    try {
-      const packageJson = require('./package.json');
-      return createSuccessResponse(packageJson.version);
-    } catch (error) {
-      console.error('[Main Process] Failed to get app version:', error);
-      return createErrorResponse(error);
-    }
-  });
-
-  // UI locale sync (renderer -> main)
-  // Used to localize Electron-only UI like context menus.
-  ipcMain.handle('app-set-locale', (_event, locale) => {
-    try {
-      uiLocale = normalizeUiLocale(locale) || 'en-US';
-      return createSuccessResponse(null);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  // 日志相关处理器
-  ipcMain.handle('logs-get-paths', () => {
-    try {
-      const paths = consoleLogger.getLogPaths();
-      return createSuccessResponse(paths);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  ipcMain.handle('logs-open-directory', async () => {
-    try {
-      const { logDir } = consoleLogger.getLogPaths();
-      await shell.openPath(logDir);
-      return createSuccessResponse(true);
-    } catch (error) {
-      return createErrorResponse(error);
-    }
+  // 将文本模型管理 IPC 委托给独立后端 module。
+  registerModelIpcHandlers({
+    ipcMain,
+    modelManager,
+    safeSerialize,
+    createSuccessResponse,
+    createErrorResponse,
+  });
+
+  // 将图像模型配置与图像生成 IPC 委托给独立后端 module。
+  registerImageIpcHandlers({
+    ipcMain,
+    imageModelManager,
+    imageService,
+    imageAdapterRegistry,
+    safeSerialize,
+    createSuccessResponse,
+    createErrorResponse,
+    createStructuredErrorResponse,
+  });
+
+  // 将模板管理 IPC 委托给独立后端 module。
+  registerTemplateIpcHandlers({
+    ipcMain,
+    templateManager,
+    safeSerialize,
+    createSuccessResponse,
+    createErrorResponse,
+  });
+
+  // 将历史记录 IPC 委托给独立后端 module。
+  registerHistoryIpcHandlers({
+    ipcMain,
+    historyManager,
+    safeSerialize,
+    createSuccessResponse,
+    createErrorResponse,
+  });
+
+  // 将会话上下文 IPC 委托给独立后端 module。
+  registerContextIpcHandlers({
+    ipcMain,
+    contextRepo,
+    safeSerialize,
+    createSuccessResponse,
+    createErrorResponse,
+  });
+
+  // 将收藏管理 IPC 委托给独立后端 module。
+  registerFavoriteIpcHandlers({
+    ipcMain,
+    favoriteManager,
+    safeSerialize,
+    createSuccessResponse,
+  });
+
+  // 将数据导入导出与本地存储信息 IPC 委托给独立后端 module。
+  registerDataIpcHandlers({
+    ipcMain,
+    dataManager,
+    app,
+    shell,
+    createSuccessResponse,
+    createErrorResponse,
+  });
+
+  // 将运行时配置、外链、应用信息与日志 IPC 委托给独立后端 module。
+  registerSystemIpcHandlers({
+    ipcMain,
+    shell,
+    consoleLogger,
+    registerSensitiveIpc,
+    getPublicRuntimeConfig,
+    isSafeExternalUrl,
+    createIpcError,
+    createSuccessResponse,
+    createErrorResponse,
+    setUiLocale: (locale) => {
+      uiLocale = locale;
+    },
+    normalizeUiLocale,
   });
 
   // 自动更新相关处理器
@@ -2464,877 +1080,3 @@ app.on('window-all-closed', function () {
   }
 });
 
-// 忽略版本管理辅助函数（全局作用域）
-const getIgnoredVersions = async () => {
-  try {
-    const ignoredVersions = await preferenceService.get(PREFERENCE_KEYS.IGNORED_VERSIONS, null);
-    if (ignoredVersions && typeof ignoredVersions === 'object') {
-      return ignoredVersions;
-    }
-    return { stable: null, prerelease: null };
-  } catch (error) {
-    console.warn('[Updater] Failed to read ignored versions, using defaults:', error);
-    return { stable: null, prerelease: null };
-  }
-};
-
-const isVersionIgnored = async (version) => {
-  const ignoredVersions = await getIgnoredVersions();
-  const versionType = version.includes('-') ? 'prerelease' : 'stable';
-
-  // 检查对应类型的忽略版本
-  if (versionType === 'stable' && ignoredVersions.stable === version) {
-    return true;
-  }
-  if (versionType === 'prerelease' && ignoredVersions.prerelease === version) {
-    return true;
-  }
-
-  return false;
-};
-
-// 自动更新处理器设置
-async function setupUpdateHandlers() {
-  console.log('[Main Process] Setting up auto-update handlers...');
-
-
-
-  // 更新操作状态锁，防止并发调用
-  let isCheckingForUpdate = false;
-  let isDownloadingUpdate = false;
-  let isInstallingUpdate = false;
-
-  // 配置更新器基本设置
-  autoUpdater.autoDownload = DEFAULT_CONFIG.autoDownload;
-  autoUpdater.allowPrerelease = DEFAULT_CONFIG.allowPrerelease;
-  autoUpdater.allowDowngrade = false; // 默认不允许降级，只在渠道切换时临时启用
-
-  // Resolve the repository once so the feed, delivery policy, and Release URLs
-  // cannot diverge when development repository overrides are enabled.
-  const {
-    packagedRepositoryInfo,
-    repositoryInfo: resolvedRepositoryInfo,
-    packagedRepositorySlug: defaultRepo,
-    repositorySlug: currentRepo,
-    shouldOverrideFeed,
-  } = resolveUpdateRepositoryConfig();
-  let repositoryInfo = resolvedRepositoryInfo;
-
-  // 如果环境变量中的仓库与默认仓库不同，使用setFeedURL动态配置
-  if (shouldOverrideFeed) {
-    try {
-      const { owner, repo } = repositoryInfo;
-
-      const feedConfig = {
-        provider: 'github',
-        owner,
-        repo,
-        private: false // 只支持公开仓库
-      };
-
-      console.log('[Updater] Using custom repository configuration:', {
-        owner,
-        repo,
-        private: false,
-        source: 'environment variables'
-      });
-
-      autoUpdater.setFeedURL(feedConfig);
-    } catch (configError) {
-      console.error('[Updater] Failed to configure custom repository:', configError);
-      console.log('[Updater] Falling back to default configuration');
-      repositoryInfo = packagedRepositoryInfo;
-    }
-  } else {
-    console.log('[Updater] Using default repository configuration:', defaultRepo || 'unknown');
-  }
-
-  // Main-process source of truth for how this effective repository can deliver updates.
-  // macOS remains check-only until release artifacts are Developer ID signed.
-  const updateDelivery = getUpdateDeliveryPolicy({ repositoryInfo });
-
-  // 开发模式下的更新检查配置
-  if (process.env.NODE_ENV === 'development' || !app.isPackaged) {
-    console.log('[Updater] Development mode detected');
-    
-    // 设置开发环境专用的日志器（官方推荐）
-    const log = require('electron-log');
-    autoUpdater.logger = log;
-    autoUpdater.logger.transports.file.level = 'debug';
-    autoUpdater.logger.transports.console.level = 'debug';
-    
-    // 为更新器创建专门的日志文件
-    const userDataPath = app.getPath('userData');
-    autoUpdater.logger.transports.file.resolvePathFn = () => 
-      path.join(userDataPath, 'logs', 'auto-updater.log');
-    
-    // 强制启用开发模式更新检查
-    autoUpdater.forceDevUpdateConfig = true;
-    
-    console.log('[Updater] Development mode configuration:');
-    console.log('[Updater] - forceDevUpdateConfig: true');
-    console.log('[Updater] - Looking for dev-app-update.yml in:', path.join(__dirname, 'dev-app-update.yml'));
-    console.log('[Updater] - dev-app-update.yml exists:', require('fs').existsSync(path.join(__dirname, 'dev-app-update.yml')));
-    
-    console.log('[Updater] Development mode update testing enabled');
-    console.log('[Updater] Auto-updater logs will be saved to:', path.join(userDataPath, 'logs', 'auto-updater.log'));
-  }
-
-  // 设置更新事件处理 - 仅在应用启动时设置一次
-  autoUpdater.on('update-available', async (info) => {
-    console.log('[Updater] Update available:', info);
-
-    try {
-      // 验证版本号格式
-      if (!validateVersion(info.version)) {
-        console.error('[Updater] Invalid version format:', info.version);
-        return;
-      }
-
-      // 检查版本是否被忽略
-      try {
-        const isIgnored = await isVersionIgnored(info.version);
-        if (isIgnored) {
-          console.log('[Updater] Ignoring version:', info.version);
-          return;
-        }
-      } catch (prefError) {
-        console.warn('[Updater] Failed to check ignored versions, continuing with update check:', prefError);
-        // 继续执行，不阻断更新流程
-      }
-
-      // 构建安全的GitHub Release页面链接
-      let releaseUrl;
-      try {
-        releaseUrl = buildReleaseUrl(info.version, repositoryInfo);
-      } catch (urlError) {
-        console.error('[Updater] Failed to build release URL:', urlError);
-        // 使用fallback URL或跳过URL
-        releaseUrl = null;
-      }
-
-      // 发送更新可用通知到UI
-      if (mainWindow && !mainWindow.isDestroyed()) {
-        mainWindow.webContents.send(IPC_EVENTS.UPDATE_AVAILABLE_INFO, {
-          version: info.version,
-          releaseDate: info.releaseDate,
-          releaseNotes: info.releaseNotes,
-          releaseUrl: releaseUrl
-        });
-      }
-    } catch (error) {
-      console.error('[Updater] Critical error in update-available handler:', error);
-      // 即使出错也要通知用户有更新可用，但不包含详细信息
-      if (mainWindow && !mainWindow.isDestroyed()) {
-        mainWindow.webContents.send(IPC_EVENTS.UPDATE_AVAILABLE_INFO, {
-          version: info.version || 'Unknown',
-          releaseDate: info.releaseDate || null,
-          releaseNotes: null,
-          releaseUrl: null,
-          error: 'Failed to process update information'
-        });
-      }
-    }
-  });
-
-  autoUpdater.on('update-not-available', (info) => {
-    console.log('[Updater] No update available:', info);
-    // 注意：现在这个事件监听器主要用于日志记录
-    // 实际的UI更新逻辑已经移到前端的请求-响应模式中
-    // 这样避免了竞争条件和全局状态的问题
-  });
-
-  autoUpdater.on('error', (error) => {
-    console.error('[Updater] Update error:', error);
-
-    // 如果是 403 错误，提供基本的调试信息
-    if (error.code === 'HTTP_ERROR_403' || (error.message && error.message.includes('403'))) {
-      console.log('[Updater Debug] ===== 403 ERROR DEBUGGING =====');
-      console.log('[Updater Debug] This is a 403 Forbidden error, likely repository access issue');
-
-      console.log('[Updater Debug] Common 403 causes:');
-      console.log('[Updater Debug] 1. Repository is private (not supported)');
-      console.log('[Updater Debug] 2. Repository does not exist');
-      console.log('[Updater Debug] 3. Network/firewall blocking GitHub API');
-      console.log('[Updater Debug] 4. GitHub API rate limiting');
-
-      console.log('[Updater Debug] Error details:', {
-        code: error.code,
-        message: error.message,
-        stack: error.stack
-      });
-      console.log('[Updater Debug] =====================================');
-    }
-
-    // Operation handlers and download callbacks own their respective locks.
-    // A global updater error must not unlock an unrelated in-flight operation.
-
-    // 创建详细的错误信息
-    const detailedErrorResponse = createDetailedErrorResponse(error);
-
-    // 发送详细错误事件到UI
-    if (mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.webContents.send(IPC_EVENTS.UPDATE_ERROR, {
-        message: detailedErrorResponse.error,
-        code: error.code || 'UNKNOWN_ERROR',
-        timestamp: new Date().toISOString()
-      });
-    }
-  });
-
-  autoUpdater.on('download-progress', (progress) => {
-    console.log('[Updater] Download progress:', progress);
-    if (mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.webContents.send(IPC_EVENTS.UPDATE_DOWNLOAD_PROGRESS, progress);
-    }
-  });
-
-  autoUpdater.on('update-downloaded', (info) => {
-    console.log('[Updater] Update downloaded:', info);
-    console.log('[Updater] ===== UPDATE READY FOR INSTALLATION =====');
-    console.log('[Updater] Downloaded version:', info.version);
-    console.log('[Updater] Release date:', info.releaseDate);
-    console.log('[Updater] Next step: User needs to click "Install and Restart" to complete the update');
-    console.log('[Updater] The application will automatically restart after installation');
-    console.log('[Updater] =============================================');
-    
-    // 下载完成，重置下载状态
-    isDownloadingUpdate = false;
-    
-    if (mainWindow && !mainWindow.isDestroyed()) {
-      // 发送更详细的信息给前端，包含安装提示
-      mainWindow.webContents.send(IPC_EVENTS.UPDATE_DOWNLOADED, {
-        ...info,
-        message: 'Update downloaded successfully. Click "Install and Restart" to complete the installation.',
-        needsRestart: true,
-        canInstallNow: true,
-        installAction: 'Click the install button to restart and apply the update'
-      });
-    }
-  });
-
-  // 检查更新 - 直接返回完整结果，避免全局状态
-  ipcMain.handle(IPC_EVENTS.UPDATE_CHECK, async () => {
-    // 检查是否已有更新检查在进行中
-    if (isCheckingForUpdate) {
-      console.log('[Updater] Update check already in progress, ignoring request');
-      return createSuccessResponse({
-        message: 'Update check already in progress',
-        inProgress: true
-      });
-    }
-
-    // 设置检查状态锁
-    isCheckingForUpdate = true;
-
-    try {
-      // 读取用户偏好设置，使用错误边界处理和明确的备用方案
-      let allowPrerelease = DEFAULT_CONFIG.allowPrerelease;
-      try {
-        allowPrerelease = await preferenceService.get(PREFERENCE_KEYS.ALLOW_PRERELEASE, DEFAULT_CONFIG.allowPrerelease);
-        console.log('[Updater] Successfully read prerelease preference:', allowPrerelease);
-      } catch (prefError) {
-        console.warn('[Updater] PreferenceService unavailable, using safe default (stable releases only):', prefError);
-        allowPrerelease = false; // 明确的安全默认值
-
-        // 可选：通知用户偏好设置不可用
-        if (mainWindow && !mainWindow.isDestroyed()) {
-          mainWindow.webContents.send('preference-service-warning', {
-            message: 'Settings temporarily unavailable, using default configuration',
-            timestamp: new Date().toISOString()
-          });
-        }
-      }
-
-      console.log('[Updater] Checking for updates with settings:', { allowPrerelease });
-
-      // 配置更新器
-      autoUpdater.allowPrerelease = allowPrerelease;
-
-      // 执行更新检查
-      console.log('[Updater] Starting update check...');
-      
-      // 在实际调用 checkForUpdates 前检查配置
-      console.log('[Updater Debug] ===== PRE-CHECK CONFIGURATION =====');
-      console.log('[Updater Debug] autoUpdater.allowPrerelease:', autoUpdater.allowPrerelease);
-      console.log('[Updater Debug] autoUpdater.autoDownload:', autoUpdater.autoDownload);
-      console.log('[Updater Debug] ===============================================');
-      
-      const result = await autoUpdater.checkForUpdates();
-
-      console.log('[DEBUG] ===== BACKEND UPDATE CHECK RESULT =====');
-      console.log('[DEBUG] autoUpdater.checkForUpdates() returned:', result);
-      console.log('[DEBUG] Result type:', typeof result);
-      console.log('[DEBUG] Result is null:', result === null);
-      console.log('[DEBUG] Result is undefined:', result === undefined);
-      if (result) {
-        console.log('[DEBUG] Result.updateInfo:', result.updateInfo);
-        console.log('[DEBUG] Result.updateInfo type:', typeof result.updateInfo);
-      }
-      console.log('[DEBUG] ==========================================');
-
-      // 构建完整的响应数据，包含所有必要信息
-      const currentVersion = require('./package.json').version;
-      let responseData = {
-        checkResult: result,
-        currentVersion: currentVersion,
-        hasUpdate: false,
-        remoteVersion: null,
-        remoteReleaseUrl: null,
-        message: 'Update check completed'
-      };
-
-      if (result && result.updateInfo) {
-        const updateInfo = result.updateInfo;
-        responseData.remoteVersion = updateInfo.version;
-        responseData.hasUpdate = updateInfo.version !== currentVersion;
-
-        // 构建发布页面URL
-        try {
-          responseData.remoteReleaseUrl = buildReleaseUrl(updateInfo.version, repositoryInfo);
-        } catch (urlError) {
-          console.warn('[Updater] Failed to build release URL:', urlError);
-        }
-
-        if (responseData.hasUpdate) {
-          responseData.message = `New version ${updateInfo.version} is available`;
-        } else {
-          responseData.message = `You are already using the latest version (${updateInfo.version})`;
-        }
-
-        console.log('[Updater] Successfully retrieved update info:', {
-          remoteVersion: updateInfo.version,
-          hasUpdate: responseData.hasUpdate,
-          releaseUrl: responseData.remoteReleaseUrl
-        });
-      } else {
-        // 没有获取到远程版本信息，这可能是配置或网络问题
-        console.log('[Updater] No update info received - checking possible causes...');
-
-        // 生产环境或配置了开发环境但仍然没有获取到信息
-        console.warn('[Updater] No update info received - this may indicate a configuration or network issue');
-        console.warn('[Updater] Possible causes:');
-        console.warn('  - app-update.yml missing or misconfigured');
-        console.warn('  - Network connectivity issues');
-        console.warn('  - GitHub repository access issues');
-        console.warn('  - Invalid repository configuration');
-
-        responseData.message = 'Unable to check for updates - configuration or network issue';
-        responseData.checkResult = null;
-      }
-
-      return createSuccessResponse(responseData);
-    } catch (error) {
-      console.error('[Updater] Check update failed:', error);
-      const detailedResponse = createDetailedErrorResponse(error);
-      console.error('[DEBUG] Detailed error response being sent:', detailedResponse);
-      return detailedResponse;
-    } finally {
-      // 无论成功还是失败，都要释放锁
-      isCheckingForUpdate = false;
-      console.log('[Updater] Update check completed, lock released');
-    }
-  });
-
-  // 统一检查所有版本（解决并发冲突问题）
-  ipcMain.handle(IPC_EVENTS.UPDATE_CHECK_ALL_VERSIONS, async () => {
-    console.log('[Updater] Starting unified version check for all versions');
-    const currentVersion = require('./package.json').version;
-    
-    // 检查是否已有更新检查在进行中
-    if (isCheckingForUpdate) {
-      console.log('[Updater] Update check already in progress, ignoring request');
-      return createSuccessResponse({
-        currentVersion,
-        updateDelivery,
-        stable: null,
-        prerelease: null,
-        message: 'Update check already in progress',
-        inProgress: true
-      });
-    }
-
-    // 设置检查状态锁
-    isCheckingForUpdate = true;
-
-    try {
-      const results = {
-        currentVersion,
-        updateDelivery,
-        stable: null,
-        prerelease: null
-      };
-
-      // 辅助函数：处理单个版本检查结果
-      const processResult = (result, versionType) => {
-        if (!result || !result.updateInfo) {
-          console.log(`[Updater] No ${versionType} update available`);
-          return {
-            hasUpdate: false,
-            remoteVersion: null,
-            remoteReleaseUrl: null,
-            message: `No ${versionType} update available`,
-            versionType,
-            noVersionFound: true
-          };
-        }
-
-        const updateInfo = result.updateInfo;
-        const remoteVersion = updateInfo.version;
-
-        // 预览版检查时，过滤掉正式版
-        if (versionType === 'prerelease') {
-          const isPrerelease = remoteVersion.includes('-');
-          if (!isPrerelease) {
-            return {
-              hasUpdate: false,
-              remoteVersion: null,
-              remoteReleaseUrl: null,
-              message: 'No newer prerelease available (latest release is stable)',
-              versionType,
-              noVersionFound: true,
-              latestStableVersion: remoteVersion
-            };
-          }
-        }
-
-        // 简单但有效的版本比较：让前端处理复杂的语义化版本比较
-        // 这里只需要确保返回远程版本信息，前端会进行准确的版本比较
-        const hasUpdate = remoteVersion !== currentVersion;
-
-        console.log(`[Updater] Version check for ${versionType}:`, {
-          currentVersion,
-          remoteVersion,
-          hasUpdate: hasUpdate ? 'possible (will be verified by frontend)' : 'no'
-        });
-        let remoteReleaseUrl = null;
-
-        // 构建发布页面URL
-        try {
-          remoteReleaseUrl = buildReleaseUrl(updateInfo.version, repositoryInfo);
-        } catch (urlError) {
-          console.warn(`[Updater] Failed to build ${versionType} release URL:`, urlError);
-        }
-
-        console.log(`[Updater] ${versionType} version check result:`, {
-          remoteVersion,
-          hasUpdate,
-          releaseUrl: remoteReleaseUrl
-        });
-
-        return {
-          hasUpdate,
-          remoteVersion,
-          remoteReleaseUrl,
-          message: hasUpdate ?
-            `New ${versionType} version ${remoteVersion} is available` :
-            `You are already using the latest ${versionType} version`,
-          versionType,
-          releaseDate: updateInfo.releaseDate,
-          releaseNotes: updateInfo.releaseNotes
-        };
-      };
-
-      // 1. 检查正式版
-      console.log('[Updater] Checking stable version...');
-      autoUpdater.allowPrerelease = false;
-      
-      try {
-        const stableResult = await autoUpdater.checkForUpdates();
-        results.stable = processResult(stableResult, 'stable');
-      } catch (error) {
-        console.error('[Updater] Stable version check failed:', error);
-        results.stable = {
-          hasUpdate: false,
-          remoteVersion: null,
-          remoteReleaseUrl: null,
-          message: `Stable version check failed: ${error.message}`,
-          versionType: 'stable',
-          error: error.message
-        };
-      }
-
-      // 2. 延迟后检查预览版（避免状态冲突）
-      console.log('[Updater] Waiting before checking prerelease version...');
-      await new Promise(resolve => setTimeout(resolve, 1000));
-
-      console.log('[Updater] Checking prerelease version...');
-      autoUpdater.allowPrerelease = true;
-      
-      try {
-        const prereleaseResult = await autoUpdater.checkForUpdates();
-        results.prerelease = processResult(prereleaseResult, 'prerelease');
-      } catch (error) {
-        console.error('[Updater] Prerelease version check failed:', error);
-        results.prerelease = {
-          hasUpdate: false,
-          remoteVersion: null,
-          remoteReleaseUrl: null,
-          message: `Prerelease version check failed: ${error.message}`,
-          versionType: 'prerelease',
-          error: error.message
-        };
-      }
-
-      // 3. 恢复用户偏好设置
-      try {
-        const userPreference = await preferenceService.get(PREFERENCE_KEYS.ALLOW_PRERELEASE, DEFAULT_CONFIG.allowPrerelease);
-        autoUpdater.allowPrerelease = userPreference;
-        autoUpdater.allowDowngrade = false; // 总是恢复为 false
-        console.log('[Updater] Restored user preference:', { allowPrerelease: userPreference, allowDowngrade: false });
-      } catch (prefError) {
-        console.warn('[Updater] Failed to restore user preference, using default:', prefError);
-        autoUpdater.allowPrerelease = DEFAULT_CONFIG.allowPrerelease;
-        autoUpdater.allowDowngrade = false; // 确保在错误情况下也恢复
-      }
-
-      console.log('[Updater] Unified version check completed:', {
-        stable: results.stable?.hasUpdate ? results.stable.remoteVersion : 'no update',
-        prerelease: results.prerelease?.hasUpdate ? results.prerelease.remoteVersion : 'no update'
-      });
-
-      return createSuccessResponse(results);
-    } catch (error) {
-      console.error('[Updater] Unified version check failed:', error);
-      return createDetailedErrorResponse(error);
-    } finally {
-      // 无论成功还是失败，都要释放锁
-      isCheckingForUpdate = false;
-      console.log('[Updater] Unified version check completed, lock released');
-    }
-  });
-
-  // Open only a main-process constructed URL for an updater release page.
-  ipcMain.handle(IPC_EVENTS.UPDATE_OPEN_RELEASE_PAGE, async (event, version) => {
-    try {
-      const releaseUrl = version
-        ? buildReleaseUrl(version, repositoryInfo)
-        : updateDelivery.fallbackReleaseUrl;
-
-      if (!releaseUrl) {
-        const error = new Error('Release page URL is unavailable');
-        error.code = 'UPDATER_RELEASE_URL_UNAVAILABLE';
-        throw error;
-      }
-
-      await shell.openExternal(releaseUrl);
-      return createSuccessResponse({ url: releaseUrl });
-    } catch (error) {
-      return createErrorResponse(error);
-    }
-  });
-
-  // 开始下载更新
-  ipcMain.handle(IPC_EVENTS.UPDATE_START_DOWNLOAD, async () => {
-    if (isManualReleaseDelivery(updateDelivery)) {
-      return createErrorResponse(
-        createManualUpdateRequiredError('start-download', updateDelivery)
-      );
-    }
-
-    // 检查是否已有下载在进行中
-    if (isDownloadingUpdate) {
-      console.log('[Updater] Download already in progress, ignoring request');
-      return createSuccessResponse({
-        message: 'Download already in progress',
-        inProgress: true
-      });
-    }
-
-    // 设置下载状态锁
-    isDownloadingUpdate = true;
-
-    try {
-      console.log('[Updater] Starting update download...');
-      await autoUpdater.downloadUpdate();
-      return createSuccessResponse(null);
-    } catch (error) {
-      console.error('[Updater] Download failed:', error);
-      isDownloadingUpdate = false; // 失败时重置状态
-      return createDetailedErrorResponse(error);
-    }
-  });
-
-  // 安装更新
-  ipcMain.handle(IPC_EVENTS.UPDATE_INSTALL, async () => {
-    if (isManualReleaseDelivery(updateDelivery)) {
-      return createErrorResponse(
-        createManualUpdateRequiredError('install', updateDelivery)
-      );
-    }
-
-    // 检查是否已有安装在进行中
-    if (isInstallingUpdate) {
-      console.log('[Updater] Install already in progress, ignoring request');
-      return createSuccessResponse({
-        message: 'Install already in progress',
-        inProgress: true
-      });
-    }
-
-    // 设置安装状态锁
-    isInstallingUpdate = true;
-
-    try {
-      console.log('[Updater] ===== STARTING UPDATE INSTALLATION =====');
-      console.log('[Updater] User clicked "Install and Restart"');
-      console.log('[Updater] The application will now close and restart with the new version');
-      console.log('[Updater] If the application does not restart automatically, please launch it manually');
-      console.log('[Updater] ==========================================');
-      
-      // 设置更新安装退出标志，跳过数据保存逻辑
-      isUpdaterQuitting = true;
-      console.log('[Updater] Set updater quit flag to skip data save');
-      
-      // 注意：quitAndInstall会立即退出应用，所以不会执行到finally
-      // 这个方法会：
-      // 1. 关闭当前应用
-      // 2. 安装新版本
-      // 3. 启动新版本的应用
-      autoUpdater.quitAndInstall();
-      
-      // 这行代码通常不会执行到，因为 quitAndInstall() 会立即退出应用
-      return createSuccessResponse({
-        message: 'Installation started, application will restart'
-      });
-    } catch (error) {
-      console.error('[Updater] Install failed:', error);
-      console.error('[Updater] ===== INSTALLATION ERROR =====');
-      console.error('[Updater] Error details:', error.message);
-      console.error('[Updater] This may indicate:');
-      console.error('[Updater] 1. Update file was corrupted during download');
-      console.error('[Updater] 2. Insufficient permissions to install');
-      console.error('[Updater] 3. Antivirus software blocked the installation');
-      console.error('[Updater] 4. The update file was not properly downloaded');
-      console.error('[Updater] Please try downloading the update again');
-      console.error('[Updater] ===============================');
-      
-      return createDetailedErrorResponse(error);
-    } finally {
-      // 确保锁总是被释放（虽然quitAndInstall成功时不会执行到这里）
-      isInstallingUpdate = false;
-    }
-  });
-
-  // 获取忽略版本状态
-  ipcMain.handle(IPC_EVENTS.UPDATE_GET_IGNORED_VERSIONS, async () => {
-    try {
-      const ignoredVersions = await getIgnoredVersions();
-      console.log('[Updater] Retrieved ignored versions:', ignoredVersions);
-      return createSuccessResponse(ignoredVersions);
-    } catch (error) {
-      console.error('[Updater] Failed to get ignored versions:', error);
-      return createDetailedErrorResponse(error);
-    }
-  });
-
-  // 忽略版本
-  ipcMain.handle(IPC_EVENTS.UPDATE_IGNORE_VERSION, async (event, version, versionType) => {
-    try {
-      // 验证版本号格式
-      if (!validateVersion(version)) {
-        throw new Error(`Invalid version format: ${version}`);
-      }
-
-      // 如果没有指定类型，根据版本号自动判断
-      if (!versionType) {
-        versionType = version.includes('-') ? 'prerelease' : 'stable';
-      }
-
-      console.log('[Updater] Ignoring version:', version, 'type:', versionType);
-
-      // 获取当前忽略版本数据
-      const ignoredVersions = await getIgnoredVersions();
-
-      // 更新对应类型的忽略版本
-      ignoredVersions[versionType] = version;
-
-      // 保存更新后的数据
-      await preferenceService.set(PREFERENCE_KEYS.IGNORED_VERSIONS, ignoredVersions);
-
-      return createSuccessResponse(null);
-    } catch (error) {
-      console.error('[Updater] Failed to ignore version:', error);
-      return createDetailedErrorResponse(error);
-    }
-  });
-
-  // 取消忽略版本
-  ipcMain.handle(IPC_EVENTS.UPDATE_UNIGNORE_VERSION, async (event, versionType) => {
-    try {
-      // 验证版本类型
-      if (!['stable', 'prerelease'].includes(versionType)) {
-        throw new Error(`Invalid version type: ${versionType}`);
-      }
-
-      console.log('[Updater] Unignoring version type:', versionType);
-
-      // 获取当前忽略版本数据
-      const ignoredVersions = await getIgnoredVersions();
-
-      // 清除对应类型的忽略版本
-      ignoredVersions[versionType] = null;
-
-      // 保存更新后的数据
-      await preferenceService.set(PREFERENCE_KEYS.IGNORED_VERSIONS, ignoredVersions);
-
-      return createSuccessResponse(null);
-    } catch (error) {
-      console.error('[Updater] Failed to unignore version:', error);
-      return createDetailedErrorResponse(error);
-    }
-  });
-
-  // 下载特定版本（原子操作）
-  ipcMain.handle(IPC_EVENTS.UPDATE_DOWNLOAD_SPECIFIC_VERSION, async (event, versionType) => {
-    if (isManualReleaseDelivery(updateDelivery)) {
-      return createErrorResponse(
-        createManualUpdateRequiredError('download-specific-version', updateDelivery, {
-          versionType,
-        })
-      );
-    }
-
-    try {
-      console.log('[Updater] Starting atomic download for version type:', versionType);
-
-      // 验证版本类型
-      if (!['stable', 'prerelease'].includes(versionType)) {
-        throw new Error(`Invalid version type: ${versionType}`);
-      }
-
-      // 防止并发下载 - 立即设置状态锁
-      if (isDownloadingUpdate) {
-        console.log('[Updater] Download already in progress');
-        return createErrorResponse('Download already in progress');
-      }
-
-      // 立即设置下载状态，防止竞态条件
-      isDownloadingUpdate = true;
-
-      // 1. 保存当前配置（包括偏好设置和autoUpdater实例配置）
-      const originalPreference = await preferenceService.get(PREFERENCE_KEYS.ALLOW_PRERELEASE, false);
-      const originalAutoUpdaterConfig = {
-        allowPrerelease: autoUpdater.allowPrerelease,
-        allowDowngrade: autoUpdater.allowDowngrade
-      };
-      console.log('[Updater] Original preference:', originalPreference);
-      console.log('[Updater] Original autoUpdater config:', originalAutoUpdaterConfig);
-
-      try {
-        // 2. 设置目标通道（同时修改偏好设置和autoUpdater实例）
-        const targetPreference = versionType === 'prerelease';
-        await preferenceService.set(PREFERENCE_KEYS.ALLOW_PRERELEASE, targetPreference);
-
-        // 直接配置autoUpdater实例，确保本次操作使用正确配置
-        autoUpdater.allowPrerelease = targetPreference;
-        autoUpdater.allowDowngrade = true; // 允许降级，支持从预览版切换到正式版
-
-        console.log('[Updater] Set preference to:', targetPreference);
-        console.log('[Updater] Set autoUpdater config:', {
-          allowPrerelease: autoUpdater.allowPrerelease,
-          allowDowngrade: autoUpdater.allowDowngrade
-        });
-
-        // 3. 检查更新
-        console.log('[Updater] Checking for updates...');
-        const checkResult = await autoUpdater.checkForUpdates();
-
-        if (!checkResult || !checkResult.updateInfo) {
-          console.log('[Updater] No update available for', versionType);
-          isDownloadingUpdate = false; // 重置状态
-          return createSuccessResponse({
-            hasUpdate: false,
-            message: `No ${versionType} update available`,
-            versionType,
-            version: null,
-            reason: 'no-update'
-          });
-        }
-
-        // 检查版本是否被忽略
-        const isIgnored = await isVersionIgnored(checkResult.updateInfo.version);
-        if (isIgnored) {
-          console.log('[Updater] Version is ignored:', checkResult.updateInfo.version);
-          isDownloadingUpdate = false; // 重置状态
-          return createSuccessResponse({
-            hasUpdate: false,
-            message: `Version ${checkResult.updateInfo.version} is ignored`,
-            versionType,
-            version: checkResult.updateInfo.version,
-            reason: 'ignored'
-          });
-        }
-
-        // 4. 立即开始下载
-        console.log('[Updater] Starting download for version:', checkResult.updateInfo.version);
-        // 注意：isDownloadingUpdate 已在函数开始时设置
-
-        // 由于 autoDownload = false，必须手动调用 downloadUpdate()
-        // 注意：不要 await downloadUpdate()，因为它会等到下载完成
-        // 我们只需要启动下载，然后立即返回，避免超时问题
-        try {
-          // 启动下载（不等待完成）
-          autoUpdater.downloadUpdate().catch(downloadError => {
-            console.error('[Updater] Download failed:', downloadError);
-            isDownloadingUpdate = false;
-            // 发送错误事件到前端
-            if (mainWindow && !mainWindow.isDestroyed()) {
-              mainWindow.webContents.send(IPC_EVENTS.UPDATE_ERROR, {
-                message: downloadError.message || 'Download failed',
-                error: downloadError,
-                timestamp: new Date().toISOString()
-              });
-            }
-          });
-          console.log('[Updater] Download started successfully');
-
-          // 立即发送下载开始事件到前端，确保UI状态同步
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            mainWindow.webContents.send(IPC_EVENTS.UPDATE_DOWNLOAD_STARTED, {
-              versionType,
-              version: checkResult.updateInfo.version,
-              timestamp: new Date().toISOString()
-            });
-          }
-        } catch (downloadError) {
-          console.error('[Updater] Failed to start download:', downloadError);
-          isDownloadingUpdate = false;
-          throw downloadError;
-        }
-
-        return createSuccessResponse({
-          hasUpdate: true,
-          updateInfo: checkResult.updateInfo,
-          versionType,
-          message: `Started downloading ${versionType} version ${checkResult.updateInfo.version}`
-        });
-
-      } finally {
-        // 5. 确保恢复原始配置（偏好设置和autoUpdater实例）
-        try {
-          // 恢复偏好设置
-          await preferenceService.set(PREFERENCE_KEYS.ALLOW_PRERELEASE, originalPreference);
-          console.log('[Updater] Restored preference to:', originalPreference);
-
-          // 恢复autoUpdater实例配置
-          autoUpdater.allowPrerelease = originalAutoUpdaterConfig.allowPrerelease;
-          autoUpdater.allowDowngrade = originalAutoUpdaterConfig.allowDowngrade;
-          console.log('[Updater] Restored autoUpdater config to:', originalAutoUpdaterConfig);
-        } catch (restoreError) {
-          console.error('[Updater] Failed to restore configuration:', restoreError);
-        }
-      }
-
-    } catch (error) {
-      console.error('[Updater] Atomic download failed:', error);
-      // 确保下载状态被重置
-      if (isDownloadingUpdate) {
-        isDownloadingUpdate = false;
-      }
-      return createDetailedErrorResponse(error);
-    }
-  });
-
-  console.log('[Main Process] Auto-update handlers ready.');
-}

--- a/packages/desktop/preload.js
+++ b/packages/desktop/preload.js
@@ -3,7 +3,6 @@ const { contextBridge, ipcRenderer } = require('electron');
 // IPC事件名称常量 - 直接内联避免沙箱环境的模块加载问题
 const IPC_EVENTS = {
   UPDATE_CHECK: 'updater-check-update',
-  UPDATE_OPEN_RELEASE_PAGE: 'updater-open-release-page',
   UPDATE_START_DOWNLOAD: 'updater-start-download',
   UPDATE_INSTALL: 'updater-install-update',
   UPDATE_IGNORE_VERSION: 'updater-ignore-version',
@@ -22,6 +21,7 @@ const IPC_EVENTS = {
 };
 
 const REMOTE_STORAGE_CHANNEL = 'remote-storage:invoke';
+const ipcListenerWrappers = new Map();
 
 // 简单的超时包装器，避免过度设计
 const withTimeout = (promise, timeoutMs = 30000) => {
@@ -80,6 +80,105 @@ function createIpcError(payload) {
   return new Error(String(payload));
 }
 
+/** 请求主进程取消当前 renderer 所拥有的流任务。 */
+async function cancelMainProcessStream(streamId) {
+  const result = await ipcRenderer.invoke('stream-cancel', streamId);
+  if (!result.success) {
+    throw createIpcError(result.error);
+  }
+  return result.data;
+}
+
+/** 将前端 AbortSignal 转换为 IPC 取消请求和可参与竞速的拒绝 Promise。 */
+function createStreamAbortRace(streamId, cleanup, signal) {
+  if (!signal) {
+    return { abortPromise: null, dispose: () => {} };
+  }
+
+  let rejectAbort;
+  let cancelled = false;
+  const abortPromise = new Promise((_, reject) => {
+    rejectAbort = reject;
+  });
+  const abortListener = () => {
+    if (cancelled) {
+      return;
+    }
+    cancelled = true;
+    cleanup();
+
+    void cancelMainProcessStream(streamId)
+      .catch(() => {})
+      .finally(() => {
+        rejectAbort(createIpcError({
+          code: 'IPC_STREAM_CANCELLED',
+          message: 'IPC stream was cancelled',
+        }));
+      });
+  };
+
+  if (signal.aborted) {
+    abortListener();
+  } else {
+    signal.addEventListener('abort', abortListener, { once: true });
+  }
+
+  return {
+    abortPromise,
+    dispose: () => signal.removeEventListener('abort', abortListener),
+  };
+}
+
+/**
+ * 为前端回调创建并保存唯一的 Electron 监听器包装，返回可重复调用的注销函数。
+ */
+function subscribeIpcEvent(channel, callback) {
+  if (typeof channel !== 'string' || typeof callback !== 'function') {
+    throw new TypeError('IPC event subscription requires a channel and callback');
+  }
+
+  let channelListeners = ipcListenerWrappers.get(channel);
+  if (!channelListeners) {
+    channelListeners = new Map();
+    ipcListenerWrappers.set(channel, channelListeners);
+  }
+
+  const existingListener = channelListeners.get(callback);
+  if (existingListener) {
+    ipcRenderer.removeListener(channel, existingListener);
+  }
+
+  /** 去除 Electron event 参数，仅向前端传递业务载荷。 */
+  const wrappedListener = (_event, ...args) => callback(...args);
+  channelListeners.set(callback, wrappedListener);
+  ipcRenderer.on(channel, wrappedListener);
+
+  let disposed = false;
+  return () => {
+    if (disposed) return;
+    disposed = true;
+    unsubscribeIpcEvent(channel, callback);
+  };
+}
+
+/**
+ * 使用注册时保存的同一函数引用移除 Electron 监听器，并清理空映射。
+ */
+function unsubscribeIpcEvent(channel, callback) {
+  const channelListeners = ipcListenerWrappers.get(channel);
+  const wrappedListener = channelListeners?.get(callback);
+  if (!wrappedListener) {
+    return false;
+  }
+
+  ipcRenderer.removeListener(channel, wrappedListener);
+  channelListeners.delete(callback);
+  if (channelListeners.size === 0) {
+    ipcListenerWrappers.delete(channel);
+  }
+  return true;
+}
+
 async function invokeFavorite(channel, ...args) {
   const result = await ipcRenderer.invoke(channel, ...args);
   if (!result.success) {
@@ -90,12 +189,8 @@ async function invokeFavorite(channel, ...args) {
 
 contextBridge.exposeInMainWorld('electronAPI', {
   // IPC event listeners
-  on: (channel, callback) => {
-    ipcRenderer.on(channel, (event, ...args) => callback(...args));
-  },
-  off: (channel, callback) => {
-    ipcRenderer.removeListener(channel, callback);
-  },
+  on: subscribeIpcEvent,
+  off: unsubscribeIpcEvent,
 
   // High-level LLM service interface
   llm: {
@@ -136,8 +231,15 @@ contextBridge.exposeInMainWorld('electronAPI', {
     },
 
     // Send streaming message
-    sendMessageStream: async (messages, provider, callbacks) => {
+    sendMessageStream: async (messages, provider, callbacks, signal) => {
       const streamId = generateStreamId();
+
+      if (signal?.aborted) {
+        throw createIpcError({
+          code: 'IPC_STREAM_CANCELLED',
+          message: 'IPC stream was cancelled',
+        });
+      }
       
       // Set up event listeners for streaming responses
       const contentListener = (event, content) => {
@@ -170,21 +272,31 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.on(`stream-error-${streamId}`, errorListener);
 
       // Send the streaming request
+      const cancellation = createStreamAbortRace(streamId, cleanup, signal);
       try {
-        const result = await ipcRenderer.invoke('llm-sendMessageStream', messages, provider, streamId);
+        const request = ipcRenderer.invoke('llm-sendMessageStream', messages, provider, streamId);
+        const result = cancellation.abortPromise
+          ? await Promise.race([request, cancellation.abortPromise])
+          : await request;
         if (!result.success) {
-          cleanup();
           throw createIpcError(result.error);
         }
-      } catch (error) {
+      } finally {
         cleanup();
-        throw error;
+        cancellation.dispose();
       }
     },
 
     // Send streaming message with tools (supports tool-call events)
-    sendMessageStreamWithTools: async (messages, provider, tools, callbacks) => {
+    sendMessageStreamWithTools: async (messages, provider, tools, callbacks, signal) => {
       const streamId = generateStreamId();
+
+      if (signal?.aborted) {
+        throw createIpcError({
+          code: 'IPC_STREAM_CANCELLED',
+          message: 'IPC stream was cancelled',
+        });
+      }
 
       // Set up event listeners for streaming responses
       const contentListener = (event, content) => {
@@ -222,22 +334,29 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.on(`stream-error-${streamId}`, errorListener);
 
       // Send the streaming request
+      const cancellation = createStreamAbortRace(streamId, cleanup, signal);
       try {
-        const result = await ipcRenderer.invoke(
+        const request = ipcRenderer.invoke(
           'llm-sendMessageStreamWithTools',
           messages,
           provider,
           tools,
           streamId
         );
+        const result = cancellation.abortPromise
+          ? await Promise.race([request, cancellation.abortPromise])
+          : await request;
         if (!result.success) {
-          cleanup();
           throw createIpcError(result.error);
         }
-      } catch (error) {
+      } finally {
         cleanup();
-        throw error;
+        cancellation.dispose();
       }
+    },
+
+    cancelStream: async (streamId) => {
+      return cancelMainProcessStream(streamId);
     }
   },
 
@@ -830,8 +949,16 @@ contextBridge.exposeInMainWorld('electronAPI', {
       return result.data;
     },
     // 统一的流式封装（与 llm.sendMessageStream 同模式）
-    optimizePromptStream: async (request, callbacks) => {
+    // signal 为可选位置参数，保持既有调用方兼容
+    optimizePromptStream: async (request, callbacks, signal) => {
       const streamId = generateStreamId();
+
+      if (signal?.aborted) {
+        throw createIpcError({
+          code: 'IPC_STREAM_CANCELLED',
+          message: 'IPC stream was cancelled',
+        });
+      }
 
       const tokenListener = (event, token) => {
         if (callbacks?.onToken) callbacks.onToken(token);
@@ -860,14 +987,29 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.on(`stream-finish-${streamId}`, finishListener);
       ipcRenderer.on(`stream-error-${streamId}`, errorListener);
 
-      const result = await ipcRenderer.invoke('prompt-optimizePromptStream', request, streamId);
-      if (!result.success) {
+      const cancellation = createStreamAbortRace(streamId, cleanup, signal);
+      try {
+        const requestPromise = ipcRenderer.invoke('prompt-optimizePromptStream', request, streamId);
+        const result = cancellation.abortPromise
+          ? await Promise.race([requestPromise, cancellation.abortPromise])
+          : await requestPromise;
+        if (!result.success) {
+          throw createIpcError(result.error);
+        }
+      } finally {
         cleanup();
-        throw createIpcError(result.error);
+        cancellation.dispose();
       }
     },
-    optimizeMessageStream: async (request, callbacks) => {
+    optimizeMessageStream: async (request, callbacks, signal) => {
       const streamId = generateStreamId();
+
+      if (signal?.aborted) {
+        throw createIpcError({
+          code: 'IPC_STREAM_CANCELLED',
+          message: 'IPC stream was cancelled',
+        });
+      }
 
       const tokenListener = (event, token) => {
         if (callbacks?.onToken) callbacks.onToken(token);
@@ -896,14 +1038,29 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.on(`stream-finish-${streamId}`, finishListener);
       ipcRenderer.on(`stream-error-${streamId}`, errorListener);
 
-      const result = await ipcRenderer.invoke('prompt-optimizeMessageStream', request, streamId);
-      if (!result.success) {
+      const cancellation = createStreamAbortRace(streamId, cleanup, signal);
+      try {
+        const requestPromise = ipcRenderer.invoke('prompt-optimizeMessageStream', request, streamId);
+        const result = cancellation.abortPromise
+          ? await Promise.race([requestPromise, cancellation.abortPromise])
+          : await requestPromise;
+        if (!result.success) {
+          throw createIpcError(result.error);
+        }
+      } finally {
         cleanup();
-        throw createIpcError(result.error);
+        cancellation.dispose();
       }
     },
-    iteratePromptStream: async (originalPrompt, lastOptimizedPrompt, iterateInput, modelKey, templateId, callbacks, contextData) => {
+    iteratePromptStream: async (originalPrompt, lastOptimizedPrompt, iterateInput, modelKey, templateId, callbacks, contextData, signal) => {
       const streamId = generateStreamId();
+
+      if (signal?.aborted) {
+        throw createIpcError({
+          code: 'IPC_STREAM_CANCELLED',
+          message: 'IPC stream was cancelled',
+        });
+      }
 
       const tokenListener = (event, token) => {
         if (callbacks?.onToken) callbacks.onToken(token);
@@ -932,14 +1089,43 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.on(`stream-finish-${streamId}`, finishListener);
       ipcRenderer.on(`stream-error-${streamId}`, errorListener);
 
-      const result = await ipcRenderer.invoke('prompt-iteratePromptStream', originalPrompt, lastOptimizedPrompt, iterateInput, modelKey, templateId, streamId, contextData);
-      if (!result.success) {
+      const cancellation = createStreamAbortRace(streamId, cleanup, signal);
+      try {
+        const requestPromise = ipcRenderer.invoke(
+          'prompt-iteratePromptStream',
+          originalPrompt,
+          lastOptimizedPrompt,
+          iterateInput,
+          modelKey,
+          templateId,
+          streamId,
+          contextData,
+        );
+        const result = cancellation.abortPromise
+          ? await Promise.race([requestPromise, cancellation.abortPromise])
+          : await requestPromise;
+        if (!result.success) {
+          throw createIpcError(result.error);
+        }
+      } finally {
         cleanup();
-        throw createIpcError(result.error);
+        cancellation.dispose();
       }
     },
-    testPromptStream: async (systemPrompt, userPrompt, modelKey, callbacks, inputImages) => {
+    testPromptStream: async (systemPrompt, userPrompt, modelKey, callbacks, inputImages, signal) => {
+      // Back-compat: allow (callbacks, signal) without images.
+      if (inputImages && typeof inputImages === 'object' && typeof inputImages.aborted === 'boolean' && signal === undefined) {
+        signal = inputImages;
+        inputImages = undefined;
+      }
       const streamId = generateStreamId();
+
+      if (signal?.aborted) {
+        throw createIpcError({
+          code: 'IPC_STREAM_CANCELLED',
+          message: 'IPC stream was cancelled',
+        });
+      }
 
       const tokenListener = (event, token) => {
         if (callbacks?.onToken) callbacks.onToken(token);
@@ -968,15 +1154,37 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.on(`stream-finish-${streamId}`, finishListener);
       ipcRenderer.on(`stream-error-${streamId}`, errorListener);
 
-      const result = await ipcRenderer.invoke('prompt-testPromptStream', systemPrompt, userPrompt, modelKey, streamId, inputImages);
-      if (!result.success) {
+      const cancellation = createStreamAbortRace(streamId, cleanup, signal);
+      try {
+        const requestPromise = ipcRenderer.invoke(
+          'prompt-testPromptStream',
+          systemPrompt,
+          userPrompt,
+          modelKey,
+          streamId,
+          inputImages,
+        );
+        const result = cancellation.abortPromise
+          ? await Promise.race([requestPromise, cancellation.abortPromise])
+          : await requestPromise;
+        if (!result.success) {
+          throw createIpcError(result.error);
+        }
+      } finally {
         cleanup();
-        throw createIpcError(result.error);
+        cancellation.dispose();
       }
     },
     // 自定义会话测试（支持工具调用）
-    testCustomConversationStream: async (request, callbacks) => {
+    testCustomConversationStream: async (request, callbacks, signal) => {
       const streamId = generateStreamId();
+
+      if (signal?.aborted) {
+        throw createIpcError({
+          code: 'IPC_STREAM_CANCELLED',
+          message: 'IPC stream was cancelled',
+        });
+      }
 
       const tokenListener = (event, token) => {
         if (callbacks?.onToken) callbacks.onToken(token);
@@ -1010,10 +1218,22 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.on(`stream-finish-${streamId}`, finishListener);
       ipcRenderer.on(`stream-error-${streamId}`, errorListener);
 
-      const result = await ipcRenderer.invoke('prompt-testCustomConversationStream', request, streamId);
-      if (!result.success) {
+      const cancellation = createStreamAbortRace(streamId, cleanup, signal);
+      try {
+        const requestPromise = ipcRenderer.invoke(
+          'prompt-testCustomConversationStream',
+          request,
+          streamId,
+        );
+        const result = cancellation.abortPromise
+          ? await Promise.race([requestPromise, cancellation.abortPromise])
+          : await requestPromise;
+        if (!result.success) {
+          throw createIpcError(result.error);
+        }
+      } finally {
         cleanup();
-        throw createIpcError(result.error);
+        cancellation.dispose();
       }
     },
     iteratePrompt: async (originalPrompt, lastOptimizedPrompt, iterateInput, modelKey, templateId, contextData) => {
@@ -1381,17 +1601,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
       }
       return result.data;
     },
-
-    openReleasePage: async (version) => {
-      const result = await withTimeout(
-        ipcRenderer.invoke(IPC_EVENTS.UPDATE_OPEN_RELEASE_PAGE, version),
-        10000
-      );
-      if (!result.success) {
-        throw createIpcError(result.error);
-      }
-      return result.data;
-    },
     
     startDownload: async () => {
       const result = await withTimeout(
@@ -1399,7 +1608,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
         10000 // 10秒超时，启动下载应该很快
       );
       if (!result.success) {
-        throw createIpcError(result.error);
+        // 保留完整的错误信息
+        const error = new Error(result.error);
+        error.originalError = result.error;
+        error.detailedMessage = result.error;
+        throw error;
       }
       return result.data;
     },
@@ -1409,7 +1622,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
         10000 // 10秒超时，安装启动应该很快
       );
       if (!result.success) {
-        throw createIpcError(result.error);
+        // 保留完整的错误信息
+        const error = new Error(result.error);
+        error.originalError = result.error;
+        error.detailedMessage = result.error;
+        throw error;
       }
       return result.data;
     },
@@ -1462,7 +1679,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
         30000 // 30秒超时，现在只等待下载启动，不等待完成，所以30秒足够
       );
       if (!result.success) {
-        throw createIpcError(result.error || 'Failed to download specific version');
+        const error = new Error(result.error || 'Failed to download specific version');
+        error.originalError = result.error;
+        error.detailedMessage = result.error;
+        throw error;
       }
       return result.data;
     },

--- a/packages/desktop/remote-storage.js
+++ b/packages/desktop/remote-storage.js
@@ -12,13 +12,38 @@ const JSON_MIME_TYPE = 'application/json';
 const CLOUDFLARE_R2_DEFAULT_BACKUP_PREFIX = 'prompt-optimizer-backups/';
 let webDavModulePromise = null;
 
-const joinRemotePath = (...parts) =>
-  parts
-    .map((part) => String(part || '').replace(/^\/+|\/+$/g, ''))
-    .filter(Boolean)
-    .join('/');
+const decodeRemotePathSegment = (segment) => {
+  let decoded = segment;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    let next;
+    try {
+      next = decodeURIComponent(decoded);
+    } catch {
+      throw new Error('Remote storage path contains invalid encoding');
+    }
+    if (next === decoded) break;
+    decoded = next;
+  }
+  return decoded;
+};
 
-const normalizeObjectPath = (path) => joinRemotePath(path);
+const normalizeObjectPath = (path) => {
+  const raw = String(path || '');
+  if (/[\\\u0000-\u001f\u007f]/.test(raw)) {
+    throw new Error('Remote storage path contains invalid characters');
+  }
+
+  const segments = raw.replace(/^\/+|\/+$/g, '').split('/').filter(Boolean);
+  for (const segment of segments) {
+    const decoded = decodeRemotePathSegment(segment);
+    if (decoded === '.' || decoded === '..' || /[\\/\u0000-\u001f\u007f]/.test(decoded)) {
+      throw new Error('Remote storage path contains an unsafe segment');
+    }
+  }
+  return segments.join('/');
+};
+
+const joinRemotePath = (...parts) => parts.map(normalizeObjectPath).filter(Boolean).join('/');
 
 const parentPathOf = (path) => {
   const normalized = normalizeObjectPath(path);
@@ -292,6 +317,7 @@ class WebDavRemoteObjectStore {
   constructor(config, dependencies) {
     this.config = config;
     this.dependencies = dependencies;
+    this.rootDirectory = normalizeObjectPath(config.directory || 'prompt-optimizer-backups');
     this.clientPromise = null;
   }
 
@@ -411,7 +437,7 @@ class WebDavRemoteObjectStore {
   }
 
   directoryPath(path) {
-    return `/${joinRemotePath(this.config.directory || 'prompt-optimizer-backups', path)}`;
+    return `/${joinRemotePath(this.rootDirectory, path)}`;
   }
 
   filePath(path) {

--- a/scripts/desktop-ipc-handlers.test.mjs
+++ b/scripts/desktop-ipc-handlers.test.mjs
@@ -2,10 +2,15 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import fs from 'node:fs'
 import path from 'node:path'
+import { createRequire } from 'node:module'
 
+const require = createRequire(import.meta.url)
+
+/** 读取桌面跨层契约测试需要检查的源码文本。 */
 const readText = (relativePath) =>
   fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
 
+/** 从一组正则中收集去重后的 IPC channel 或事件常量。 */
 const collectMatches = (text, patterns) => {
   const matches = new Set()
   for (const pattern of patterns) {
@@ -22,6 +27,19 @@ test('desktop preload IPC channels have main-process handlers', () => {
   const main = [
     readText('packages/desktop/main.js'),
     readText('packages/desktop/remote-storage.js'),
+    readText('packages/desktop/config/ipc/llm-handlers.js'),
+    readText('packages/desktop/config/ipc/prompt-stream-handlers.js'),
+    readText('packages/desktop/config/ipc/prompt-sync-handlers.js'),
+    readText('packages/desktop/config/ipc/model-handlers.js'),
+    readText('packages/desktop/config/ipc/image-handlers.js'),
+    readText('packages/desktop/config/ipc/template-handlers.js'),
+    readText('packages/desktop/config/ipc/history-handlers.js'),
+    readText('packages/desktop/config/ipc/favorite-handlers.js'),
+    readText('packages/desktop/config/ipc/context-handlers.js'),
+    readText('packages/desktop/config/ipc/data-handlers.js'),
+    readText('packages/desktop/config/ipc/preference-handlers.js'),
+    readText('packages/desktop/config/ipc/system-handlers.js'),
+    readText('packages/desktop/config/ipc/update-handlers.js'),
   ].join('\n')
 
   const preloadChannels = collectMatches(preload, [
@@ -36,6 +54,7 @@ test('desktop preload IPC channels have main-process handlers', () => {
 
   const mainHandlers = collectMatches(main, [
     /ipcMain\.handle\(\s*['"]([^'"]+)['"]/g,
+    /registerSensitiveIpc\(\s*['"]([^'"]+)['"]/g,
   ])
   for (const eventName of collectMatches(main, [
     /ipcMain\.handle\(\s*IPC_EVENTS\.([A-Z0-9_]+)/g,
@@ -50,230 +69,143 @@ test('desktop preload IPC channels have main-process handlers', () => {
   assert.deepEqual(missingHandlers, [])
 })
 
-test('desktop prompt test IPC preserves optional image payloads without transforming or logging them', () => {
-  const proxy = readText('packages/core/src/services/prompt/electron-proxy.ts')
+test('desktop streaming contract exposes an owner-bound cancellation channel', () => {
   const preload = readText('packages/desktop/preload.js')
+  const llmModule = readText('packages/desktop/config/ipc/llm-handlers.js')
+
+  assert.match(preload, /cancelStream:\s*async\s*\(streamId\)/)
+  assert.match(preload, /ipcRenderer\.invoke\('stream-cancel', streamId\)/)
+  assert.match(llmModule, /registerSensitiveIpc\(\s*'stream-cancel'/)
+})
+
+test('desktop composition root delegates domain handlers to backend modules', () => {
   const main = readText('packages/desktop/main.js')
+  const llmModule = readText('packages/desktop/config/ipc/llm-handlers.js')
+  const promptStreamModule = readText('packages/desktop/config/ipc/prompt-stream-handlers.js')
+  const promptSyncModule = readText('packages/desktop/config/ipc/prompt-sync-handlers.js')
+  const modelModule = readText('packages/desktop/config/ipc/model-handlers.js')
+  const imageModule = readText('packages/desktop/config/ipc/image-handlers.js')
+  const templateModule = readText('packages/desktop/config/ipc/template-handlers.js')
+  const historyModule = readText('packages/desktop/config/ipc/history-handlers.js')
+  const favoriteModule = readText('packages/desktop/config/ipc/favorite-handlers.js')
+  const contextModule = readText('packages/desktop/config/ipc/context-handlers.js')
+  const dataModule = readText('packages/desktop/config/ipc/data-handlers.js')
+  const preferenceModule = readText('packages/desktop/config/ipc/preference-handlers.js')
+  const systemModule = readText('packages/desktop/config/ipc/system-handlers.js')
 
-  assert.match(
-    proxy,
-    /const safeInputImages = inputImages \? safeSerializeForIPC\(inputImages\) : undefined;/,
-  )
-  assert.match(
-    proxy,
-    /this\.api\.testPrompt\(systemPrompt, userPrompt, modelKey, safeInputImages\)/,
-  )
-  assert.match(
-    proxy,
-    /this\.api\.testPromptStream\(systemPrompt, userPrompt, modelKey, callbacks, safeInputImages\)/,
-  )
-
-  assert.match(
-    preload,
-    /ipcRenderer\.invoke\('prompt-testPrompt', systemPrompt, userPrompt, modelKey, inputImages\)/,
-  )
-  assert.match(
-    preload,
-    /ipcRenderer\.invoke\('prompt-testPromptStream', systemPrompt, userPrompt, modelKey, streamId, inputImages\)/,
-  )
-  assert.match(
-    main,
-    /promptService\.testPrompt\(systemPrompt, userPrompt, modelKey, inputImages\)/,
-  )
-  assert.match(
-    main,
-    /promptService\.testPromptStream\(systemPrompt, userPrompt, modelKey, streamHandlers, inputImages\)/,
-  )
-
-  for (const bridgeSource of [proxy, preload]) {
-    assert.doesNotMatch(bridgeSource, /console\.(?:log|info|warn|error)\([^\n]*inputImages/)
-    assert.doesNotMatch(bridgeSource, /data:image\/[^;]+;base64,[^'"`\s]+/)
-  }
+  assert.match(main, /registerLlmIpcHandlers\(/)
+  assert.match(main, /registerPromptStreamIpcHandlers\(/)
+  assert.match(main, /registerPromptSyncIpcHandlers\(/)
+  assert.match(main, /registerModelIpcHandlers\(/)
+  assert.match(main, /registerImageIpcHandlers\(/)
+  assert.match(main, /registerTemplateIpcHandlers\(/)
+  assert.match(main, /registerHistoryIpcHandlers\(/)
+  assert.match(main, /registerFavoriteIpcHandlers\(/)
+  assert.match(main, /registerContextIpcHandlers\(/)
+  assert.match(main, /registerDataIpcHandlers\(/)
+  assert.match(main, /registerPreferenceIpcHandlers\(/)
+  assert.match(main, /registerSystemIpcHandlers\(/)
+  assert.match(main, /createUpdateHandlers\(/)
+  assert.doesNotMatch(main, /registerSensitiveIpc\(\s*'llm-/)
+  assert.doesNotMatch(main, /registerSensitiveIpc\(\s*'prompt-[^']*Stream'/)
+  assert.doesNotMatch(main, /ipcMain\.handle\(\s*'model-/)
+  assert.doesNotMatch(main, /ipcMain\.handle\(\s*'image-(?!understanding)/)
+  assert.doesNotMatch(main, /ipcMain\.handle\(\s*'template-/)
+  assert.doesNotMatch(main, /ipcMain\.handle\(\s*'history-/)
+  assert.doesNotMatch(main, /ipcMain\.handle\(\s*'favorite-/)
+  assert.doesNotMatch(main, /ipcMain\.handle\(\s*'context-/)
+  assert.doesNotMatch(main, /ipcMain\.handle\(\s*'data-/)
+  assert.doesNotMatch(main, /ipcMain\.handle\(\s*'preference-/)
+  assert.doesNotMatch(main, /ipcMain\.handle\(\s*'prompt-/)
+  assert.doesNotMatch(main, /ipcMain\.handle\(\s*'app-/)
+  assert.doesNotMatch(main, /ipcMain\.handle\(\s*'logs-/)
+  assert.doesNotMatch(main, /async function setupUpdateHandlers/)
+  assert.match(llmModule, /registerSensitiveIpc\(\s*'llm-sendMessage'/)
+  assert.match(promptStreamModule, /registerSensitiveIpc\(\s*'prompt-optimizePromptStream'/)
+  assert.match(promptSyncModule, /ipcMain\.handle\(\s*'prompt-optimizePrompt'/)
+  assert.match(modelModule, /ipcMain\.handle\(\s*'model-getAllModels'/)
+  assert.match(imageModule, /ipcMain\.handle\(\s*'image-generate'/)
+  assert.match(templateModule, /ipcMain\.handle\(\s*'template-getTemplates'/)
+  assert.match(historyModule, /ipcMain\.handle\(\s*'history-getHistory'/)
+  assert.match(favoriteModule, /ipcMain\.handle\(\s*'favorite-addFavorite'/)
+  assert.match(contextModule, /ipcMain\.handle\(\s*'context-list'/)
+  assert.match(dataModule, /ipcMain\.handle\(\s*'data-exportAllData'/)
+  assert.match(preferenceModule, /ipcMain\.handle\(\s*'preference-get'/)
+  assert.match(systemModule, /registerSensitiveIpc\(\s*'config-getEnvironmentVariables'/)
+  const updateModule = readText('packages/desktop/config/ipc/update-handlers.js')
+  assert.match(updateModule, /function createUpdateHandlers/)
+  assert.match(updateModule, /IPC_EVENTS\.UPDATE_CHECK|updater-check-update/)
 })
 
-test('desktop multimodal evaluation routes image understanding through the main process', () => {
-  const proxy = readText('packages/core/src/services/image-understanding/electron-proxy.ts')
-  const initializer = readText('packages/ui/src/composables/system/useAppInitializer.ts')
-  const preload = readText('packages/desktop/preload.js')
-  const main = readText('packages/desktop/main.js')
+test('desktop channel manifest covers registered domain invoke channels', () => {
+  // channel-manifest 是 CommonJS；契约测试通过 createRequire 读取。
+  const {
+    ALL_DOMAIN_CHANNELS,
+    MODEL_CHANNELS,
+    IMAGE_CHANNELS,
+    TEMPLATE_CHANNELS,
+    HISTORY_CHANNELS,
+    CONTEXT_CHANNELS,
+    FAVORITE_CHANNELS,
+    DATA_CHANNELS,
+    PREFERENCE_CHANNELS,
+    PROMPT_CHANNELS,
+    LLM_CHANNELS,
+    SYSTEM_CHANNELS,
+    UPDATE_CHANNELS,
+    IPC_PROTOCOL_VERSION,
+    isKnownInvokeChannel,
+    assertKnownInvokeChannel,
+    getChannelMeta,
+  } = require('../packages/desktop/config/ipc/channel-manifest.js')
 
-  assert.match(proxy, /this\.api\.understand\(safeSerializeForIPC\(request\)\)/)
-  assert.match(initializer, /imageUnderstandingService: new ElectronImageUnderstandingServiceProxy\(\)/)
-  assert.match(
-    preload,
-    /ipcRenderer\.invoke\('image-understanding-understand', request\)/,
-  )
-  assert.match(
-    main,
-    /imageUnderstandingService = createImageUnderstandingService\(\{[\s\S]*?imageInputConverter: convertImageInputWithElectronNativeImage/,
-  )
-  assert.match(
-    main,
-    /imageUnderstandingService\.understand\(safeSerialize\(request\)\)/,
-  )
-})
+  assert.equal(new Set(ALL_DOMAIN_CHANNELS).size, ALL_DOMAIN_CHANNELS.length)
+  assert.ok(MODEL_CHANNELS.includes('model-getAllModels'))
+  assert.ok(IMAGE_CHANNELS.includes('image-generate'))
+  assert.ok(TEMPLATE_CHANNELS.includes('template-getTemplates'))
+  assert.ok(HISTORY_CHANNELS.includes('history-getHistory'))
+  assert.ok(CONTEXT_CHANNELS.includes('context-list'))
+  assert.ok(FAVORITE_CHANNELS.includes('favorite-addFavorite'))
+  assert.ok(DATA_CHANNELS.includes('data-exportAllData'))
+  assert.ok(PREFERENCE_CHANNELS.includes('preference-get'))
+  assert.ok(PROMPT_CHANNELS.includes('prompt-optimizePromptStream'))
+  assert.ok(LLM_CHANNELS.includes('stream-cancel'))
+  assert.ok(SYSTEM_CHANNELS.includes('shell-openExternal'))
+  assert.ok(UPDATE_CHANNELS.includes('updater-check-update'))
+  assert.match(String(IPC_PROTOCOL_VERSION), /^\d+\.\d+\.\d+$/)
+  assert.equal(isKnownInvokeChannel('llm-sendMessage'), true)
+  assert.equal(getChannelMeta('llm-sendMessageStream')?.kind, 'stream')
+  assert.throws(() => assertKnownInvokeChannel('definitely-not-a-channel'), /Unknown IPC invoke channel/)
 
-test('macOS manual-update policy guards every mutating updater entry point first', () => {
-  const main = readText('packages/desktop/main.js')
+  const handlerSources = [
+    readText('packages/desktop/config/ipc/llm-handlers.js'),
+    readText('packages/desktop/config/ipc/prompt-stream-handlers.js'),
+    readText('packages/desktop/config/ipc/prompt-sync-handlers.js'),
+    readText('packages/desktop/config/ipc/model-handlers.js'),
+    readText('packages/desktop/config/ipc/image-handlers.js'),
+    readText('packages/desktop/config/ipc/template-handlers.js'),
+    readText('packages/desktop/config/ipc/history-handlers.js'),
+    readText('packages/desktop/config/ipc/favorite-handlers.js'),
+    readText('packages/desktop/config/ipc/context-handlers.js'),
+    readText('packages/desktop/config/ipc/data-handlers.js'),
+    readText('packages/desktop/config/ipc/preference-handlers.js'),
+    readText('packages/desktop/config/ipc/system-handlers.js'),
+    readText('packages/desktop/config/ipc/update-handlers.js'),
+  ].join('\n')
 
-  for (const [eventName, signature] of [
-    ['UPDATE_START_DOWNLOAD', 'async \\(\\)'],
-    ['UPDATE_INSTALL', 'async \\(\\)'],
-    ['UPDATE_DOWNLOAD_SPECIFIC_VERSION', 'async \\(event, versionType\\)'],
-  ]) {
-    const handlerStartsWithGuard = new RegExp(
-      `ipcMain\\.handle\\(IPC_EVENTS\\.${eventName}, ${signature} => \\{\\s*` +
-      'if \\(isManualReleaseDelivery\\(updateDelivery\\)\\)',
-    )
-    assert.match(main, handlerStartsWithGuard, `${eventName} must fail before mutating updater state`)
-  }
-})
-
-test('global updater errors do not release handler-owned operation locks', () => {
-  const main = readText('packages/desktop/main.js')
-  const errorHandlerStart = main.indexOf("autoUpdater.on('error'")
-  const errorHandlerEnd = main.indexOf("autoUpdater.on('download-progress'", errorHandlerStart)
-
-  assert.notEqual(errorHandlerStart, -1)
-  assert.notEqual(errorHandlerEnd, -1)
-
-  const errorHandler = main.slice(errorHandlerStart, errorHandlerEnd)
-  for (const lock of ['isCheckingForUpdate', 'isDownloadingUpdate', 'isInstallingUpdate']) {
-    assert.doesNotMatch(errorHandler, new RegExp(`${lock}\\s*=\\s*false`))
-  }
-
-  for (const [startMarker, endMarker] of [
-    ['ipcMain.handle(IPC_EVENTS.UPDATE_CHECK,', '// 统一检查所有版本'],
-    ['ipcMain.handle(IPC_EVENTS.UPDATE_CHECK_ALL_VERSIONS', '// Open only a main-process'],
-  ]) {
-    const handlerStart = main.indexOf(startMarker)
-    const handlerEnd = main.indexOf(endMarker, handlerStart)
-    assert.notEqual(handlerStart, -1)
-    assert.notEqual(handlerEnd, -1)
-
-    const handler = main.slice(handlerStart, handlerEnd)
-    assert.match(handler, /finally\s*\{[\s\S]*isCheckingForUpdate\s*=\s*false/)
-  }
-})
-
-test('concurrent unified update checks keep the delivery-policy response contract', () => {
-  const main = readText('packages/desktop/main.js')
-  const handlerStart = main.indexOf('ipcMain.handle(IPC_EVENTS.UPDATE_CHECK_ALL_VERSIONS')
-  const lockStart = main.indexOf('// 设置检查状态锁', handlerStart)
-
-  assert.notEqual(handlerStart, -1)
-  assert.notEqual(lockStart, -1)
-
-  const inProgressBranch = main.slice(handlerStart, lockStart)
-  assert.match(inProgressBranch, /const currentVersion = require\('\.\/package\.json'\)\.version/)
-  assert.match(inProgressBranch, /currentVersion/)
-  assert.match(inProgressBranch, /updateDelivery/)
-  assert.match(inProgressBranch, /stable:\s*null/)
-  assert.match(inProgressBranch, /prerelease:\s*null/)
-  assert.match(inProgressBranch, /inProgress:\s*true/)
-})
-
-test('renderer preserves updater state while a unified check is already in progress', () => {
-  const updater = readText('packages/ui/src/composables/system/useUpdater.ts')
-  const inProgressStart = updater.indexOf('if (results.inProgress)')
-  const completedResultStart = updater.indexOf('// Unknown/missing capability', inProgressStart)
-
-  assert.notEqual(inProgressStart, -1)
-  assert.notEqual(completedResultStart, -1)
-
-  const inProgressBranch = updater.slice(inProgressStart, completedResultStart)
-  assert.match(inProgressBranch, /return/)
-  assert.doesNotMatch(inProgressBranch, /state\.isDownloading\s*=\s*false/)
-
-  const checkUpdateStart = updater.indexOf('const checkUpdate = async')
-  const checkBothVersionsCall = updater.indexOf('await checkBothVersions()', checkUpdateStart)
-  assert.notEqual(checkUpdateStart, -1)
-  assert.notEqual(checkBothVersionsCall, -1)
-
-  const preRequestState = updater.slice(checkUpdateStart, checkBothVersionsCall)
-  assert.doesNotMatch(preRequestState, /state\.stableVersion\s*=\s*null/)
-  assert.doesNotMatch(preRequestState, /state\.updateDelivery\s*=\s*null/)
-  assert.doesNotMatch(preRequestState, /state\.downloadMessage\s*=\s*null/)
-})
-
-test('renderer invalidates actionable version state after a terminal unified-check failure', () => {
-  const updater = readText('packages/ui/src/composables/system/useUpdater.ts')
-  const checkStart = updater.indexOf('const checkBothVersions = async')
-  const catchStart = updater.indexOf("console.error('[useUpdater] Error checking all versions:'", checkStart)
-  const finallyStart = updater.indexOf('} finally {', catchStart)
-
-  assert.notEqual(checkStart, -1)
-  assert.notEqual(catchStart, -1)
-  assert.notEqual(finallyStart, -1)
-
-  const terminalErrorBranch = updater.slice(catchStart, finallyStart)
-  assert.match(terminalErrorBranch, /invalidateActionableCheckState\(state\)/)
-  assert.match(terminalErrorBranch, /state\.lastCheckResult\s*=\s*'error'/)
-})
-
-test('updater feed, delivery policy, and release URLs share one repository snapshot', () => {
-  const main = readText('packages/desktop/main.js')
-  const setupStart = main.indexOf('async function setupUpdateHandlers()')
-  const eventHandlersStart = main.indexOf('// 设置更新事件处理', setupStart)
-
-  assert.notEqual(setupStart, -1)
-  assert.notEqual(eventHandlersStart, -1)
-
-  const repositorySetup = main.slice(setupStart, eventHandlersStart)
-  assert.match(repositorySetup, /resolveUpdateRepositoryConfig\(\)/)
-  assert.match(repositorySetup, /shouldOverrideFeed/)
-  assert.match(repositorySetup, /getUpdateDeliveryPolicy\(\{ repositoryInfo \}\)/)
-  assert.match(repositorySetup, /const \{ owner, repo \} = repositoryInfo/)
-  assert.match(repositorySetup, /repositoryInfo = packagedRepositoryInfo/)
-  assert.doesNotMatch(repositorySetup, /process\.env\.DEV_REPO_/)
-})
-
-test('updater release navigation is constructed and opened in the main process', () => {
-  const main = readText('packages/desktop/main.js')
-  const handlerStart = main.indexOf('ipcMain.handle(IPC_EVENTS.UPDATE_OPEN_RELEASE_PAGE')
-  const handlerEnd = main.indexOf('ipcMain.handle(IPC_EVENTS.UPDATE_START_DOWNLOAD', handlerStart)
-
-  assert.notEqual(handlerStart, -1)
-  assert.notEqual(handlerEnd, -1)
-
-  const handler = main.slice(handlerStart, handlerEnd)
-  assert.match(handler, /buildReleaseUrl\(version, repositoryInfo\)/)
-  assert.match(handler, /updateDelivery\.fallbackReleaseUrl/)
-  assert.match(handler, /shell\.openExternal\(releaseUrl\)/)
-  assert.doesNotMatch(handler, /shell\.openExternal\(version\)/)
-})
-
-test('manual release workflow normalizes tags used by release-page navigation', () => {
-  const workflow = readText('.github/workflows/release.yml')
-  const normalization = /VERSION="\$\{\{ inputs\.version \}\}"\s+if \[\[ "\$VERSION" != v\* \]\]; then\s+VERSION="v\$VERSION"\s+fi/g
-
-  assert.equal([...workflow.matchAll(normalization)].length, 2)
-  assert.match(workflow, /gh release create "\$VERSION"/)
-})
-
-test('desktop release jobs keep repository metadata and updater publish config aligned', () => {
-  const workflow = readText('.github/workflows/release.yml')
-  const jobBlock = (jobName, nextJobName) => {
-    const start = workflow.indexOf(`  ${jobName}:`)
-    const end = workflow.indexOf(`  ${nextJobName}:`, start)
-    assert.notEqual(start, -1, `${jobName} job must exist`)
-    assert.notEqual(end, -1, `${nextJobName} job must follow ${jobName}`)
-    return workflow.slice(start, end)
+  const registered = collectMatches(handlerSources, [
+    /ipcMain\.handle\(\s*['"]([^'"]+)['"]/g,
+    /registerSensitiveIpc\(\s*['"]([^'"]+)['"]/g,
+    /ipcMain\.handle\(\s*IPC_EVENTS\.([A-Z0-9_]+)/g,
+  ])
+  // update handlers register via IPC_EVENTS.X; map those keys to string channels
+  const { IPC_EVENTS } = require('../packages/desktop/config/constants.js')
+  for (const [key, value] of Object.entries(IPC_EVENTS)) {
+    if (registered.has(key)) registered.add(value)
   }
 
-  const windowsJob = jobBlock('build-windows', 'build-macos')
-  const macosJob = jobBlock('build-macos', 'build-linux')
-  const linuxJob = jobBlock('build-linux', 'build-extension')
-
-  assert.match(windowsJob, /\$pkgJson\.repository\.url\s*=\s*\$repoUrl/)
-  assert.match(windowsJob, /\$pkgJson\.build\.publish\.owner\s*=\s*\$repoOwner/)
-  assert.match(windowsJob, /\$pkgJson\.build\.publish\.repo\s*=\s*\$repoName/)
-
-  for (const [name, job] of [['build-macos', macosJob], ['build-linux', linuxJob]]) {
-    assert.match(job, /\.repository\.url\s*=\s*\$repo_url/, `${name} must update repository.url`)
-    assert.match(job, /\.build\.publish\.owner\s*=\s*\$repo_owner/, `${name} must update publish owner`)
-    assert.match(job, /\.build\.publish\.repo\s*=\s*\$repo_name/, `${name} must update publish repo`)
-  }
+  const missingInHandlers = ALL_DOMAIN_CHANNELS.filter((channel) => !registered.has(channel)).sort()
+  assert.deepEqual(missingInHandlers, [])
 })
 
 test('desktop remote storage handler routes S3-compatible operations through AWS SDK commands', async () => {
@@ -488,10 +420,14 @@ test('desktop remote storage implementation avoids renderer fetch/WebDAV XML pat
 })
 
 test('desktop preference bridge exposes only registered preference handlers', () => {
+  // preference 已拆到独立 module；契约仍要求完整 channel 集合可用。
+  const preferenceModule = readText('packages/desktop/config/ipc/preference-handlers.js')
   const main = readText('packages/desktop/main.js')
-  const mainHandlers = collectMatches(main, [
+  const preferenceHandlers = collectMatches(preferenceModule, [
     /ipcMain\.handle\(\s*['"]([^'"]+)['"]/g,
   ])
+
+  assert.match(main, /registerPreferenceIpcHandlers\(/)
 
   for (const channel of [
     'preference-get',
@@ -505,6 +441,6 @@ test('desktop preference bridge exposes only registered preference handlers', ()
     'preference-getDataType',
     'preference-validateData',
   ]) {
-    assert.equal(mainHandlers.has(channel), true, `Missing handler for ${channel}`)
+    assert.equal(preferenceHandlers.has(channel), true, `Missing handler for ${channel}`)
   }
 })


### PR DESCRIPTION
## Summary
Re-submit of retracted #330 (closed by author without merge).

**Stack:** includes stream-cancellation + window/runtime/IPC security commits (same lineage as #333 + stream PR). Please merge **#333 and stream-cancel first**, then rebase if needed.

### Changes
- Mechanical split of IPC handlers into `packages/desktop/config/ipc/*`
- Channel manifest
- Updater isolated in its own module (**preserves #313** macOS manual-release path)
- Domain handler contract tests

### Test plan
- [x] `node --check packages/desktop/main.js`
- [x] `node --test packages/desktop/config/ipc-domain-handlers.test.js` → **15/15**

### Notes
- Pure mechanical split + keep existing request/response semantics
- No `.pipeline/*`, no local paths