### PR TITLE
fix: restore broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,11 +370,11 @@ For detailed project status, see [Project Status Document](docs/project/project-
 
 ## Star History
 
-<a href="https://star-history.com/#linshenkx/prompt-optimizer&Date">
+<a href="https://star-history.dera.page/#linshenkx/prompt-optimizer&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=linshenkx/prompt-optimizer&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=linshenkx/prompt-optimizer&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=linshenkx/prompt-optimizer&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=linshenkx/prompt-optimizer&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=linshenkx/prompt-optimizer&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=linshenkx/prompt-optimizer&type=Date" />
  </picture>
 </a>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -365,11 +365,11 @@ pnpm dev:fresh        # 完整重置并重新启动开发环境
 
 ## Star History
 
-<a href="https://star-history.com/#linshenkx/prompt-optimizer&Date">
+<a href="https://star-history.dera.page/#linshenkx/prompt-optimizer&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=linshenkx/prompt-optimizer&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=linshenkx/prompt-optimizer&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=linshenkx/prompt-optimizer&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=linshenkx/prompt-optimizer&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=linshenkx/prompt-optimizer&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=linshenkx/prompt-optimizer&type=Date" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is currently broken: the upstream service depends on the GitHub stargazer API, which has been restricted, so the image no longer renders. This PR moves the chart to a working drop-in replacement (star-history.dera.page) that serves the same data from a different source and requires no API token. The change is applied to both the English and Chinese READMEs.