### PR TITLE
fix(core): suppress split think-tag content in streams

### DIFF
--- a/packages/core/src/services/llm/adapters/abstract-adapter.ts
+++ b/packages/core/src/services/llm/adapters/abstract-adapter.ts
@@ -269,16 +269,6 @@ export abstract class AbstractTextProviderAdapter implements ITextProviderAdapte
     callbacks: StreamHandlers,
     thinkState: { isInThinkMode: boolean; buffer: string }
   ): void {
-    // 如果没有推理回调，过滤掉think标签后发送到主要内容流
-    if (!callbacks.onReasoningToken) {
-      // 使用processThinkTags过滤掉think标签
-      const { content: mainContent } = this.processThinkTags(content)
-      if (mainContent) {
-        callbacks.onToken(mainContent)
-      }
-      return
-    }
-
     // 将新内容添加到缓冲区
     thinkState.buffer += content
     let remaining = thinkState.buffer
@@ -333,7 +323,7 @@ export abstract class AbstractTextProviderAdapter implements ITextProviderAdapte
           // 发送结束标签前的内容到推理流
           if (thinkEndIndex > 0) {
             const reasoningContent = remaining.slice(0, thinkEndIndex)
-            callbacks.onReasoningToken!(reasoningContent)
+            callbacks.onReasoningToken?.(reasoningContent)
             processed += reasoningContent + '</think>'
           } else {
             processed += '</think>'
@@ -359,7 +349,7 @@ export abstract class AbstractTextProviderAdapter implements ITextProviderAdapte
             return
           } else {
             // 确定没有结束标签，发送所有内容到推理流
-            callbacks.onReasoningToken!(remaining)
+            callbacks.onReasoningToken?.(remaining)
             processed += remaining
             remaining = ''
           }

--- a/packages/core/tests/unit/llm/think-tag-processing.test.ts
+++ b/packages/core/tests/unit/llm/think-tag-processing.test.ts
@@ -119,5 +119,56 @@ describe('Think标签处理测试', () => {
       // 当没有推理回调时，think标签内容被过滤，只返回正文
       expect(mockCallbacks.onToken).toHaveBeenCalledWith('正文内容');
     });
+
+    it('在没有推理回调时应跨 chunk 识别拆分的开始标签', () => {
+      const adapter = new OpenAIAdapter();
+      const mockCallbacks = {
+        onToken: vi.fn(),
+        onComplete: vi.fn(),
+        onError: vi.fn()
+      };
+      const thinkState = { isInThinkMode: false, buffer: '' };
+
+      (adapter as any).processStreamContentWithThinkTags('Answer: <thi', mockCallbacks, thinkState);
+      (adapter as any).processStreamContentWithThinkTags('nk>private reasoning</think> visible', mockCallbacks, thinkState);
+
+      expect(mockCallbacks.onToken).toHaveBeenNthCalledWith(1, 'Answer: ');
+      expect(mockCallbacks.onToken).toHaveBeenNthCalledWith(2, ' visible');
+      expect(mockCallbacks.onToken).toHaveBeenCalledTimes(2);
+    });
+
+    it('在没有推理回调时应跨 chunk 识别拆分的结束标签', () => {
+      const adapter = new OpenAIAdapter();
+      const mockCallbacks = {
+        onToken: vi.fn(),
+        onComplete: vi.fn(),
+        onError: vi.fn()
+      };
+      const thinkState = { isInThinkMode: false, buffer: '' };
+
+      (adapter as any).processStreamContentWithThinkTags('Answer: <think>private reasoning</thi', mockCallbacks, thinkState);
+      (adapter as any).processStreamContentWithThinkTags('nk> visible', mockCallbacks, thinkState);
+
+      expect(mockCallbacks.onToken).toHaveBeenNthCalledWith(1, 'Answer: ');
+      expect(mockCallbacks.onToken).toHaveBeenNthCalledWith(2, ' visible');
+      expect(mockCallbacks.onToken).toHaveBeenCalledTimes(2);
+    });
+
+    it('在没有推理回调时应保留普通可见文本的 chunk 边界', () => {
+      const adapter = new OpenAIAdapter();
+      const mockCallbacks = {
+        onToken: vi.fn(),
+        onComplete: vi.fn(),
+        onError: vi.fn()
+      };
+      const thinkState = { isInThinkMode: false, buffer: '' };
+
+      (adapter as any).processStreamContentWithThinkTags('Answer: ', mockCallbacks, thinkState);
+      (adapter as any).processStreamContentWithThinkTags('visible', mockCallbacks, thinkState);
+
+      expect(mockCallbacks.onToken).toHaveBeenNthCalledWith(1, 'Answer: ');
+      expect(mockCallbacks.onToken).toHaveBeenNthCalledWith(2, 'visible');
+      expect(mockCallbacks.onToken).toHaveBeenCalledTimes(2);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Reuse the stateful streaming `<think>` parser when `onReasoningToken` is absent.
- Discard reasoning tokens in that mode while preserving visible content and split-tag buffering.
- Add regression coverage for split opening tags, split closing tags, and ordinary visible chunks.

## Problem

The no-callback path parsed each incoming chunk independently. When a provider split `<think>` or `</think>` across streaming chunks, hidden reasoning and partial tags were emitted through `onToken`.

## Validation

- `pnpm -F @prompt-optimizer/core exec vitest run tests/unit/llm/think-tag-processing.test.ts` — 7 passed
- `pnpm -F @prompt-optimizer/core test:unit` — 925 passed, 20 skipped
- `pnpm -F @prompt-optimizer/core typecheck`
- `pnpm test:gate:core` — 21 passed

## AI assistance

This PR was prepared with Codex. The automated checks listed above were run locally.
