### PR TITLE
fix(history): preserve record order when restoring backups

### DIFF
--- a/packages/core/src/services/history/manager.ts
+++ b/packages/core/src/services/history/manager.ts
@@ -412,8 +412,8 @@ export class HistoryManager implements IHistoryManager {
 
     const failedRecords: { record: PromptRecord; error: Error }[] = [];
 
-    // Import each record individually, capturing failures
-    for (const record of records) {
+    // addRecord prepends, so replay the exported order backwards without mutating it.
+    for (const record of [...records].reverse()) {
       try {
         // 保持原始ID，维护数据关联性（chainId、previousId等）
         await this.addRecord(record);

--- a/packages/core/tests/unit/history/import-export.test.ts
+++ b/packages/core/tests/unit/history/import-export.test.ts
@@ -356,6 +356,46 @@ describe('HistoryManager Import/Export', () => {
   });
 
   describe('data integrity', () => {
+    const makeRecord = (index: number): PromptRecord => ({
+      id: `record-${index}`,
+      originalPrompt: `Prompt ${index}`,
+      optimizedPrompt: `Response ${index}`,
+      type: 'optimize',
+      chainId: `chain-${index}`,
+      version: 1,
+      timestamp: 1000 + index,
+      modelKey: 'openai',
+      templateId: 'template-1'
+    });
+
+    it('should preserve record order through an export/import round trip', async () => {
+      for (let index = 1; index <= 3; index++) {
+        await historyManager.addRecord(makeRecord(index));
+      }
+      const backup = JSON.parse(JSON.stringify(await historyManager.exportData()));
+      const originalIds = backup.map((record: PromptRecord) => record.id);
+
+      await historyManager.importData(backup);
+
+      expect((await historyManager.getRecords()).map(record => record.id)).toEqual(originalIds);
+      expect(backup.map((record: PromptRecord) => record.id)).toEqual(originalIds);
+    });
+
+    it('should evict the oldest record after restoring a full history', async () => {
+      for (let index = 1; index <= 50; index++) {
+        await historyManager.addRecord(makeRecord(index));
+      }
+      const backup = JSON.parse(JSON.stringify(await historyManager.exportData()));
+
+      await historyManager.importData(backup);
+      await historyManager.addRecord(makeRecord(51));
+
+      const records = await historyManager.getRecords();
+      expect(records).toHaveLength(50);
+      expect(records.map(record => record.id)).toContain('record-50');
+      expect(records.map(record => record.id)).not.toContain('record-1');
+    });
+
     it('should maintain chain relationships after import', async () => {
       // 创建一个完整的对话链
       const importData: PromptRecord[] = [


### PR DESCRIPTION
## Summary

Restoring an exported history backup reverses its record order because `importData()` replays a newest-first array through `addRecord()`, which prepends each entry. With 50 restored records, the next addition consequently removes the newest prior record instead of the oldest one.

Replay a copy of the exported array backwards to preserve its order without mutating the caller's array. Add regressions for a JSON backup round trip and eviction after restoring a full history.

## Regression evidence

On unchanged `develop` at `3e677b1d9f7e0493c142c175560531e7ae786dce`, both regressions fail: `[3, 2, 1]` is restored as `[1, 2, 3]`, and adding record 51 after restoring records 1–50 removes record 50. The same tests pass after the fix.

## Verification

All commands ran with Node.js 22 and pnpm 10.6.1:

- `pnpm -F @prompt-optimizer/core test:unit`: 924 passed, 20 existing skips.
- `pnpm test:gate`: 45 repository tests, 21 core gate tests, and 945 UI tests passed; one existing UI todo.
- `E2E_VCR_MODE=replay pnpm test:gate:e2e`: 12 Chromium tests passed.
- `pnpm lint` and `pnpm -F @prompt-optimizer/core typecheck`: passed.
- `pnpm build`: passed, including core, UI, web, and extension builds. Existing large-chunk warnings remain.

Provider live-API integration tests were not run; this fix uses only local history storage. The patch changes two files and leaves the storage format and 50-record capacity unchanged.
