### PR TITLE
fix(security): 修复 /api 路径绕过访问密码校验的未授权访问漏洞

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -2,11 +2,13 @@ export const config = {
   matcher: [
     /*
      * 匹配除以下路径之外的所有路径:
-     * - api routes (以 /api/ 开头)
+     * - 认证接口 /api/auth（登录/登出本身不能要求已登录）
      * - 静态文件 (以 . 结尾)
      * - 其他静态资源
+     * 注意：/api 及其他 /api/* 路径必须经过认证检查，
+     * 否则 /api 会命中 SPA 兜底 rewrite 返回完整前端，造成未授权访问绕过
      */
-    '/((?!api|_next/static|_next/image|favicon.ico|assets/|.*\\.).*)' 
+    '/((?!api/auth|_next/static|_next/image|favicon.ico|assets/|.*\\.).*)'
   ],
 };
 


### PR DESCRIPTION
middleware matcher 原先豁免所有 /api 开头路径，而 Vercel 部署下
/api 无对应 serverless 函数，请求会命中 SPA 兜底 rewrite 返回完整
前端应用，导致攻击者无需密码即可通过 /api#/basic/system 进入系统。

现将豁免范围收窄为仅 /api/auth（登录/登出接口），其余 /api/* 路径
全部纳入访问密码校验。